### PR TITLE
Benchmark sketch of `maxsumexp` op on CPU

### DIFF
--- a/experimental/halide/.gitignore
+++ b/experimental/halide/.gitignore
@@ -1,0 +1,8 @@
+# Automatically generated.
+maxsumexp.h
+maxsumexp.a
+
+# Binaries.
+a.out
+maxsumexp
+maxsumexp-bench

--- a/experimental/halide/main.cc
+++ b/experimental/halide/main.cc
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <vector>
+
+#include <Halide.h>
+
+using Halide::Buffer, Halide::Expr, Halide::Func, Halide::Var, Halide::Tuple;
+
+class MaxSumExpGenerator : public Halide::Generator<MaxSumExpGenerator> {
+public:
+    Input<Buffer<float, 1>> input{"input"};
+
+    Output<Buffer<float, 1>> output{"output"};
+
+    Var i;
+
+    void generate() {
+        output(i) = input(i);
+    }
+};
+
+HALIDE_REGISTER_GENERATOR(MaxSumExpGenerator, maxsumexp);
+
+int main(int argc, char *argv[]) {
+    constexpr auto size = 4;
+    std::vector<int> shape = {size, size, size};
+    std::vector<float> data(size * size * size);
+    for (auto it = 0; it != size * size * size; ++it) {
+        data[it] = it;
+    }
+    // Buffer<float, 3> input(data.data(), shape, "input");
+    Halide::ImageParam input(Halide::type_of<float>(), 3);
+
+    Var i, j, k;
+
+    Func state;
+    // state.trace_stores();
+    state(i, j) = {input(i, j, 0), Expr(1.0f)};
+
+    Halide::RDom r(1, size - 1);
+     Expr prev_max = state(i, j)[0];
+     Expr prev_sum = state(i, j)[1];
+     Tuple keep_max = {
+         prev_max,
+         prev_sum + Halide::exp(input(i, j, r) - prev_max)};
+     Tuple update_max = {
+         input(i, j, r),
+         prev_sum * Halide::exp(prev_max - input(i, j, r)) + Expr(1)};
+     state(i, j) = Halide::select(
+         prev_max >= input(i, j, r), keep_max, update_max);
+
+    Func maxsumexp;
+    maxsumexp(i, j, k) = Halide::select(k == 0, state(i, j)[0], state(i, j)[1]);
+    // maxsumexp.compile_to_lowered_stmt("maxsumexp.stmt.html", {}, Halide::HTML);
+
+    maxsumexp.compile_to_static_library("maxsumexp", {input}, "maxsumexp");
+
+    {
+        // maxsumexp.realize({size, size, 2});
+        // Halide::Realization result = maxsumexp.realize({size});
+        // Buffer<float> max = result[0];
+        // Buffer<float> sum = result[1];
+        // std::cout << "Max: " << max(0) << std::endl;
+        // std::cout << "Sum: " << sum(0) << std::endl;
+    }
+
+    return 0;
+}

--- a/experimental/halide/makefile
+++ b/experimental/halide/makefile
@@ -1,0 +1,15 @@
+all: a.out
+
+a.out: main.cc
+	clang++ -std=c++17 -lHalide -o $@ $^
+
+.PHONY: run
+run: a.out
+	./a.out
+
+maxsumexp: maxsumexp.cc maxsumexp.a
+	clang++ -std=c++20 -lHalide -o $@ $^
+
+maxsumexp-bench: maxsumexp_bench.cc maxsumexp.a
+	clang++ -std=c++20 -lHalide -lbenchmark \
+		-I../../include -I../../build/include -o $@ $^ ../../build/libnntile.so

--- a/experimental/halide/maxsumexp.cc
+++ b/experimental/halide/maxsumexp.cc
@@ -1,0 +1,16 @@
+#include <iostream>
+
+#include <Halide.h>
+
+#include "maxsumexp.h"
+
+namespace Runtime = Halide::Runtime;
+
+int main(int argc, char *argv[]) {
+    Runtime::Buffer<float> input(64, 64, 64), output(64, 64, 2);
+    if (int retcode = maxsumexp(input, output); retcode) {
+        std::cerr << "failed to execute halide routine: " << retcode << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/experimental/halide/maxsumexp_bench.cc
+++ b/experimental/halide/maxsumexp_bench.cc
@@ -1,0 +1,51 @@
+#include <memory>
+#include <random>
+
+#include <Halide.h>
+#include <benchmark/benchmark.h>
+
+#include "maxsumexp.h"
+#include "nntile/kernel/maxsumexp.hh"
+
+namespace Runtime = Halide::Runtime;
+
+std::unique_ptr<float[]> MakeData(auto &&rng, size_t size) {
+    auto ptr = std::make_unique<float[]>(size);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    for (auto it = 0; it != size; ++it) {
+        ptr[it] = dist(rng);
+    }
+    return ptr;
+}
+
+static void MaxSumExpHalide(benchmark::State& state) {
+    std::mt19937_64 rng{42};
+    int size = state.range();
+    auto input_data = MakeData(rng, size * size * size);
+    auto output_data = MakeData(rng, size * size * 2);
+    Runtime::Buffer<float> input(input_data.get(), {size, size, size});
+    Runtime::Buffer<float> output(output_data.get(), {size, size, 2});
+
+    for (auto _ : state) {
+        maxsumexp(input, output);
+    }
+}
+
+BENCHMARK(MaxSumExpHalide)->Arg(64)->Arg(256)->Arg(512);
+
+static void MaxSumExpNNTile(benchmark::State& state) {
+    std::mt19937_64 rng{42};
+    int size = state.range();
+    auto input = MakeData(rng, size * size * size);
+    auto output = MakeData(rng, size * size * 2);
+    auto inp = reinterpret_cast<nntile::fp32_t *>(input.get());
+    auto out = reinterpret_cast<nntile::fp32_t *>(output.get());
+
+    for (auto _ : state) {
+        nntile::kernel::maxsumexp::cpu<nntile::fp32_t>(size, size, size, inp, out);
+    }
+}
+
+BENCHMARK(MaxSumExpNNTile)->Arg(64)->Arg(256)->Arg(512);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
For some reason, original CPU implementation of `maxsumexp` operation totally sucks (vectorization?).

```
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
MaxSumExpHalide/64      140812 ns       140753 ns         4985
MaxSumExpHalide/256    2290624 ns      2288591 ns          296
MaxSumExpHalide/512    9912208 ns      9904807 ns           77
MaxSumExpNNTile/64     2460951 ns      2458875 ns          295
MaxSumExpNNTile/256  154909921 ns    154790587 ns            5
MaxSumExpNNTile/512 1782378669 ns   1780913904 ns            1
```