### PR TITLE
Add support GPT2 training in fp32_fast_fp16 type

### DIFF
--- a/include/nntile/base_types.hh
+++ b/include/nntile/base_types.hh
@@ -336,7 +336,7 @@ public:
         fp32_fast_fp16_t one{1.0}, one_p_eps{1.0};
         auto uintptr = reinterpret_cast<std::uint32_t *>(&one_p_eps);
         // Add a bit into mantissa of 1+eps to get actual value of 1+eps
-        *uintptr += 0x2000;
+        *uintptr += 0x10000;
         // Output difference of 1+eps and 1
         return static_cast<repr_t>(one_p_eps) - static_cast<repr_t>(one);
     }

--- a/include/nntile/base_types.hh
+++ b/include/nntile/base_types.hh
@@ -294,6 +294,62 @@ inline std::ostream &operator<<(std::ostream &os,
     return os;
 }
 
+class fp32_fast_fp16_t
+{
+public:
+    //! Basic type that must have the same size, as this type
+    using storage_t = float;
+    //! Basic type that must cover all possible values of this type
+    using repr_t = float;
+    //! Flag if copy from repr_t does not require conversion
+    static const bool trivial_copy_from_compat = true;
+    //! String to represent this type
+    static constexpr const char *type_repr = "fp32_fast_fp16_t";
+    //! Internal value of this type to hold actual data
+    storage_t value;
+    //! Constructor
+    NNTILE_HOST_DEVICE fp32_fast_fp16_t() = default;
+    //! Constructor from another value of this type
+    NNTILE_HOST_DEVICE fp32_fast_fp16_t(const fp32_fast_fp16_t &other) = default;
+    //! Constructor from a repr_t value
+    NNTILE_HOST_DEVICE explicit fp32_fast_fp16_t(const repr_t &other):
+        value(other)
+    {
+    }
+    //! Assignment from another value of this type
+    NNTILE_HOST_DEVICE fp32_fast_fp16_t &operator=(const fp32_fast_fp16_t &other) = default;
+    //! Assignment from a repr_t value
+    NNTILE_HOST_DEVICE fp32_fast_fp16_t &operator=(const repr_t &other)
+    {
+        value = other;
+        return *this;
+    }
+    //! Conversion to repr_t value
+    NNTILE_HOST_DEVICE explicit operator repr_t() const
+    {
+        return value;
+    }
+    //! Machine precision of this type
+    static repr_t epsilon()
+    {
+        // Init 1.0 and 1.0+eps identically
+        fp32_fast_fp16_t one{1.0}, one_p_eps{1.0};
+        auto uintptr = reinterpret_cast<std::uint32_t *>(&one_p_eps);
+        // Add a bit into mantissa of 1+eps to get actual value of 1+eps
+        *uintptr += 0x2000;
+        // Output difference of 1+eps and 1
+        return static_cast<repr_t>(one_p_eps) - static_cast<repr_t>(one);
+    }
+};
+
+//! Print function for nntile::fp32_fast_fp16_t
+inline std::ostream &operator<<(std::ostream &os,
+        const fp32_fast_fp16_t &value)
+{
+    os << static_cast<typename fp32_fast_fp16_t::repr_t>(value);
+    return os;
+}
+
 //! NNTile wrapper type BrainFloat16 type inside tensors
 class bf16_t
 {

--- a/include/nntile/kernel/gemm.hh.in
+++ b/include/nntile/kernel/gemm.hh.in
@@ -100,6 +100,20 @@ void cublas(cublasHandle_t handle, cublasOperation_t transA,
             CUBLAS_GEMM_DEFAULT_TENSOR_OP);
 }
 
+// Overloaded call to cuBLAS GEMM for fp32_fast_fp16_t
+static inline
+void cublas(cublasHandle_t handle, cublasOperation_t transA,
+        cublasOperation_t transB, int M, int N, int K, float alpha,
+        const fp32_fast_fp16_t *A, int ldA, const fp32_fast_fp16_t *B, int ldB,
+        float beta, fp32_fast_fp16_t *C, int ldC)
+    noexcept
+{
+    cublasGemmEx(handle, transA, transB, M, N, K, &alpha, (const float *)A,
+            CUDA_R_32F, ldA, (const float *)B, CUDA_R_32F, ldB, &beta,
+            (float *)C, CUDA_R_32F, ldC, CUBLAS_COMPUTE_32F_FAST_16F,
+            CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+}
+
 // Overloaded call to cuBLAS GEMM for bf16_t
 static inline
 void cublas(cublasHandle_t handle, cublasOperation_t transA,
@@ -155,6 +169,22 @@ void cublas_batch(cublasHandle_t handle, cublasOperation_t transA,
             (const float *)A, CUDA_R_32F, ldA, strideA, (const float *)B,
             CUDA_R_32F, ldB, strideB, &beta, (float *)C, CUDA_R_32F, ldC,
             strideC, batchCount, CUBLAS_COMPUTE_32F_FAST_TF32,
+            CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+}
+
+// Overloaded call to batched cuBLAS gemm
+static inline
+void cublas_batch(cublasHandle_t handle, cublasOperation_t transA,
+        cublasOperation_t transB, int M, int N, int K, float alpha,
+        const fp32_fast_fp16_t *A, int ldA, long long int strideA,
+        const fp32_fast_fp16_t *B, int ldB, long long int strideB, float beta,
+        fp32_fast_fp16_t *C, int ldC, long long int strideC, int batchCount)
+    noexcept
+{
+    cublasGemmStridedBatchedEx(handle, transA, transB, M, N, K, &alpha,
+            (const float *)A, CUDA_R_32F, ldA, strideA, (const float *)B,
+            CUDA_R_32F, ldB, strideB, &beta, (float *)C, CUDA_R_32F, ldC,
+            strideC, batchCount, CUBLAS_COMPUTE_32F_FAST_16F,
             CUBLAS_GEMM_DEFAULT_TENSOR_OP);
 }
 

--- a/include/nntile/starpu/accumulate.hh
+++ b/include/nntile/starpu/accumulate.hh
@@ -34,7 +34,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-    codelet_bf16;
+    codelet_bf16, codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -53,6 +53,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/accumulate.hh
+++ b/include/nntile/starpu/accumulate.hh
@@ -34,7 +34,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-    codelet_bf16, codelet_fp32_fast_fp16;
+               codelet_bf16, codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/accumulate_hypot.hh
+++ b/include/nntile/starpu/accumulate_hypot.hh
@@ -33,7 +33,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -64,6 +65,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 void init();

--- a/include/nntile/starpu/accumulate_maxsumexp.hh
+++ b/include/nntile/starpu/accumulate_maxsumexp.hh
@@ -34,7 +34,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-        codelet_bf16;
+        codelet_bf16, codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -53,6 +53,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/accumulate_maxsumexp.hh
+++ b/include/nntile/starpu/accumulate_maxsumexp.hh
@@ -34,7 +34,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-        codelet_bf16, codelet_fp32_fast_fp16;
+               codelet_bf16, codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/adam_step.hh
+++ b/include/nntile/starpu/adam_step.hh
@@ -45,7 +45,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/adam_step.hh
+++ b/include/nntile/starpu/adam_step.hh
@@ -44,7 +44,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -69,6 +70,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/adamw_step.hh
+++ b/include/nntile/starpu/adamw_step.hh
@@ -45,7 +45,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/adamw_step.hh
+++ b/include/nntile/starpu/adamw_step.hh
@@ -44,7 +44,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -69,6 +70,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/add.hh
+++ b/include/nntile/starpu/add.hh
@@ -48,7 +48,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-       codelet_bf16;
+       codelet_bf16, codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -73,6 +73,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/add_fiber_inplace.hh
+++ b/include/nntile/starpu/add_fiber_inplace.hh
@@ -38,7 +38,7 @@ void cpu(void *buffers[], void *cl_args)
     noexcept;
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/add_fiber_inplace.hh
+++ b/include/nntile/starpu/add_fiber_inplace.hh
@@ -37,7 +37,8 @@ template<typename T>
 void cpu(void *buffers[], void *cl_args)
     noexcept;
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -68,6 +69,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 void init();

--- a/include/nntile/starpu/add_inplace.hh
+++ b/include/nntile/starpu/add_inplace.hh
@@ -48,7 +48,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/add_inplace.hh
+++ b/include/nntile/starpu/add_inplace.hh
@@ -47,7 +47,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -72,6 +73,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/add_slice.hh
+++ b/include/nntile/starpu/add_slice.hh
@@ -43,7 +43,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -74,6 +75,12 @@ template<>
 constexpr Codelet *codelet<fp64_t>()
 {
     return &codelet_fp64;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 void init();

--- a/include/nntile/starpu/add_slice.hh
+++ b/include/nntile/starpu/add_slice.hh
@@ -44,7 +44,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/add_slice_inplace.hh
+++ b/include/nntile/starpu/add_slice_inplace.hh
@@ -43,7 +43,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -62,6 +63,12 @@ template<>
 constexpr Codelet *codelet<bf16_t>()
 {
     return &codelet_bf16;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/add_slice_inplace.hh
+++ b/include/nntile/starpu/add_slice_inplace.hh
@@ -44,7 +44,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/embedding.hh
+++ b/include/nntile/starpu/embedding.hh
@@ -36,7 +36,8 @@ template<typename T>
 void cpu(void *buffers[], void *cl_args)
     noexcept;
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -61,6 +62,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/embedding_backward.hh
+++ b/include/nntile/starpu/embedding_backward.hh
@@ -35,7 +35,8 @@ template<typename T>
 void cpu(void *buffers[], void *cl_args)
     noexcept;
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -60,6 +61,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/fill.hh
+++ b/include/nntile/starpu/fill.hh
@@ -41,7 +41,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/fill.hh
+++ b/include/nntile/starpu/fill.hh
@@ -40,7 +40,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -65,6 +66,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/flash_maxsumexp.hh
+++ b/include/nntile/starpu/flash_maxsumexp.hh
@@ -41,7 +41,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/flash_maxsumexp.hh
+++ b/include/nntile/starpu/flash_maxsumexp.hh
@@ -40,7 +40,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -63,6 +64,12 @@ constexpr Codelet *codelet<bf16_t>()
 
 template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
+{
+    return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
 {
     return &codelet_fp32_fast_tf32;
 }

--- a/include/nntile/starpu/flash_softmax_gemm.hh
+++ b/include/nntile/starpu/flash_softmax_gemm.hh
@@ -42,7 +42,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/flash_softmax_gemm.hh
+++ b/include/nntile/starpu/flash_softmax_gemm.hh
@@ -41,7 +41,8 @@ void cuda(void *buffers[], void *cl_args)
 
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -66,6 +67,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/flash_softmax_gemm_backward_dq_dk.hh
+++ b/include/nntile/starpu/flash_softmax_gemm_backward_dq_dk.hh
@@ -41,7 +41,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/flash_softmax_gemm_backward_dq_dk.hh
+++ b/include/nntile/starpu/flash_softmax_gemm_backward_dq_dk.hh
@@ -40,7 +40,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -65,6 +66,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/flash_softmax_gemm_backward_sumprod_slice.hh
+++ b/include/nntile/starpu/flash_softmax_gemm_backward_sumprod_slice.hh
@@ -41,7 +41,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/flash_softmax_gemm_backward_sumprod_slice.hh
+++ b/include/nntile/starpu/flash_softmax_gemm_backward_sumprod_slice.hh
@@ -40,7 +40,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -65,6 +66,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/gelutanh.hh
+++ b/include/nntile/starpu/gelutanh.hh
@@ -33,7 +33,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/gelutanh.hh
+++ b/include/nntile/starpu/gelutanh.hh
@@ -32,7 +32,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -57,6 +58,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/gelutanh_backward.hh
+++ b/include/nntile/starpu/gelutanh_backward.hh
@@ -34,7 +34,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/gelutanh_backward.hh
+++ b/include/nntile/starpu/gelutanh_backward.hh
@@ -33,7 +33,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -58,6 +59,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/gemm.hh
+++ b/include/nntile/starpu/gemm.hh
@@ -58,6 +58,9 @@ extern Codelet codelet_NN_fp32, codelet_NN_fp64,
 extern Codelet codelet_NN_fp32_fast_tf32, codelet_NT_fp32_fast_tf32,
        codelet_TN_fp32_fast_tf32, codelet_TT_fp32_fast_tf32;
 
+extern Codelet codelet_NN_fp32_fast_fp16, codelet_NT_fp32_fast_fp16,
+       codelet_TN_fp32_fast_fp16, codelet_TT_fp32_fast_fp16;
+
 extern Codelet codelet_NN_bf16, codelet_NT_bf16,
        codelet_TN_bf16, codelet_TT_bf16;
 
@@ -125,6 +128,36 @@ Codelet *codelet<fp32_fast_tf32_t>(TransOp transA, TransOp transB)
                 //case TransOp::Trans:
                 default:
                     return &codelet_TT_fp32_fast_tf32;
+            }
+    }
+}
+
+template<>
+Codelet *codelet<fp32_fast_fp16_t>(TransOp transA, TransOp transB)
+{
+    switch(transA.value)
+    {
+        case TransOp::NoTrans:
+            switch(transB.value)
+            {
+                case TransOp::NoTrans:
+                    return &codelet_NN_fp32_fast_fp16;
+                default:
+                // This parameter was already checked in gemm_check_opA_opB
+                //case TransOp::Trans:
+                    return &codelet_NT_fp32_fast_fp16;
+            }
+        // This parameter was already checked in gemm_check_opA_opB
+        //case TransOp::Trans:
+        default:
+            switch(transB.value)
+            {
+                case TransOp::NoTrans:
+                    return &codelet_TN_fp32_fast_fp16;
+                // This parameter was already checked in gemm_check_opA_opB
+                //case TransOp::Trans:
+                default:
+                    return &codelet_TT_fp32_fast_fp16;
             }
     }
 }

--- a/include/nntile/starpu/gemm.hh
+++ b/include/nntile/starpu/gemm.hh
@@ -48,9 +48,9 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_NN_fp32, codelet_NN_fp64,
-       codelet_NT_fp32, codelet_NT_fp64,
-       codelet_TN_fp32, codelet_TN_fp64,
-       codelet_TT_fp32, codelet_TT_fp64;
+               codelet_NT_fp32, codelet_NT_fp64,
+               codelet_TN_fp32, codelet_TN_fp64,
+               codelet_TT_fp32, codelet_TT_fp64;
 
 //extern Codelet codelet_NN_fp16, codelet_NT_fp16,
 //       codelet_TN_fp16, codelet_TT_fp16;

--- a/include/nntile/starpu/hypot_scalar_inverse.hh
+++ b/include/nntile/starpu/hypot_scalar_inverse.hh
@@ -39,7 +39,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -64,6 +65,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/hypot_scalar_inverse.hh
+++ b/include/nntile/starpu/hypot_scalar_inverse.hh
@@ -40,7 +40,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/logsumexp.hh
+++ b/include/nntile/starpu/logsumexp.hh
@@ -31,7 +31,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-               codelet_bf16;
+               codelet_bf16, codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -56,6 +56,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/mask_scalar.hh
+++ b/include/nntile/starpu/mask_scalar.hh
@@ -41,7 +41,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -66,6 +67,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/mask_scalar.hh
+++ b/include/nntile/starpu/mask_scalar.hh
@@ -42,7 +42,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/maxsumexp.hh
+++ b/include/nntile/starpu/maxsumexp.hh
@@ -41,7 +41,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-               codelet_bf16;
+               codelet_bf16, codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -66,6 +66,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/norm_slice.hh
+++ b/include/nntile/starpu/norm_slice.hh
@@ -43,7 +43,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/norm_slice.hh
+++ b/include/nntile/starpu/norm_slice.hh
@@ -42,7 +42,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -67,6 +68,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/prod_fiber3.hh
+++ b/include/nntile/starpu/prod_fiber3.hh
@@ -36,7 +36,7 @@ void cpu(void *buffers[], void *cl_args)
     noexcept;
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/prod_fiber3.hh
+++ b/include/nntile/starpu/prod_fiber3.hh
@@ -35,7 +35,8 @@ template<typename T>
 void cpu(void *buffers[], void *cl_args)
     noexcept;
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -60,6 +61,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/prod_inplace.hh
+++ b/include/nntile/starpu/prod_inplace.hh
@@ -33,7 +33,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/prod_inplace.hh
+++ b/include/nntile/starpu/prod_inplace.hh
@@ -32,7 +32,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -57,6 +58,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/prod_slice.hh
+++ b/include/nntile/starpu/prod_slice.hh
@@ -43,7 +43,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/prod_slice.hh
+++ b/include/nntile/starpu/prod_slice.hh
@@ -42,7 +42,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -67,6 +68,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/scal.hh
+++ b/include/nntile/starpu/scal.hh
@@ -41,7 +41,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/scal.hh
+++ b/include/nntile/starpu/scal.hh
@@ -40,7 +40,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -65,6 +66,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/scal_inplace.hh
+++ b/include/nntile/starpu/scal_inplace.hh
@@ -41,7 +41,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -60,6 +61,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/scal_inplace.hh
+++ b/include/nntile/starpu/scal_inplace.hh
@@ -42,7 +42,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/softmax.hh
+++ b/include/nntile/starpu/softmax.hh
@@ -43,7 +43,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-               codelet_bf16;
+               codelet_bf16, codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -68,6 +68,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/softmax_inplace.hh
+++ b/include/nntile/starpu/softmax_inplace.hh
@@ -43,7 +43,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/softmax_inplace.hh
+++ b/include/nntile/starpu/softmax_inplace.hh
@@ -42,7 +42,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -67,6 +68,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/subcopy.hh
+++ b/include/nntile/starpu/subcopy.hh
@@ -27,7 +27,8 @@ void cpu(void *buffers[], void *cl_args)
 
 //extern Codelet codelet_fp16;
 extern Codelet codelet_fp32, codelet_fp64, codelet_int64,
-       codelet_bool, codelet_fp32_fast_tf32, codelet_bf16;
+       codelet_bool, codelet_fp32_fast_tf32, codelet_bf16,
+       codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -76,6 +77,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 void init();

--- a/include/nntile/starpu/subtract_indexed_outputs.hh
+++ b/include/nntile/starpu/subtract_indexed_outputs.hh
@@ -37,7 +37,8 @@ void cpu(void *buffers[], void *cl_args)
 //     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -62,6 +63,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/subtract_indexed_outputs.hh
+++ b/include/nntile/starpu/subtract_indexed_outputs.hh
@@ -38,7 +38,7 @@ void cpu(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/sum_fiber.hh
+++ b/include/nntile/starpu/sum_fiber.hh
@@ -37,7 +37,7 @@ void cpu(void *buffers[], void *cl_args)
     noexcept;
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/sum_fiber.hh
+++ b/include/nntile/starpu/sum_fiber.hh
@@ -36,7 +36,8 @@ template<typename T>
 void cpu(void *buffers[], void *cl_args)
     noexcept;
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -61,6 +62,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/sum_slice.hh
+++ b/include/nntile/starpu/sum_slice.hh
@@ -43,7 +43,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()

--- a/include/nntile/starpu/sum_slice.hh
+++ b/include/nntile/starpu/sum_slice.hh
@@ -42,7 +42,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -67,6 +68,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/sumprod_fiber.hh
+++ b/include/nntile/starpu/sumprod_fiber.hh
@@ -35,7 +35,8 @@ template<typename T>
 void cpu(void *buffers[], void *cl_args)
     noexcept;
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -60,6 +61,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/sumprod_slice.hh
+++ b/include/nntile/starpu/sumprod_slice.hh
@@ -42,7 +42,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -67,6 +68,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/starpu/total_sum_accum.hh
+++ b/include/nntile/starpu/total_sum_accum.hh
@@ -41,7 +41,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-               codelet_bf16;
+               codelet_bf16, codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -64,6 +64,12 @@ constexpr Codelet *codelet<bf16_t>()
 
 template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
+{
+    return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
 {
     return &codelet_fp32_fast_tf32;
 }

--- a/include/nntile/starpu/transpose.hh
+++ b/include/nntile/starpu/transpose.hh
@@ -41,7 +41,8 @@ void cuda(void *buffers[], void *cl_args)
     noexcept;
 #endif // NNTILE_USE_CUDA
 
-extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -66,6 +67,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_tf32_t>()
 {
     return &codelet_fp32_fast_tf32;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_fp16_t>()
+{
+    return &codelet_fp32_fast_fp16;
 }
 
 template<>

--- a/include/nntile/tile/rope.hh
+++ b/include/nntile/tile/rope.hh
@@ -6,7 +6,7 @@
  * NNTile is software framework for fast training of big neural networks on
  * distributed-memory heterogeneous systems based on StarPU runtime system.
  *
- * @file include/nntile/tile/add_slice3.hh
+ * @file include/nntile/tile/rope.hh
  * Tile wrappers for the Rotary Positional Embedding
  *
  * @version 1.1.0

--- a/src/kernel/add_slice_inplace/cuda.cu
+++ b/src/kernel/add_slice_inplace/cuda.cu
@@ -276,6 +276,11 @@ void cuda<fp32_fast_tf32_t>(cudaStream_t stream, Index m, Index n, Index k, Scal
     noexcept;
 
 template
+void cuda<fp32_fast_fp16_t>(cudaStream_t stream, Index m, Index n, Index k, Scalar alpha,
+        const fp32_fast_fp16_t *src, Scalar beta, fp32_fast_fp16_t *dst)
+    noexcept;
+
+template
 void cuda<fp64_t>(cudaStream_t stream, Index m, Index n, Index k, Scalar alpha,
         const fp64_t *src, Scalar beta, fp64_t *dst)
     noexcept;

--- a/src/kernel/mask_scalar/cuda.cu
+++ b/src/kernel/mask_scalar/cuda.cu
@@ -87,6 +87,11 @@ void cuda<fp32_fast_tf32_t>(cudaStream_t stream, Index nrows, Index ncols,
     noexcept;
 
 template
+void cuda<fp32_fast_fp16_t>(cudaStream_t stream, Index nrows, Index ncols,
+        const bool_t *mask, Scalar val, fp32_fast_fp16_t *data)
+    noexcept;
+
+template
 void cuda<fp64_t>(cudaStream_t stream, Index nrows, Index ncols,
         const bool_t *mask, Scalar val, fp64_t *data)
     noexcept;

--- a/src/kernel/maxsumexp/cuda.cu
+++ b/src/kernel/maxsumexp/cuda.cu
@@ -338,4 +338,8 @@ template void cuda<fp32_fast_tf32_t>(cudaStream_t stream, Index m, Index n,
         Index k, const fp32_fast_tf32_t *src, fp32_fast_tf32_t *maxsumexp)
     noexcept;
 
+template void cuda<fp32_fast_fp16_t>(cudaStream_t stream, Index m, Index n,
+        Index k, const fp32_fast_fp16_t *src, fp32_fast_fp16_t *maxsumexp)
+    noexcept;
+
 } // namespace nntile::kernel::maxsumexp

--- a/src/kernel/prod_inplace/cuda.cu
+++ b/src/kernel/prod_inplace/cuda.cu
@@ -86,6 +86,11 @@ void cuda<fp32_fast_tf32_t>(cudaStream_t stream, Index nelems,
     noexcept;
 
 template
+void cuda<fp32_fast_fp16_t>(cudaStream_t stream, Index nelems,
+        const fp32_fast_fp16_t *src, fp32_fast_fp16_t *dst)
+    noexcept;
+
+template
 void cuda<fp64_t>(cudaStream_t stream, Index nelems, const fp64_t *src,
         fp64_t *dst)
     noexcept;

--- a/src/kernel/softmax_inplace/cuda.cu
+++ b/src/kernel/softmax_inplace/cuda.cu
@@ -201,4 +201,9 @@ void cuda<fp32_fast_tf32_t>(cudaStream_t stream, Index m, Index n, Index k,
         const fp32_fast_tf32_t *maxsumexp, Scalar alpha, fp32_fast_tf32_t *dst)
     noexcept;
 
+template
+void cuda<fp32_fast_fp16_t>(cudaStream_t stream, Index m, Index n, Index k,
+        const fp32_fast_fp16_t *maxsumexp, Scalar alpha, fp32_fast_fp16_t *dst)
+    noexcept;
+
 } // namespace nntile::kernel::softmax_inplace

--- a/src/kernel/sumprod_slice/cuda.cu
+++ b/src/kernel/sumprod_slice/cuda.cu
@@ -226,6 +226,12 @@ void cuda<fp32_fast_tf32_t>(cudaStream_t stream, Index m, Index n, Index k,
     noexcept;
 
 template
+void cuda<fp32_fast_fp16_t>(cudaStream_t stream, Index m, Index n, Index k,
+        Scalar alpha, const fp32_fast_fp16_t *src1,
+        const fp32_fast_fp16_t *src2, Scalar beta, fp32_fast_fp16_t *sum_dst)
+    noexcept;
+
+template
 void cuda<fp64_t>(cudaStream_t stream, Index m, Index n, Index k, Scalar alpha,
         const fp64_t *src1, const fp64_t *src2, Scalar beta, fp64_t *sum_dst)
     noexcept;

--- a/src/starpu/accumulate.cc
+++ b/src/starpu/accumulate.cc
@@ -59,7 +59,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-        codelet_bf16;
+        codelet_bf16, codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -105,6 +105,20 @@ void init()
             STARPU_RW | STARPU_COMMUTE);
     codelet_fp32_fast_tf32.modes[1] = STARPU_R;
 
+    codelet_fp32_fast_fp16.init("nntile_accumulate_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+    codelet_fp32_fast_fp16.nbuffers = 2;
+    codelet_fp32_fast_fp16.modes[0] = static_cast<starpu_data_access_mode>(
+            STARPU_RW | STARPU_COMMUTE);
+    codelet_fp32_fast_fp16.modes[1] = STARPU_R;
+
 
     codelet_fp64.init("nntile_accumulate_fp64",
             nullptr,
@@ -125,6 +139,7 @@ void restrict_where(uint32_t where)
 {
     codelet_fp32.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
     codelet_bf16.restrict_where(where);
 }
@@ -133,6 +148,7 @@ void restore_where()
 {
     codelet_fp32.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
     codelet_bf16.restore_where();
 }
@@ -165,6 +181,9 @@ void submit<fp32_t>(Handle src, Handle dst);
 
 template
 void submit<fp32_fast_tf32_t>(Handle src, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Handle src, Handle dst);
 
 template
 void submit<fp64_t>(Handle src, Handle dst);

--- a/src/starpu/accumulate_hypot.cc
+++ b/src/starpu/accumulate_hypot.cc
@@ -58,7 +58,8 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif // NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+        codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -105,6 +106,20 @@ void init()
             STARPU_RW | STARPU_COMMUTE);
     codelet_fp32_fast_tf32.modes[1] = STARPU_R;
 
+    codelet_fp32_fast_fp16.init("nntile_accumulate_hypot_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+    codelet_fp32_fast_fp16.nbuffers = 2;
+    codelet_fp32_fast_fp16.modes[0] = static_cast<starpu_data_access_mode>(
+            STARPU_RW | STARPU_COMMUTE);
+    codelet_fp32_fast_fp16.modes[1] = STARPU_R;
+
     codelet_fp64.init("nntile_accumulate_hypot_fp64",
             nullptr,
             {cpu<fp64_t>},
@@ -126,6 +141,7 @@ void restrict_where(uint32_t where)
     codelet_bf16.restrict_where(where);
     codelet_fp64.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
 }
 
 void restore_where()
@@ -134,6 +150,7 @@ void restore_where()
     codelet_bf16.restore_where();
     codelet_fp64.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
 }
 
 template<typename T>
@@ -167,6 +184,9 @@ void submit<bf16_t>(Handle src, Handle dst);
 
 template
 void submit<fp32_fast_tf32_t>(Handle src, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Handle src, Handle dst);
 
 template
 void submit<fp64_t>(Handle src, Handle dst);

--- a/src/starpu/accumulate_maxsumexp.cc
+++ b/src/starpu/accumulate_maxsumexp.cc
@@ -59,7 +59,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/accumulate_maxsumexp.cc
+++ b/src/starpu/accumulate_maxsumexp.cc
@@ -58,7 +58,8 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif // NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -89,6 +90,20 @@ void init()
     codelet_fp32_fast_tf32.modes[0] = static_cast<starpu_data_access_mode>(
             STARPU_RW | STARPU_COMMUTE);
     codelet_fp32_fast_tf32.modes[1] = STARPU_R;
+
+    codelet_fp32_fast_fp16.init("nntile_accumulate_maxsumexp_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+    codelet_fp32_fast_fp16.nbuffers = 2;
+    codelet_fp32_fast_fp16.modes[0] = static_cast<starpu_data_access_mode>(
+            STARPU_RW | STARPU_COMMUTE);
+    codelet_fp32_fast_fp16.modes[1] = STARPU_R;
 
 
     codelet_fp64.init("nntile_accumulate_maxsumexp_fp64",
@@ -125,6 +140,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_fp64.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_bf16.restrict_where(where);
 }
 
@@ -134,6 +150,7 @@ void restore_where()
     codelet_bf16.restore_where();
     codelet_fp64.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
 }
 
 template<typename T>
@@ -164,6 +181,9 @@ void submit<fp32_t>(Handle src, Handle dst);
 
 template
 void submit<fp32_fast_tf32_t>(Handle src, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Handle src, Handle dst);
 
 template
 void submit<fp64_t>(Handle src, Handle dst);

--- a/src/starpu/adam_step.cc
+++ b/src/starpu/adam_step.cc
@@ -66,7 +66,8 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif // NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -100,6 +101,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_adam_step_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_adam_step_fp64",
             nullptr,
             {cpu<fp64_t>},
@@ -116,6 +127,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -124,6 +136,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -174,6 +187,11 @@ void submit<fp32_t>(Index num_iter, Index num_elems, Scalar beta_1, Scalar beta_
 
 template
 void submit<fp32_fast_tf32_t>(Index num_iter, Index num_elems, Scalar beta_1, Scalar beta_2,
+            Scalar eps, Scalar lr, Scalar weight_decay,
+            Handle grad, Handle first_moment, Handle second_moment, Handle p);
+
+template
+void submit<fp32_fast_fp16_t>(Index num_iter, Index num_elems, Scalar beta_1, Scalar beta_2,
             Scalar eps, Scalar lr, Scalar weight_decay,
             Handle grad, Handle first_moment, Handle second_moment, Handle p);
 

--- a/src/starpu/adam_step.cc
+++ b/src/starpu/adam_step.cc
@@ -67,7 +67,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/adamw_step.cc
+++ b/src/starpu/adamw_step.cc
@@ -69,7 +69,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/adamw_step.cc
+++ b/src/starpu/adamw_step.cc
@@ -68,7 +68,8 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif // NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -102,6 +103,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_adamw_step_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_adamw_step_fp64",
             nullptr,
             {cpu<fp64_t>},
@@ -118,6 +129,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -126,6 +138,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -175,6 +188,11 @@ void submit<fp32_t>(Index num_iter, Index num_elems, Scalar beta_1, Scalar beta_
 
 template
 void submit<fp32_fast_tf32_t>(Index num_iter, Index num_elems, Scalar beta_1, Scalar beta_2,
+            Scalar eps, Scalar lr, Scalar weight_decay,
+            Handle grad, Handle first_moment, Handle second_moment, Handle p);
+
+template
+void submit<fp32_fast_fp16_t>(Index num_iter, Index num_elems, Scalar beta_1, Scalar beta_2,
             Scalar eps, Scalar lr, Scalar weight_decay,
             Handle grad, Handle first_moment, Handle second_moment, Handle p);
 

--- a/src/starpu/add.cc
+++ b/src/starpu/add.cc
@@ -80,7 +80,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/add.cc
+++ b/src/starpu/add.cc
@@ -79,7 +79,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -113,6 +114,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_add_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_add_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -129,6 +140,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -137,6 +149,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -197,6 +210,10 @@ void submit<bf16_t>(Index nelems, Scalar alpha, Handle src1, Scalar beta,
 
 template
 void submit<fp32_fast_tf32_t>(Index nelems, Scalar alpha, Handle src1,
+        Scalar beta, Handle src2, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index nelems, Scalar alpha, Handle src1,
         Scalar beta, Handle src2, Handle dst);
 
 template

--- a/src/starpu/add_fiber_inplace.cc
+++ b/src/starpu/add_fiber_inplace.cc
@@ -77,7 +77,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -110,7 +111,18 @@ void init()
             {}
 #endif // NNTILE_USE_CUDA
             );
+
     codelet_fp32_fast_tf32.init("nntile_add_fiber_inplace_fp32_fast_tf32",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
+    codelet_fp32_fast_fp16.init("nntile_add_fiber_inplace_fp32_fast_fp16",
             footprint,
             {cpu<fp32_t>},
 #ifdef NNTILE_USE_CUDA
@@ -127,6 +139,7 @@ void restrict_where(uint32_t where)
     codelet_bf16.restrict_where(where);
     codelet_fp64.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
 }
 
 void restore_where()
@@ -135,6 +148,7 @@ void restore_where()
     codelet_bf16.restore_where();
     codelet_fp64.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
 }
 
 template<typename T>
@@ -195,6 +209,10 @@ void submit<bf16_t>(Index m, Index n, Index k, Index batch, Scalar alpha,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Index batch, Scalar alpha,
+        Handle src, Scalar beta, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Index batch, Scalar alpha,
         Handle src, Scalar beta, Handle dst);
 
 template

--- a/src/starpu/add_fiber_inplace.cc
+++ b/src/starpu/add_fiber_inplace.cc
@@ -78,7 +78,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/add_inplace.cc
+++ b/src/starpu/add_inplace.cc
@@ -76,7 +76,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -110,6 +111,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_add_inplace_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_add_inplace_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -126,6 +137,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -134,6 +146,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -200,6 +213,10 @@ void submit<bf16_t>(Index nelems, Scalar alpha, Handle src, Scalar beta,
 
 template
 void submit<fp32_fast_tf32_t>(Index nelems, Scalar alpha, Handle src,
+        Scalar beta, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index nelems, Scalar alpha, Handle src,
         Scalar beta, Handle dst);
 
 template

--- a/src/starpu/add_inplace.cc
+++ b/src/starpu/add_inplace.cc
@@ -77,7 +77,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/add_slice.cc
+++ b/src/starpu/add_slice.cc
@@ -80,7 +80,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/add_slice.cc
+++ b/src/starpu/add_slice.cc
@@ -79,7 +79,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -122,6 +123,16 @@ void init()
             {}
 #endif // NNTILE_USE_CUDA
             );
+
+    codelet_fp32_fast_fp16.init("nntile_add_slice_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
 }
 
 void restrict_where(uint32_t where)
@@ -130,6 +141,7 @@ void restrict_where(uint32_t where)
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
     codelet_fp64.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
 }
 
 void restore_where()
@@ -138,6 +150,7 @@ void restore_where()
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
     codelet_fp64.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
 }
 
 template<typename T>
@@ -209,6 +222,10 @@ void submit<fp64_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
 
 template
 void submit<bf16_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
+        Scalar beta, Handle src2, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
         Scalar beta, Handle src2, Handle dst);
 
 } // namespace nntile::starpu::add_slice

--- a/src/starpu/add_slice_inplace.cc
+++ b/src/starpu/add_slice_inplace.cc
@@ -77,7 +77,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -101,7 +102,17 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
-    codelet_fp64.init("nntile_add_slice_inplace_fp64",
+    codelet_fp32_fast_fp16.init("nntile_add_slice3_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
+    codelet_fp64.init("nntile_add_slice3_fp64",
             footprint,
             {cpu<fp64_t>},
 #ifdef NNTILE_USE_CUDA
@@ -110,6 +121,7 @@ void init()
             {}
 #endif // NNTILE_USE_CUDA
             );
+
     codelet_fp32_fast_tf32.init("nntile_add_slice_inplace_fp32_fast_tf32",
             footprint,
             {cpu<fp32_t>},
@@ -125,16 +137,18 @@ void restrict_where(uint32_t where)
 {
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
-    codelet_fp64.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
+    codelet_fp64.restrict_where(where);
 }
 
 void restore_where()
 {
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
-    codelet_fp64.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
+    codelet_fp64.restore_where();
 }
 
 template<typename T>
@@ -199,9 +213,12 @@ template
 void submit<bf16_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
         Scalar beta, Handle dst);
 
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
+        Scalar beta, Handle src2, Handle dst);
+
 template
-void submit<fp64_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
-        Scalar beta, Handle dst);
+void submit<fp64_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
+        Scalar beta, Handle src2, Handle dst);
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Scalar alpha,

--- a/src/starpu/add_slice_inplace.cc
+++ b/src/starpu/add_slice_inplace.cc
@@ -102,7 +102,7 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
-    codelet_fp32_fast_fp16.init("nntile_add_slice3_fp32_fast_fp16",
+    codelet_fp32_fast_fp16.init("nntile_add_slice_inplace_fp32_fast_fp16",
             footprint,
             {cpu<fp32_t>},
 #ifdef NNTILE_USE_CUDA
@@ -112,7 +112,7 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
-    codelet_fp64.init("nntile_add_slice3_fp64",
+    codelet_fp64.init("nntile_add_slice_inplace_fp64",
             footprint,
             {cpu<fp64_t>},
 #ifdef NNTILE_USE_CUDA

--- a/src/starpu/add_slice_inplace.cc
+++ b/src/starpu/add_slice_inplace.cc
@@ -78,7 +78,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/add_slice_inplace.cc
+++ b/src/starpu/add_slice_inplace.cc
@@ -213,12 +213,13 @@ template
 void submit<bf16_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
         Scalar beta, Handle dst);
 
-void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
-        Scalar beta, Handle src2, Handle dst);
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
+        Scalar beta, Handle dst);
 
 template
-void submit<fp64_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
-        Scalar beta, Handle src2, Handle dst);
+void submit<fp64_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
+        Scalar beta, Handle dst);
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Scalar alpha,

--- a/src/starpu/embedding.cc
+++ b/src/starpu/embedding.cc
@@ -77,7 +77,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+        codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -111,6 +112,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_embedding_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_embedding_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -127,6 +138,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -135,6 +147,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -182,6 +195,10 @@ void submit<bf16_t>(Index m, Index n, Index k, Index k_start, Index k_size,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Index k_start, Index k_size,
+        Handle index, Handle vocab, Handle embed);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Index k_start, Index k_size,
         Handle index, Handle vocab, Handle embed);
 
 template

--- a/src/starpu/embedding_backward.cc
+++ b/src/starpu/embedding_backward.cc
@@ -77,7 +77,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+        codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -111,6 +112,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_embedding_backward_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_embedding_backward_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -127,6 +138,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -135,6 +147,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -193,6 +206,10 @@ void submit<bf16_t>(Index m, Index n, Index k, Index k_start, Index k_size,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Index k_start, Index k_size,
+        Handle index, Handle embed, Handle vocab, int redux);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Index k_start, Index k_size,
         Handle index, Handle embed, Handle vocab, int redux);
 
 template

--- a/src/starpu/fill.cc
+++ b/src/starpu/fill.cc
@@ -57,7 +57,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/fill.cc
+++ b/src/starpu/fill.cc
@@ -56,7 +56,8 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif // NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -90,6 +91,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_fill_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_fill_fp64",
             nullptr,
             {cpu<fp64_t>},
@@ -106,6 +117,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -114,6 +126,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -150,6 +163,9 @@ void submit<bf16_t>(Index nelems, Scalar val, Handle data);
 
 template
 void submit<fp32_fast_tf32_t>(Index nelems, Scalar val, Handle data);
+
+template
+void submit<fp32_fast_fp16_t>(Index nelems, Scalar val, Handle data);
 
 template
 void submit<fp64_t>(Index nelems, Scalar val, Handle data);

--- a/src/starpu/flash_maxsumexp.cc
+++ b/src/starpu/flash_maxsumexp.cc
@@ -124,7 +124,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/flash_maxsumexp.cc
+++ b/src/starpu/flash_maxsumexp.cc
@@ -123,7 +123,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -182,6 +183,20 @@ void init()
             {}
 #endif // NNTILE_USE_CUDA
             );
+
+    codelet_fp32_fast_fp16.init("nntile_flash_maxsumexp_fp32_fast_fp16",
+            footprint,
+#ifdef NNTILE_USE_CBLAS
+            {},
+#else // NNTILE_USE_CBLAS
+            {},
+#endif // NNTILE_USE_CBLAS
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_fast_fp16_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
 }
 
 void restrict_where(uint32_t where)
@@ -190,6 +205,7 @@ void restrict_where(uint32_t where)
     codelet_bf16.restrict_where(where);
     codelet_fp64.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
 }
 
 void restore_where()
@@ -198,6 +214,7 @@ void restore_where()
     codelet_bf16.restore_where();
     codelet_fp64.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
 }
 
 template<typename T>
@@ -254,6 +271,10 @@ void submit<bf16_t>(Index seq, Index head, Index batch, Handle K, Handle Q,
 
 template
 void submit<fp32_fast_tf32_t>(Index seq, Index head, Index batch, Handle K, Handle Q,
+        Handle mask, Handle maxsumexp, Handle tmp, int redux);
+
+template
+void submit<fp32_fast_fp16_t>(Index seq, Index head, Index batch, Handle K, Handle Q,
         Handle mask, Handle maxsumexp, Handle tmp, int redux);
 
 template

--- a/src/starpu/flash_softmax_gemm.cc
+++ b/src/starpu/flash_softmax_gemm.cc
@@ -148,7 +148,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -207,6 +208,20 @@ void init()
             {}
 #endif // NNTILE_USE_CUDA
             );
+
+    codelet_fp32_fast_fp16.init("nntile_flash_softmax_gemm_fp32_fast_fp16",
+            footprint,
+#ifdef NNTILE_USE_CBLAS
+            {},
+#else // NNTILE_USE_CBLAS
+            {},
+#endif // NNTILE_USE_CBLAS
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_fast_fp16_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
 }
 
 void restrict_where(uint32_t where)
@@ -215,6 +230,7 @@ void restrict_where(uint32_t where)
     codelet_bf16.restrict_where(where);
     codelet_fp64.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
 }
 
 void restore_where()
@@ -223,6 +239,7 @@ void restore_where()
     codelet_bf16.restore_where();
     codelet_fp64.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
 }
 
 template<typename T>
@@ -284,6 +301,11 @@ void submit<bf16_t>(Index seq, Index head, Index batch, Handle K, Handle Q,
 
 template
 void submit<fp32_fast_tf32_t>(Index seq, Index head, Index batch, Handle K, Handle Q,
+        Handle mask, Handle maxsumexp, Handle V, Handle A, Handle tmp,
+        int redux);
+
+template
+void submit<fp32_fast_fp16_t>(Index seq, Index head, Index batch, Handle K, Handle Q,
         Handle mask, Handle maxsumexp, Handle V, Handle A, Handle tmp,
         int redux);
 

--- a/src/starpu/flash_softmax_gemm.cc
+++ b/src/starpu/flash_softmax_gemm.cc
@@ -149,7 +149,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/flash_softmax_gemm_backward_dq_dk.cc
+++ b/src/starpu/flash_softmax_gemm_backward_dq_dk.cc
@@ -203,7 +203,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/flash_softmax_gemm_backward_sumprod_slice.cc
+++ b/src/starpu/flash_softmax_gemm_backward_sumprod_slice.cc
@@ -178,7 +178,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -208,6 +209,7 @@ void init()
             {}
 #endif // NNTILE_USE_CUDA
             );
+
     codelet_fp32_fast_tf32.init("nntile_flash_softmax_gemm_backward_sumprod_slice_fp32_fast_tf32",
             footprint,
 #ifdef NNTILE_USE_CBLAS
@@ -221,6 +223,21 @@ void init()
             {}
 #endif // NNTILE_USE_CUDA
             );
+
+        codelet_fp32_fast_fp16.init("nntile_flash_softmax_gemm_backward_sumprod_slice_fp32_fast_fp16",
+            footprint,
+#ifdef NNTILE_USE_CBLAS
+            {},
+#else // NNTILE_USE_CBLAS
+            {},
+#endif // NNTILE_USE_CBLAS
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_fast_fp16_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
         codelet_bf16.init("nntile_flash_softmax_gemm_backward_sumprod_slice_bf16",
             footprint,
 #ifdef NNTILE_USE_CBLAS
@@ -242,6 +259,7 @@ void restrict_where(uint32_t where)
     codelet_bf16.restrict_where(where);
     codelet_fp64.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
 }
 
 void restore_where()
@@ -250,6 +268,7 @@ void restore_where()
     codelet_bf16.restore_where();
     codelet_fp64.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
 }
 
 template<typename T>
@@ -315,6 +334,11 @@ void submit<bf16_t>(Index seq, Index head, Index batch, Handle K, Handle Q,
 
 template
 void submit<fp32_fast_tf32_t>(Index seq, Index head, Index batch, Handle K, Handle Q,
+        Handle mask, Handle maxsumexp, Handle dA, Handle V, Handle dV,
+        Handle sumprod_slice, Handle tmp, Handle tmp_grad, int redux);
+
+template
+void submit<fp32_fast_fp16_t>(Index seq, Index head, Index batch, Handle K, Handle Q,
         Handle mask, Handle maxsumexp, Handle dA, Handle V, Handle dV,
         Handle sumprod_slice, Handle tmp, Handle tmp_grad, int redux);
 

--- a/src/starpu/flash_softmax_gemm_backward_sumprod_slice.cc
+++ b/src/starpu/flash_softmax_gemm_backward_sumprod_slice.cc
@@ -179,7 +179,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/gelutanh.cc
+++ b/src/starpu/gelutanh.cc
@@ -60,7 +60,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/gelutanh.cc
+++ b/src/starpu/gelutanh.cc
@@ -59,7 +59,8 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif // NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -93,6 +94,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_gelutanh_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_gelutanh_fp64",
             nullptr,
             {cpu<fp64_t>},
@@ -109,6 +120,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -117,6 +129,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -146,6 +159,9 @@ void submit<fp32_t>(Index nelems, Handle src, Handle dst);
 
 template
 void submit<fp32_fast_tf32_t>(Index nelems, Handle src, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index nelems, Handle src, Handle dst);
 
 template
 void submit<fp64_t>(Index nelems, Handle src, Handle dst);

--- a/src/starpu/gelutanh_backward.cc
+++ b/src/starpu/gelutanh_backward.cc
@@ -61,7 +61,8 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif // NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -95,6 +96,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_gelutanh_backward_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_gelutanh_backward_fp64",
             nullptr,
             {cpu<fp64_t>},
@@ -111,6 +122,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -119,6 +131,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -149,6 +162,9 @@ void submit<bf16_t>(Index nelems, Handle x, Handle dy, Handle dx);
 
 template
 void submit<fp32_fast_tf32_t>(Index nelems, Handle x, Handle dy, Handle dx);
+
+template
+void submit<fp32_fast_fp16_t>(Index nelems, Handle x, Handle dy, Handle dx);
 
 template
 void submit<fp64_t>(Index nelems, Handle x, Handle dy, Handle dx);
@@ -204,6 +220,10 @@ void submit_mpi<bf16_t>(Index nelems, Handle x, Handle dy, Handle dx,
 
 template
 void submit_mpi<fp32_fast_tf32_t>(Index nelems, Handle x, Handle dy, Handle dx,
+        int exec_rank);
+
+template
+void submit_mpi<fp32_fast_fp16_t>(Index nelems, Handle x, Handle dy, Handle dx,
         int exec_rank);
 
 template

--- a/src/starpu/gelutanh_backward.cc
+++ b/src/starpu/gelutanh_backward.cc
@@ -62,7 +62,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/gemm.cc
+++ b/src/starpu/gemm.cc
@@ -175,6 +175,9 @@ Codelet codelet_NN_fp32, codelet_NN_fp64, codelet_NT_fp32, codelet_NT_fp64,
 Codelet codelet_NN_fp32_fast_tf32, codelet_NT_fp32_fast_tf32,
         codelet_TN_fp32_fast_tf32, codelet_TT_fp32_fast_tf32;
 
+Codelet codelet_NN_fp32_fast_fp16, codelet_NT_fp32_fast_fp16,
+        codelet_TN_fp32_fast_fp16, codelet_TT_fp32_fast_fp16;
+
 Codelet codelet_NN_bf16, codelet_NT_bf16,
         codelet_TN_bf16, codelet_TT_bf16;
 
@@ -215,6 +218,46 @@ void init()
             {},
 #ifdef NNTILE_USE_CUDA
             {cuda<fp32_fast_tf32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
+    codelet_NN_fp32_fast_fp16.init("nntile_gemm_NN_fp32_fast_fp16",
+            footprint,
+            {},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_fast_fp16_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
+    codelet_NT_fp32_fast_fp16.init("nntile_gemm_NT_fp32_fast_fp16",
+            footprint,
+            {},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_fast_fp16_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
+    codelet_TN_fp32_fast_fp16.init("nntile_gemm_TN_fp32_fast_fp16",
+            footprint,
+            {},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_fast_fp16_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
+    codelet_TT_fp32_fast_fp16.init("nntile_gemm_TT_fp32_fast_fp16",
+            footprint,
+            {},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_fast_fp16_t>}
 #else // NNTILE_USE_CUDA
             {}
 #endif // NNTILE_USE_CUDA
@@ -422,6 +465,11 @@ void restrict_where(uint32_t where)
     codelet_TN_fp32_fast_tf32.restrict_where(where);
     codelet_TT_fp32_fast_tf32.restrict_where(where);
 
+    codelet_NN_fp32_fast_fp16.restrict_where(where);
+    codelet_NT_fp32_fast_fp16.restrict_where(where);
+    codelet_TN_fp32_fast_fp16.restrict_where(where);
+    codelet_TT_fp32_fast_fp16.restrict_where(where);
+
     codelet_NN_bf16.restrict_where(where);
     codelet_NT_bf16.restrict_where(where);
     codelet_TN_bf16.restrict_where(where);
@@ -447,6 +495,11 @@ void restore_where()
     codelet_NT_fp32_fast_tf32.restore_where();
     codelet_TN_fp32_fast_tf32.restore_where();
     codelet_TT_fp32_fast_tf32.restore_where();
+
+    codelet_NN_fp32_fast_fp16.restore_where();
+    codelet_NT_fp32_fast_fp16.restore_where();
+    codelet_TN_fp32_fast_fp16.restore_where();
+    codelet_TT_fp32_fast_fp16.restore_where();
 
     codelet_NN_bf16.restore_where();
     codelet_NT_bf16.restore_where();
@@ -551,6 +604,11 @@ void submit<fp32_t>(const TransOp &transA, const TransOp &transB,
 
 template
 void submit<fp32_fast_tf32_t>(const TransOp &transA, const TransOp &transB,
+        Index m, Index n, Index k, Index batch, Scalar alpha, Handle A,
+        Handle B, Scalar beta, Handle C, int redux);
+
+template
+void submit<fp32_fast_fp16_t>(const TransOp &transA, const TransOp &transB,
         Index m, Index n, Index k, Index batch, Scalar alpha, Handle A,
         Handle B, Scalar beta, Handle C, int redux);
 

--- a/src/starpu/hypot_scalar_inverse.cc
+++ b/src/starpu/hypot_scalar_inverse.cc
@@ -61,7 +61,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/hypot_scalar_inverse.cc
+++ b/src/starpu/hypot_scalar_inverse.cc
@@ -60,7 +60,8 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif // NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -94,6 +95,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_hypot_scalar_inverse_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_hypot_scalar_inverse_fp64",
             nullptr,
             {cpu<fp64_t>},
@@ -110,6 +121,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -118,6 +130,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -155,6 +168,9 @@ void submit<bf16_t>(Index nelems, Scalar eps, Scalar alpha, Handle dst);
 
 template
 void submit<fp32_fast_tf32_t>(Index nelems, Scalar eps, Scalar alpha, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index nelems, Scalar eps, Scalar alpha, Handle dst);
 
 template
 void submit<fp64_t>(Index nelems, Scalar eps, Scalar alpha, Handle dst);

--- a/src/starpu/logsumexp.cc
+++ b/src/starpu/logsumexp.cc
@@ -58,7 +58,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/logsumexp.cc
+++ b/src/starpu/logsumexp.cc
@@ -57,7 +57,8 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif // NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -91,6 +92,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_logsumexp_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
 
     codelet_fp64.init("nntile_logsumexp_fp64",
             nullptr,
@@ -108,6 +119,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -116,6 +128,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -150,6 +163,9 @@ void submit<fp32_t>(Index nelems, Handle maxsumexp, Handle logsumexp);
 
 template
 void submit<fp32_fast_tf32_t>(Index nelems, Handle maxsumexp, Handle logsumexp);
+
+template
+void submit<fp32_fast_fp16_t>(Index nelems, Handle maxsumexp, Handle logsumexp);
 
 template
 void submit<fp64_t>(Index nelems, Handle maxsumexp, Handle logsumexp);

--- a/src/starpu/mask_scalar.cc
+++ b/src/starpu/mask_scalar.cc
@@ -74,7 +74,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/mask_scalar.cc
+++ b/src/starpu/mask_scalar.cc
@@ -73,7 +73,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -88,6 +89,16 @@ void init()
             );
 
     codelet_fp32_fast_tf32.init("nntile_mask_scalar_fp32_fast_tf32",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
+    codelet_fp32_fast_fp16.init("nntile_mask_scalar_fp32_fast_fp16",
             footprint,
             {cpu<fp32_t>},
 #ifdef NNTILE_USE_CUDA
@@ -123,6 +134,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -131,6 +143,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -170,6 +183,10 @@ void submit<fp32_t>(Index nrows, Index ncols, Handle mask, Scalar val,
 
 template
 void submit<fp32_fast_tf32_t>(Index nrows, Index ncols, Handle mask,
+        Scalar val, Handle data);
+
+template
+void submit<fp32_fast_fp16_t>(Index nrows, Index ncols, Handle mask,
         Scalar val, Handle data);
 
 template

--- a/src/starpu/maxsumexp.cc
+++ b/src/starpu/maxsumexp.cc
@@ -76,7 +76,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/maxsumexp.cc
+++ b/src/starpu/maxsumexp.cc
@@ -75,7 +75,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -109,6 +110,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_maxsumexp_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
 
     codelet_fp64.init("nntile_maxsumexp_fp64",
             footprint,
@@ -126,6 +137,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -134,6 +146,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -185,6 +198,10 @@ void submit<fp32_t>(Index m, Index n, Index k, Handle src, Handle dst,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Handle src,
+        Handle dst, int redux);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Handle src,
         Handle dst, int redux);
 
 template

--- a/src/starpu/norm_slice.cc
+++ b/src/starpu/norm_slice.cc
@@ -76,7 +76,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -110,6 +111,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_norm_slice_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_norm_slice_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -126,6 +137,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -134,6 +146,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -206,6 +219,10 @@ void submit<bf16_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
+        Scalar beta, Handle dst, int redux);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
         Scalar beta, Handle dst, int redux);
 
 template

--- a/src/starpu/norm_slice.cc
+++ b/src/starpu/norm_slice.cc
@@ -77,7 +77,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/prod_fiber3.cc
+++ b/src/starpu/prod_fiber3.cc
@@ -79,7 +79,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/prod_fiber3.cc
+++ b/src/starpu/prod_fiber3.cc
@@ -78,7 +78,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -112,6 +113,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_prod_fiber3_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_prod_fiber3_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -128,6 +139,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -136,6 +148,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -183,6 +196,10 @@ void submit<bf16_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Scalar alpha,
+        Handle src1, Handle src2, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Scalar alpha,
         Handle src1, Handle src2, Handle dst);
 
 template

--- a/src/starpu/prod_inplace.cc
+++ b/src/starpu/prod_inplace.cc
@@ -59,7 +59,8 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif // NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -93,6 +94,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_prod_inplace_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_prod_inplace_fp64",
             nullptr,
             {cpu<fp64_t>},
@@ -109,6 +120,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -117,6 +129,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -148,6 +161,9 @@ void submit<bf16_t>(Index nelems, Handle src, Handle dst);
 
 template
 void submit<fp32_fast_tf32_t>(Index nelems, Handle src, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index nelems, Handle src, Handle dst);
 
 template
 void submit<fp64_t>(Index nelems, Handle src, Handle dst);

--- a/src/starpu/prod_inplace.cc
+++ b/src/starpu/prod_inplace.cc
@@ -60,7 +60,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/prod_slice.cc
+++ b/src/starpu/prod_slice.cc
@@ -77,7 +77,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/prod_slice.cc
+++ b/src/starpu/prod_slice.cc
@@ -76,7 +76,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -110,6 +111,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_prod_slice_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_prod_slice_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -126,6 +137,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -134,6 +146,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -178,6 +191,10 @@ void submit<bf16_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
+        Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
         Handle dst);
 
 template

--- a/src/starpu/scal.cc
+++ b/src/starpu/scal.cc
@@ -62,7 +62,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/scal.cc
+++ b/src/starpu/scal.cc
@@ -61,7 +61,8 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif // NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -95,6 +96,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_scal_fp32_fast_fp16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_scal_fp64",
             nullptr,
             {cpu<fp64_t>},
@@ -111,6 +122,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -119,6 +131,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -161,6 +174,9 @@ void submit<fp32_t>(Index nelems, Scalar alpha, Handle src, Handle dst);
 
 template
 void submit<fp32_fast_tf32_t>(Index nelems, Scalar alpha, Handle src, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index nelems, Scalar alpha, Handle src, Handle dst);
 
 template
 void submit<fp64_t>(Index nelems, Scalar alpha, Handle src, Handle dst);

--- a/src/starpu/scal_inplace.cc.in
+++ b/src/starpu/scal_inplace.cc.in
@@ -113,7 +113,7 @@ void cuda(void *buffers[], void *cl_args)
 }
 #endif //NNTILE_USE_CUDA
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -132,6 +132,20 @@ void init()
             );
 
     codelet_fp32_fast_tf32.init("nntile_scal_inplace_fp32_fast_tf32",
+            nullptr,
+#ifdef NNTILE_USE_CBLAS
+            {cpu<fp32_t>},
+#else // NNTILE_USE_CBLAS
+            {},
+#endif // NNTILE_USE_CBLAS
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
+    codelet_fp32_fast_fp16.init("nntile_scal_inplace_fp32_fast_fp16",
             nullptr,
 #ifdef NNTILE_USE_CBLAS
             {cpu<fp32_t>},
@@ -164,6 +178,7 @@ void restrict_where(uint32_t where)
 {
     codelet_fp32.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -171,6 +186,7 @@ void restore_where()
 {
     codelet_fp32.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -218,6 +234,9 @@ void submit<fp32_t>(Index nelems, Scalar alpha, Handle data);
 
 template
 void submit<fp32_fast_tf32_t>(Index nelems, Scalar alpha, Handle data);
+
+template
+void submit<fp32_fast_fp16_t>(Index nelems, Scalar alpha, Handle data);
 
 template
 void submit<fp64_t>(Index nelems, Scalar alpha, Handle data);

--- a/src/starpu/softmax.cc
+++ b/src/starpu/softmax.cc
@@ -80,7 +80,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-        codelet_bf16;
+        codelet_bf16, codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -114,6 +114,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_softmax_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_softmax_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -130,6 +140,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -138,6 +149,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -180,6 +192,10 @@ void submit<fp32_t>(Index m, Index n, Index k, Handle maxsumexp, Handle src,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Handle maxsumexp, Handle src,
+        Scalar alpha, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Handle maxsumexp, Handle src,
         Scalar alpha, Handle dst);
 
 template

--- a/src/starpu/softmax_inplace.cc
+++ b/src/starpu/softmax_inplace.cc
@@ -76,7 +76,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -110,6 +111,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_softmax_inplace_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_softmax_inplace_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -126,6 +137,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -134,6 +146,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -179,6 +192,10 @@ void submit<bf16_t>(Index m, Index n, Index k, Handle maxsumexp, Scalar alpha,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Handle maxsumexp, Scalar alpha,
+        Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Handle maxsumexp, Scalar alpha,
         Handle dst);
 
 template

--- a/src/starpu/softmax_inplace.cc
+++ b/src/starpu/softmax_inplace.cc
@@ -77,7 +77,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/subcopy.cc
+++ b/src/starpu/subcopy.cc
@@ -58,7 +58,8 @@ uint32_t footprint(struct starpu_task *task)
 
 //Codelet codelet_fp16;
 Codelet codelet_fp32, codelet_fp64, codelet_int64,
-        codelet_bool, codelet_fp32_fast_tf32, codelet_bf16;
+        codelet_bool, codelet_fp32_fast_tf32, codelet_bf16,
+        codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -92,6 +93,11 @@ void init()
             {cpu<fp32_t>},
             {}
             );
+    codelet_fp32_fast_fp16.init("nntile_subcopy_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+            {}
+            );
     codelet_bf16.init("nntile_subcopy_bf16",
             footprint,
             {cpu<bf16_t>},
@@ -107,6 +113,7 @@ void restrict_where(uint32_t where)
     codelet_int64.restrict_where(where);
     codelet_bool.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_bf16.restrict_where(where);
 }
 
@@ -118,6 +125,7 @@ void restore_where()
     codelet_int64.restore_where();
     codelet_bool.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_bf16.restore_where();
 }
 
@@ -169,6 +177,14 @@ void submit<fp32_t>(Index ndim, const std::vector<Index> &src_start,
 
 template
 void submit<fp32_fast_tf32_t>(Index ndim, const std::vector<Index> &src_start,
+        const std::vector<Index> &src_stride,
+        const std::vector<Index> &dst_start,
+        const std::vector<Index> &dst_stride,
+        const std::vector<Index> &copy_shape, Handle src, Handle dst,
+        Handle tmp_index, starpu_data_access_mode mode);
+
+template
+void submit<fp32_fast_fp16_t>(Index ndim, const std::vector<Index> &src_start,
         const std::vector<Index> &src_stride,
         const std::vector<Index> &dst_start,
         const std::vector<Index> &dst_stride,

--- a/src/starpu/subtract_indexed_outputs.cc
+++ b/src/starpu/subtract_indexed_outputs.cc
@@ -79,7 +79,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/subtract_indexed_outputs.cc
+++ b/src/starpu/subtract_indexed_outputs.cc
@@ -78,7 +78,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -112,6 +113,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_subtract_indexed_outputs_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_subtract_indexed_outputs_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -128,6 +139,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -136,6 +148,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -174,6 +187,10 @@ void submit<bf16_t>(Index n_labels, Index n_outputs, Scalar val, Handle labels,
 
 template
 void submit<fp32_fast_tf32_t>(Index n_labels, Index n_outputs, Scalar val, Handle labels,
+        Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index n_labels, Index n_outputs, Scalar val, Handle labels,
         Handle dst);
 
 template

--- a/src/starpu/sum_fiber.cc
+++ b/src/starpu/sum_fiber.cc
@@ -77,7 +77,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/sum_fiber.cc
+++ b/src/starpu/sum_fiber.cc
@@ -76,7 +76,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -110,6 +111,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_sum_fiber_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_sum_fiber_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -126,6 +137,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -134,6 +146,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -201,6 +214,10 @@ void submit<bf16_t>(Index m, Index n, Index k, Index batch, Scalar alpha,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Index batch, Scalar alpha,
+        Handle src, Scalar beta, Handle dst, int redux);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Index batch, Scalar alpha,
         Handle src, Scalar beta, Handle dst, int redux);
 
 template

--- a/src/starpu/sum_slice.cc
+++ b/src/starpu/sum_slice.cc
@@ -76,7 +76,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/sum_slice.cc
+++ b/src/starpu/sum_slice.cc
@@ -75,7 +75,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -109,6 +110,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_sum_slice_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
 
     codelet_fp64.init("nntile_sum_slice_fp64",
             footprint,
@@ -126,6 +137,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -134,6 +146,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -206,6 +219,10 @@ void submit<bf16_t>(Index m, Index n, Index k, Scalar alpha, Handle src,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Scalar alpha,
+        Handle src, Scalar beta, Handle dst, int redux);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Scalar alpha,
         Handle src, Scalar beta, Handle dst, int redux);
 
 template

--- a/src/starpu/sumprod_fiber.cc
+++ b/src/starpu/sumprod_fiber.cc
@@ -79,7 +79,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/sumprod_fiber.cc
+++ b/src/starpu/sumprod_fiber.cc
@@ -78,7 +78,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -112,6 +113,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_sumprod_fiber_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_sumprod_fiber_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -128,6 +139,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -136,6 +148,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -209,6 +222,10 @@ void submit<bf16_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Scalar alpha,
+        Handle src1, Handle src2, Scalar beta, Handle dst, int redux);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Scalar alpha,
         Handle src1, Handle src2, Scalar beta, Handle dst, int redux);
 
 template

--- a/src/starpu/sumprod_slice.cc
+++ b/src/starpu/sumprod_slice.cc
@@ -77,7 +77,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -111,6 +112,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_sumprod_slice_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_sumprod_slice_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -127,6 +138,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -135,6 +147,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -208,6 +221,10 @@ void submit<bf16_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
+        Handle src2, Scalar beta, Handle dst, int redux);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Index k, Scalar alpha, Handle src1,
         Handle src2, Scalar beta, Handle dst, int redux);
 
 template

--- a/src/starpu/sumprod_slice.cc
+++ b/src/starpu/sumprod_slice.cc
@@ -78,7 +78,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/total_sum_accum.cc
+++ b/src/starpu/total_sum_accum.cc
@@ -85,7 +85,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/total_sum_accum.cc
+++ b/src/starpu/total_sum_accum.cc
@@ -84,7 +84,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -118,6 +119,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_total_sum_accum_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
 
     codelet_fp64.init("nntile_total_sum_accum_fp64",
             footprint,
@@ -135,6 +146,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -143,6 +155,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -177,6 +190,10 @@ void submit<fp32_t>(Scalar alpha, Index n_labels, Index n_outputs,
 
 template
 void submit<fp32_fast_tf32_t>(Scalar alpha, Index n_labels, Index n_outputs,
+        Handle logsumexp, Handle src, Handle class_labels, Handle val);
+
+template
+void submit<fp32_fast_fp16_t>(Scalar alpha, Index n_labels, Index n_outputs,
         Handle logsumexp, Handle src, Handle class_labels, Handle val);
 
 template

--- a/src/starpu/transpose.cc
+++ b/src/starpu/transpose.cc
@@ -74,7 +74,7 @@ uint32_t footprint(struct starpu_task *task)
 }
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16;
 
 void init()
 {

--- a/src/starpu/transpose.cc
+++ b/src/starpu/transpose.cc
@@ -73,7 +73,8 @@ uint32_t footprint(struct starpu_task *task)
     return hash;
 }
 
-Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16;
+Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
+codelet_fp32_fast_fp16;
 
 void init()
 {
@@ -107,6 +108,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_fp16.init("nntile_transpose_fp32_fast_fp16",
+            footprint,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_transpose_fp64",
             footprint,
             {cpu<fp64_t>},
@@ -123,6 +134,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
+    codelet_fp32_fast_fp16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -131,6 +143,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
+    codelet_fp32_fast_fp16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -172,6 +185,9 @@ void submit<bf16_t>(Index m, Index n, Scalar alpha, Handle src, Handle dst);
 
 template
 void submit<fp32_fast_tf32_t>(Index m, Index n, Scalar alpha, Handle src, Handle dst);
+
+template
+void submit<fp32_fast_fp16_t>(Index m, Index n, Scalar alpha, Handle src, Handle dst);
 
 template
 void submit<fp64_t>(Index m, Index n, Scalar alpha, Handle src, Handle dst);

--- a/src/tensor/adam_step.cc
+++ b/src/tensor/adam_step.cc
@@ -94,6 +94,11 @@ void adam_step_async<fp32_fast_tf32_t>(Index num_iter, Scalar beta_1, Scalar bet
                    const Tensor<fp32_fast_tf32_t> &p);
 
 template
+void adam_step_async<fp32_fast_fp16_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
+    const Tensor<fp32_fast_fp16_t> &grad, const Tensor<fp32_fast_fp16_t> &first_moment, const Tensor<fp32_fast_fp16_t> &second_moment,
+                   const Tensor<fp32_fast_fp16_t> &p);
+
+template
 void adam_step_async<fp64_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
     const Tensor<fp64_t> &grad, const Tensor<fp64_t> &first_moment, const Tensor<fp64_t> &second_moment,
                    const Tensor<fp64_t> &p);
@@ -113,6 +118,11 @@ template
 void adam_step<fp32_fast_tf32_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
     const Tensor<fp32_fast_tf32_t> &grad, const Tensor<fp32_fast_tf32_t> &first_moment, const Tensor<fp32_fast_tf32_t> &second_moment,
                    const Tensor<fp32_fast_tf32_t> &p);
+
+template
+void adam_step<fp32_fast_fp16_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
+    const Tensor<fp32_fast_fp16_t> &grad, const Tensor<fp32_fast_fp16_t> &first_moment, const Tensor<fp32_fast_fp16_t> &second_moment,
+                   const Tensor<fp32_fast_fp16_t> &p);
 
 template
 void adam_step<fp64_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,

--- a/src/tensor/adamw_step.cc
+++ b/src/tensor/adamw_step.cc
@@ -94,6 +94,11 @@ void adamw_step_async<fp32_fast_tf32_t>(Index num_iter, Scalar beta_1, Scalar be
                    const Tensor<fp32_fast_tf32_t> &p);
 
 template
+void adamw_step_async<fp32_fast_fp16_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
+                                  const Tensor<fp32_fast_fp16_t> &grad, const Tensor<fp32_fast_fp16_t> &first_moment, const Tensor<fp32_fast_fp16_t> &second_moment,
+                                  const Tensor<fp32_fast_fp16_t> &p);
+
+template
 void adamw_step_async<fp64_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
     const Tensor<fp64_t> &grad, const Tensor<fp64_t> &first_moment, const Tensor<fp64_t> &second_moment,
                    const Tensor<fp64_t> &p);
@@ -113,6 +118,11 @@ template
 void adamw_step<fp32_fast_tf32_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
                                   const Tensor<fp32_fast_tf32_t> &grad, const Tensor<fp32_fast_tf32_t> &first_moment, const Tensor<fp32_fast_tf32_t> &second_moment,
                                   const Tensor<fp32_fast_tf32_t> &p);
+
+template
+void adamw_step<fp32_fast_fp16_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
+                                  const Tensor<fp32_fast_fp16_t> &grad, const Tensor<fp32_fast_fp16_t> &first_moment, const Tensor<fp32_fast_fp16_t> &second_moment,
+                                  const Tensor<fp32_fast_fp16_t> &p);
 
 
 template

--- a/src/tensor/add.cc
+++ b/src/tensor/add.cc
@@ -112,6 +112,11 @@ void add_async<fp32_fast_tf32_t>(Scalar alpha,
         const Tensor<fp32_fast_tf32_t> &dst);
 
 template
+void add_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src1,
+        Scalar beta, const Tensor<fp32_fast_fp16_t> &src2,
+        const Tensor<fp32_fast_fp16_t> &dst);
+
+template
 void add_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src1, Scalar beta,
         const Tensor<fp64_t> &src2, const Tensor<fp64_t> &dst);
 
@@ -129,6 +134,11 @@ template
 void add<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src1,
         Scalar beta, const Tensor<fp32_fast_tf32_t> &src2,
         const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void add<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src1,
+        Scalar beta, const Tensor<fp32_fast_fp16_t> &src2,
+        const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void add<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src1, Scalar beta,

--- a/src/tensor/add_fiber_inplace.cc
+++ b/src/tensor/add_fiber_inplace.cc
@@ -143,6 +143,10 @@ void add_fiber_inplace_async<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_f
         Scalar beta, const Tensor<fp32_fast_tf32_t> &dst, Index axis, Index batch_ndim);
 
 template
+void add_fiber_inplace_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src,
+        Scalar beta, const Tensor<fp32_fast_fp16_t> &dst, Index axis, Index batch_ndim);
+
+template
 void add_fiber_inplace_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src,
         Scalar beta, const Tensor<fp64_t> &dst, Index axis, Index batch_ndim);
 
@@ -158,6 +162,10 @@ void add_fiber_inplace<fp32_t>(Scalar alpha, const Tensor<fp32_t> &src, Scalar b
 template
 void add_fiber_inplace<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src,
         Scalar beta, const Tensor<fp32_fast_tf32_t> &dst, Index axis, Index batch_ndim);
+
+template
+void add_fiber_inplace<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src,
+        Scalar beta, const Tensor<fp32_fast_fp16_t> &dst, Index axis, Index batch_ndim);
 
 template
 void add_fiber_inplace<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src, Scalar beta,

--- a/src/tensor/add_inplace.cc
+++ b/src/tensor/add_inplace.cc
@@ -94,6 +94,11 @@ void add_inplace_async<fp32_fast_tf32_t>(Scalar alpha,
         const Tensor<fp32_fast_tf32_t> &dst);
 
 template
+void add_inplace_async<fp32_fast_fp16_t>(Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &dst);
+
+template
 void add_inplace_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src,
         Scalar beta, const Tensor<fp64_t> &dst);
 
@@ -110,6 +115,11 @@ template
 void add_inplace<fp32_fast_tf32_t>(Scalar alpha,
         const Tensor<fp32_fast_tf32_t> &src, Scalar beta,
         const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void add_inplace<fp32_fast_fp16_t>(Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void add_inplace<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src, Scalar beta,

--- a/src/tensor/add_slice.cc
+++ b/src/tensor/add_slice.cc
@@ -182,6 +182,10 @@ template
 void add_slice_async<bf16_t>(Scalar alpha, const Tensor<bf16_t> &src1, Scalar beta,
         const Tensor<bf16_t> &src2, const Tensor<bf16_t> &dst, Index axis);
 
+template
+void add_slice_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src1, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &src2, const Tensor<fp32_fast_fp16_t> &dst, Index axis);
+
 // Explicit instantiation of template
 template
 void add_slice<fp32_t>(Scalar alpha, const Tensor<fp32_t> &src1, Scalar beta,
@@ -194,6 +198,10 @@ void add_slice<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &s
 template
 void add_slice<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src1, Scalar beta,
         const Tensor<fp64_t> &src2, const Tensor<fp64_t> &dst, Index axis);
+
+template
+void add_slice<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src1, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &src2, const Tensor<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void add_slice<bf16_t>(Scalar alpha, const Tensor<bf16_t> &src1, Scalar beta,

--- a/src/tensor/add_slice_inplace.cc
+++ b/src/tensor/add_slice_inplace.cc
@@ -159,6 +159,10 @@ void add_slice_inplace_async<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_f
         Scalar beta, const Tensor<fp32_fast_tf32_t> &dst, Index axis);
 
 template
+void add_slice_inplace_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void add_slice_inplace_async<bf16_t>(Scalar alpha, const Tensor<bf16_t> &src, Scalar beta,
         const Tensor<bf16_t> &dst, Index axis);
 
@@ -170,6 +174,10 @@ void add_slice_inplace<fp32_t>(Scalar alpha, const Tensor<fp32_t> &src, Scalar b
 template
 void add_slice_inplace<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src, Scalar beta,
         const Tensor<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void add_slice_inplace<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void add_slice_inplace<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src, Scalar beta,

--- a/src/tensor/clear.cc
+++ b/src/tensor/clear.cc
@@ -51,6 +51,9 @@ template
 void clear_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &dst);
 
 template
+void clear_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &dst);
+
+template
 void clear_async<fp64_t>(const Tensor<fp64_t> &dst);
 
 template
@@ -65,6 +68,9 @@ void clear<fp32_t>(const Tensor<fp32_t> &dst);
 
 template
 void clear<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void clear<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void clear<fp64_t>(const Tensor<fp64_t> &dst);

--- a/src/tensor/copy.cc
+++ b/src/tensor/copy.cc
@@ -75,7 +75,12 @@ template
 void copy_async<fp32_t>(const Tensor<fp32_t> &src, const Tensor<fp32_t> &dst);
 
 template
-void copy_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src, const Tensor<fp32_fast_tf32_t> &dst);
+void copy_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
+                                  const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void copy_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+                                  const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void copy_async<fp64_t>(const Tensor<fp64_t> &src, const Tensor<fp64_t> &dst);
@@ -91,7 +96,12 @@ template
 void copy<fp32_t>(const Tensor<fp32_t> &src, const Tensor<fp32_t> &dst);
 
 template
-void copy<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src, const Tensor<fp32_fast_tf32_t> &dst);
+void copy<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
+                            const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void copy<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+                            const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void copy<fp64_t>(const Tensor<fp64_t> &src, const Tensor<fp64_t> &dst);

--- a/src/tensor/embedding.cc
+++ b/src/tensor/embedding.cc
@@ -139,6 +139,10 @@ void embedding_async<fp32_fast_tf32_t>(const Tensor<int64_t> &index,
         const Tensor<fp32_fast_tf32_t> &vocab, const Tensor<fp32_fast_tf32_t> &embed, Index axis);
 
 template
+void embedding_async<fp32_fast_fp16_t>(const Tensor<int64_t> &index, const Tensor<fp32_fast_fp16_t> &vocab,
+        const Tensor<fp32_fast_fp16_t> &embed, Index axis);
+
+template
 void embedding_async<fp64_t>(const Tensor<int64_t> &index,
         const Tensor<fp64_t> &vocab, const Tensor<fp64_t> &embed, Index axis);
 
@@ -154,6 +158,10 @@ void embedding<bf16_t>(const Tensor<int64_t> &index,
 template
 void embedding<fp32_fast_tf32_t>(const Tensor<int64_t> &index, const Tensor<fp32_fast_tf32_t> &vocab,
         const Tensor<fp32_fast_tf32_t> &embed, Index axis);
+
+template
+void embedding<fp32_fast_fp16_t>(const Tensor<int64_t> &index, const Tensor<fp32_fast_fp16_t> &vocab,
+        const Tensor<fp32_fast_fp16_t> &embed, Index axis);
 
 
 template

--- a/src/tensor/embedding_backward.cc
+++ b/src/tensor/embedding_backward.cc
@@ -136,6 +136,11 @@ void embedding_backward_async<fp32_fast_tf32_t>(const Tensor<int64_t> &index,
         int redux);
 
 template
+void embedding_backward_async<fp32_fast_fp16_t>(const Tensor<int64_t> &index,
+        const Tensor<fp32_fast_fp16_t> &embed, const Tensor<fp32_fast_fp16_t> &vocab, Index axis,
+        int redux);
+
+template
 void embedding_backward_async<fp64_t>(const Tensor<int64_t> &index,
         const Tensor<fp64_t> &embed, const Tensor<fp64_t> &vocab, Index axis,
         int redux);
@@ -154,6 +159,11 @@ void embedding_backward<fp32_t>(const Tensor<int64_t> &index,
 template
 void embedding_backward<fp32_fast_tf32_t>(const Tensor<int64_t> &index,
         const Tensor<fp32_fast_tf32_t> &embed, const Tensor<fp32_fast_tf32_t> &vocab, Index axis,
+        int redux);
+
+template
+void embedding_backward<fp32_fast_fp16_t>(const Tensor<int64_t> &index,
+        const Tensor<fp32_fast_fp16_t> &embed, const Tensor<fp32_fast_fp16_t> &vocab, Index axis,
         int redux);
 
 template

--- a/src/tensor/fill.cc
+++ b/src/tensor/fill.cc
@@ -62,6 +62,9 @@ template
 void fill_async<fp32_fast_tf32_t>(Scalar val, const Tensor<fp32_fast_tf32_t> &A);
 
 template
+void fill_async<fp32_fast_fp16_t>(Scalar val, const Tensor<fp32_fast_fp16_t> &A);
+
+template
 void fill_async<fp64_t>(Scalar val, const Tensor<fp64_t> &A);
 
 // Explicit instantiation
@@ -73,6 +76,9 @@ void fill<bf16_t>(Scalar val, const Tensor<bf16_t> &A);
 
 template
 void fill<fp32_fast_tf32_t>(Scalar val, const Tensor<fp32_fast_tf32_t> &A);
+
+template
+void fill<fp32_fast_fp16_t>(Scalar val, const Tensor<fp32_fast_fp16_t> &A);
 
 template
 void fill<fp64_t>(Scalar val, const Tensor<fp64_t> &A);

--- a/src/tensor/flash_maxsumexp.cc
+++ b/src/tensor/flash_maxsumexp.cc
@@ -146,6 +146,11 @@ void flash_maxsumexp_async(const Tensor<fp32_fast_tf32_t> &Q, const Tensor<fp32_
         const Tensor<fp32_fast_tf32_t> &tmp, int redux);
 
 template
+void flash_maxsumexp_async(const Tensor<fp32_fast_fp16_t> &Q, const Tensor<fp32_fast_fp16_t> &K,
+        const Tensor<bool_t> &mask, const Tensor<fp32_fast_fp16_t> &maxsumexp,
+        const Tensor<fp32_fast_fp16_t> &tmp, int redux);
+
+template
 void flash_maxsumexp_async(const Tensor<fp32_t> &Q, const Tensor<fp32_t> &K,
         const Tensor<bool_t> &mask, const Tensor<fp32_t> &maxsumexp,
         const Tensor<fp32_t> &tmp, int redux);
@@ -170,6 +175,11 @@ template
 void flash_maxsumexp(const Tensor<fp32_fast_tf32_t> &Q, const Tensor<fp32_fast_tf32_t> &K,
         const Tensor<bool_t> &mask, const Tensor<fp32_fast_tf32_t> &maxsumexp,
         const Tensor<fp32_fast_tf32_t> &tmp, int redux);
+
+template
+void flash_maxsumexp(const Tensor<fp32_fast_fp16_t> &Q, const Tensor<fp32_fast_fp16_t> &K,
+        const Tensor<bool_t> &mask, const Tensor<fp32_fast_fp16_t> &maxsumexp,
+        const Tensor<fp32_fast_fp16_t> &tmp, int redux);
 
 template
 void flash_maxsumexp(const Tensor<fp64_t> &Q, const Tensor<fp64_t> &K,

--- a/src/tensor/flash_softmax_gemm.cc
+++ b/src/tensor/flash_softmax_gemm.cc
@@ -165,6 +165,12 @@ void flash_softmax_gemm_async(const Tensor<fp32_fast_tf32_t> &Q, const Tensor<fp
         const Tensor<fp32_fast_tf32_t> &tmp, int redux);
 
 template
+void flash_softmax_gemm_async(const Tensor<fp32_fast_fp16_t> &Q, const Tensor<fp32_fast_fp16_t> &K,
+        const Tensor<fp32_fast_fp16_t> &V, const Tensor<bool_t> &mask,
+        const Tensor<fp32_fast_fp16_t> &maxsumexp, const Tensor<fp32_fast_fp16_t> &dst,
+        const Tensor<fp32_fast_fp16_t> &tmp, int redux);
+
+template
 void flash_softmax_gemm_async(const Tensor<fp64_t> &Q, const Tensor<fp64_t> &K,
         const Tensor<fp64_t> &V, const Tensor<bool_t> &mask,
         const Tensor<fp64_t> &maxsumexp, const Tensor<fp64_t> &dst,
@@ -188,6 +194,12 @@ void flash_softmax_gemm(const Tensor<fp32_fast_tf32_t> &Q, const Tensor<fp32_fas
         const Tensor<fp32_fast_tf32_t> &V, const Tensor<bool_t> &mask,
         const Tensor<fp32_fast_tf32_t> &maxsumexp, const Tensor<fp32_fast_tf32_t> &dst,
         const Tensor<fp32_fast_tf32_t> &tmp, int redux);
+
+template
+void flash_softmax_gemm(const Tensor<fp32_fast_fp16_t> &Q, const Tensor<fp32_fast_fp16_t> &K,
+        const Tensor<fp32_fast_fp16_t> &V, const Tensor<bool_t> &mask,
+        const Tensor<fp32_fast_fp16_t> &maxsumexp, const Tensor<fp32_fast_fp16_t> &dst,
+        const Tensor<fp32_fast_fp16_t> &tmp, int redux);
 
 template
 void flash_softmax_gemm(const Tensor<fp64_t> &Q, const Tensor<fp64_t> &K,

--- a/src/tensor/flash_softmax_gemm_backward.cc
+++ b/src/tensor/flash_softmax_gemm_backward.cc
@@ -247,6 +247,14 @@ void flash_softmax_gemm_backward_async(const Tensor<fp32_fast_tf32_t> &Q, const 
         const Tensor<fp32_fast_tf32_t> &tmp_sumprod_slice, int redux);
 
 template
+void flash_softmax_gemm_backward_async(const Tensor<fp32_fast_fp16_t> &Q, const Tensor<fp32_fast_fp16_t> &dQ,
+        const Tensor<fp32_fast_fp16_t> &K, const Tensor<fp32_fast_fp16_t> &dK, const Tensor<fp32_fast_fp16_t> &V,
+        const Tensor<fp32_fast_fp16_t> &dV, const Tensor<bool_t> &mask,
+        const Tensor<fp32_fast_fp16_t> &maxsumexp, const Tensor<fp32_fast_fp16_t> &dst_grad,
+        const Tensor<fp32_fast_fp16_t> &tmp, const Tensor<fp32_fast_fp16_t> &tmp_grad,
+        const Tensor<fp32_fast_fp16_t> &tmp_sumprod_slice, int redux);
+
+template
 void flash_softmax_gemm_backward_async(const Tensor<fp64_t> &Q, const Tensor<fp64_t> &dQ,
         const Tensor<fp64_t> &K, const Tensor<fp64_t> &dK, const Tensor<fp64_t> &V,
         const Tensor<fp64_t> &dV, const Tensor<bool_t> &mask,
@@ -278,6 +286,14 @@ void flash_softmax_gemm_backward(const Tensor<fp32_fast_tf32_t> &Q, const Tensor
         const Tensor<fp32_fast_tf32_t> &maxsumexp, const Tensor<fp32_fast_tf32_t> &dst_grad,
         const Tensor<fp32_fast_tf32_t> &tmp, const Tensor<fp32_fast_tf32_t> &tmp_grad,
         const Tensor<fp32_fast_tf32_t> &tmp_sumprod_slice, int redux);
+
+template
+void flash_softmax_gemm_backward(const Tensor<fp32_fast_fp16_t> &Q, const Tensor<fp32_fast_fp16_t> &dQ,
+        const Tensor<fp32_fast_fp16_t> &K, const Tensor<fp32_fast_fp16_t> &dK, const Tensor<fp32_fast_fp16_t> &V,
+        const Tensor<fp32_fast_fp16_t> &dV, const Tensor<bool_t> &mask,
+        const Tensor<fp32_fast_fp16_t> &maxsumexp, const Tensor<fp32_fast_fp16_t> &dst_grad,
+        const Tensor<fp32_fast_fp16_t> &tmp, const Tensor<fp32_fast_fp16_t> &tmp_grad,
+        const Tensor<fp32_fast_fp16_t> &tmp_sumprod_slice, int redux);
 
 template
 void flash_softmax_gemm_backward(const Tensor<fp64_t> &Q, const Tensor<fp64_t> &dQ,

--- a/src/tensor/gather.cc
+++ b/src/tensor/gather.cc
@@ -150,6 +150,10 @@ void gather_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
         const Tensor<fp32_fast_tf32_t> &dst);
 
 template
+void gather_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+                              const Tensor<fp32_fast_fp16_t> &dst);
+
+template
 void gather_async<bf16_t>(const Tensor<bf16_t> &src,
         const Tensor<bf16_t> &dst);
 
@@ -160,6 +164,10 @@ void gather<fp32_t>(const Tensor<fp32_t> &src, const Tensor<fp32_t> &dst);
 template
 void gather<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
                               const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void gather<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+                              const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void gather<fp64_t>(const Tensor<fp64_t> &src, const Tensor<fp64_t> &dst);

--- a/src/tensor/gelutanh.cc
+++ b/src/tensor/gelutanh.cc
@@ -86,6 +86,10 @@ void gelutanh_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
         const Tensor<fp32_fast_tf32_t> &dst);
 
 template
+void gelutanh_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+                                const Tensor<fp32_fast_fp16_t> &dst);
+
+template
 void gelutanh_async<fp64_t>(const Tensor<fp64_t> &src,
         const Tensor<fp64_t> &dst);
 
@@ -98,6 +102,10 @@ void gelutanh<fp32_t>(const Tensor<fp32_t> &src, const Tensor<fp32_t> &dst);
 
 template
 void gelutanh<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src, const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void gelutanh<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+                                const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void gelutanh<fp64_t>(const Tensor<fp64_t> &src, const Tensor<fp64_t> &dst);

--- a/src/tensor/gelutanh_backward.cc
+++ b/src/tensor/gelutanh_backward.cc
@@ -93,6 +93,10 @@ void gelutanh_backward_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &x
         const Tensor<fp32_fast_tf32_t> &dy, const Tensor<fp32_fast_tf32_t> &dx);
 
 template
+void gelutanh_backward_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &x,
+        const Tensor<fp32_fast_fp16_t> &dy, const Tensor<fp32_fast_fp16_t> &dx);
+
+template
 void gelutanh_backward_async<fp64_t>(const Tensor<fp64_t> &x,
         const Tensor<fp64_t> &dy, const Tensor<fp64_t> &dx);
 
@@ -108,6 +112,10 @@ void gelutanh_backward<fp32_t>(const Tensor<fp32_t> &x,
 template
 void gelutanh_backward<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &x,
         const Tensor<fp32_fast_tf32_t> &dy, const Tensor<fp32_fast_tf32_t> &dx);
+
+template
+void gelutanh_backward<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &x,
+        const Tensor<fp32_fast_fp16_t> &dy, const Tensor<fp32_fast_fp16_t> &dx);
 
 template
 void gelutanh_backward<fp64_t>(const Tensor<fp64_t> &x,

--- a/src/tensor/gemm.cc
+++ b/src/tensor/gemm.cc
@@ -508,6 +508,12 @@ void gemm_async<fp32_fast_tf32_t>(Scalar alpha, const TransOp &transA,
         const Tensor<fp32_fast_tf32_t> &C, Index ndim, Index batch_ndim, int redux);
 
 template
+void gemm_async<fp32_fast_fp16_t>(Scalar alpha, const TransOp &transA,
+        const Tensor<fp32_fast_fp16_t> &A,
+        const TransOp &transB, const Tensor<fp32_fast_fp16_t> &B, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &C, Index ndim, Index batch_ndim, int redux);
+
+template
 void gemm_async<fp64_t>(Scalar alpha, const TransOp &transA,
         const Tensor<fp64_t> &A,
         const TransOp &transB, const Tensor<fp64_t> &B, Scalar beta,
@@ -531,6 +537,12 @@ void gemm<fp32_fast_tf32_t>(Scalar alpha, const TransOp &transA,
         const Tensor<fp32_fast_tf32_t> &A,
         const TransOp &transB, const Tensor<fp32_fast_tf32_t> &B, Scalar beta,
         const Tensor<fp32_fast_tf32_t> &C, Index ndim, Index batch_ndim, int redux);
+
+template
+void gemm<fp32_fast_fp16_t>(Scalar alpha, const TransOp &transA,
+        const Tensor<fp32_fast_fp16_t> &A,
+        const TransOp &transB, const Tensor<fp32_fast_fp16_t> &B, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &C, Index ndim, Index batch_ndim, int redux);
 
 template
 void gemm<fp64_t>(Scalar alpha, const TransOp &transA,

--- a/src/tensor/hypot_scalar_inverse.cc
+++ b/src/tensor/hypot_scalar_inverse.cc
@@ -62,6 +62,10 @@ void hypot_scalar_inverse_async<fp32_fast_tf32_t>(Scalar eps, Scalar alpha,
         const Tensor<fp32_fast_tf32_t> &dst);
 
 template
+void hypot_scalar_inverse_async<fp32_fast_fp16_t>(Scalar eps, Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &dst);
+
+template
 void hypot_scalar_inverse_async<fp64_t>(Scalar eps, Scalar alpha,
         const Tensor<fp64_t> &dst);
 
@@ -73,6 +77,10 @@ void hypot_scalar_inverse<fp32_t>(Scalar eps, Scalar alpha,
 template
 void hypot_scalar_inverse<fp32_fast_tf32_t>(Scalar eps, Scalar alpha,
         const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void hypot_scalar_inverse<fp32_fast_fp16_t>(Scalar eps, Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void hypot_scalar_inverse<fp64_t>(Scalar eps, Scalar alpha,

--- a/src/tensor/logsumexp.cc
+++ b/src/tensor/logsumexp.cc
@@ -92,7 +92,12 @@ template
 void logsumexp_async<fp32_t>(const Tensor<fp32_t> &src, const Tensor<fp32_t> &dst);
 
 template
-void logsumexp_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src, const Tensor<fp32_fast_tf32_t> &dst);
+void logsumexp_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
+                                       const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void logsumexp_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+                                 const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void logsumexp_async<fp64_t>(const Tensor<fp64_t> &src, const Tensor<fp64_t> &dst);
@@ -105,7 +110,12 @@ template
 void logsumexp<fp32_t>(const Tensor<fp32_t> &src, const Tensor<fp32_t> &dst);
 
 template
-void logsumexp<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src, const Tensor<fp32_fast_tf32_t> &dst);
+void logsumexp<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
+                                 const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void logsumexp<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+                                 const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void logsumexp<fp64_t>(const Tensor<fp64_t> &src, const Tensor<fp64_t> &dst);

--- a/src/tensor/mask_scalar.cc
+++ b/src/tensor/mask_scalar.cc
@@ -93,6 +93,10 @@ void mask_scalar_async<fp32_fast_tf32_t>(const Tensor<bool_t> &mask, Scalar val,
         const Tensor<fp32_fast_tf32_t> &A, Index batch_ndim);
 
 template
+void mask_scalar_async<fp32_fast_fp16_t>(const Tensor<bool_t> &mask, Scalar val,
+        const Tensor<fp32_fast_fp16_t> &A, Index batch_ndim);
+
+template
 void mask_scalar_async<fp64_t>(const Tensor<bool_t> &mask, Scalar val,
         const Tensor<fp64_t> &A, Index batch_ndim);
 
@@ -108,6 +112,10 @@ void mask_scalar<fp32_t>(const Tensor<bool_t> &mask, Scalar val,
 template
 void mask_scalar<fp32_fast_tf32_t>(const Tensor<bool_t> &mask, Scalar val,
         const Tensor<fp32_fast_tf32_t> &A, Index batch_ndim);
+
+template
+void mask_scalar<fp32_fast_fp16_t>(const Tensor<bool_t> &mask, Scalar val,
+        const Tensor<fp32_fast_fp16_t> &A, Index batch_ndim);
 
 template
 void mask_scalar<fp64_t>(const Tensor<bool_t> &mask, Scalar val,

--- a/src/tensor/maxsumexp.cc
+++ b/src/tensor/maxsumexp.cc
@@ -145,6 +145,10 @@ void maxsumexp_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
         const Tensor<fp32_fast_tf32_t> &dst, Index axis, int redux);
 
 template
+void maxsumexp_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src, const Tensor<fp32_fast_fp16_t> &dst,
+        Index axis, int redux);
+
+template
 void maxsumexp_async<fp64_t>(const Tensor<fp64_t> &src,
         const Tensor<fp64_t> &dst, Index axis, int redux);
 
@@ -159,6 +163,10 @@ void maxsumexp<fp32_t>(const Tensor<fp32_t> &src, const Tensor<fp32_t> &dst,
 
 template
 void maxsumexp<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src, const Tensor<fp32_fast_tf32_t> &dst,
+        Index axis, int redux);
+
+template
+void maxsumexp<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src, const Tensor<fp32_fast_fp16_t> &dst,
         Index axis, int redux);
 
 template

--- a/src/tensor/norm_slice.cc
+++ b/src/tensor/norm_slice.cc
@@ -145,6 +145,10 @@ void norm_slice_async<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf3
         Scalar beta, const Tensor<fp32_fast_tf32_t> &dst, Index axis, int redux);
 
 template
+void norm_slice_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis, int redux);
+
+template
 void norm_slice_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src,
         Scalar beta, const Tensor<fp64_t> &dst, Index axis, int redux);
 
@@ -160,6 +164,10 @@ void norm_slice<fp32_t>(Scalar alpha, const Tensor<fp32_t> &src, Scalar beta,
 template
 void norm_slice<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src, Scalar beta,
         const Tensor<fp32_fast_tf32_t> &dst, Index axis, int redux);
+
+template
+void norm_slice<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis, int redux);
 
 template
 void norm_slice<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src, Scalar beta,

--- a/src/tensor/prod_fiber3.cc
+++ b/src/tensor/prod_fiber3.cc
@@ -129,6 +129,10 @@ void prod_fiber3_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src1, S
         const Tensor<fp32_fast_tf32_t> &src2, const Tensor<fp32_fast_tf32_t> &dst, Index axis);
 
 template
+void prod_fiber3_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src1, Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &src2, const Tensor<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void prod_fiber3_async<fp64_t>(const Tensor<fp64_t> &src1, Scalar alpha,
         const Tensor<fp64_t> &src2, const Tensor<fp64_t> &dst, Index axis);
 
@@ -144,6 +148,10 @@ void prod_fiber3<fp32_t>(const Tensor<fp32_t> &src1, Scalar alpha,
 template
 void prod_fiber3<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src1, Scalar alpha,
         const Tensor<fp32_fast_tf32_t> &src2, const Tensor<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void prod_fiber3<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src1, Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &src2, const Tensor<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void prod_fiber3<fp64_t>(const Tensor<fp64_t> &src1, Scalar alpha,

--- a/src/tensor/prod_inplace.cc
+++ b/src/tensor/prod_inplace.cc
@@ -79,6 +79,10 @@ void prod_inplace_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
         const Tensor<fp32_fast_tf32_t> &dst);
 
 template
+void prod_inplace_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+        const Tensor<fp32_fast_fp16_t> &dst);
+
+template
 void prod_inplace_async<fp64_t>(const Tensor<fp64_t> &src,
         const Tensor<fp64_t> &dst);
 
@@ -94,6 +98,10 @@ void prod_inplace<fp32_t>(const Tensor<fp32_t> &src,
 template
 void prod_inplace<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
         const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void prod_inplace<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+        const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void prod_inplace<fp64_t>(const Tensor<fp64_t> &src,

--- a/src/tensor/prod_slice.cc
+++ b/src/tensor/prod_slice.cc
@@ -153,6 +153,10 @@ void prod_slice_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src, Sca
         const Tensor<fp32_fast_tf32_t> &dst, Index axis);
 
 template
+void prod_slice_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src, Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void prod_slice_async<fp64_t>(const Tensor<fp64_t> &src, Scalar alpha,
         const Tensor<fp64_t> &dst, Index axis);
 
@@ -168,6 +172,10 @@ void prod_slice<fp32_t>(const Tensor<fp32_t> &src, Scalar alpha,
 template
 void prod_slice<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src, Scalar alpha,
         const Tensor<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void prod_slice<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src, Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void prod_slice<fp64_t>(const Tensor<fp64_t> &src, Scalar alpha,

--- a/src/tensor/scal.cc
+++ b/src/tensor/scal.cc
@@ -86,6 +86,10 @@ void scal_async<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &
         const Tensor<fp32_fast_tf32_t> &dst);
 
 template
+void scal_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src,
+        const Tensor<fp32_fast_fp16_t> &dst);
+
+template
 void scal_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src,
         const Tensor<fp64_t> &dst);
 
@@ -101,6 +105,10 @@ void scal<bf16_t>(Scalar alpha, const Tensor<bf16_t> &src,
 template
 void scal<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src,
         const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void scal<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src,
+        const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void scal<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src,

--- a/src/tensor/scal_inplace.cc
+++ b/src/tensor/scal_inplace.cc
@@ -56,6 +56,9 @@ template
 void scal_inplace_async<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &data);
 
 template
+void scal_inplace_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &data);
+
+template
 void scal_inplace_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &data);
 
 // Explicit instantiation
@@ -64,6 +67,9 @@ void scal_inplace<fp32_t>(Scalar alpha, const Tensor<fp32_t> &data);
 
 template
 void scal_inplace<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &data);
+
+template
+void scal_inplace<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &data);
 
 template
 void scal_inplace<fp64_t>(Scalar alpha, const Tensor<fp64_t> &data);

--- a/src/tensor/scatter.cc
+++ b/src/tensor/scatter.cc
@@ -173,6 +173,10 @@ void scatter_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
         const Tensor<fp32_fast_tf32_t> &dst);
 
 template
+void scatter_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+        const Tensor<fp32_fast_fp16_t> &dst);
+
+template
 void scatter_async<bool_t>(const Tensor<bool_t> &src,
         const Tensor<bool_t> &dst);
 
@@ -190,6 +194,10 @@ void scatter<fp32_t>(const Tensor<fp32_t> &src, const Tensor<fp32_t> &dst);
 template
 void scatter<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
                                const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void scatter<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+                               const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void scatter<fp64_t>(const Tensor<fp64_t> &src, const Tensor<fp64_t> &dst);

--- a/src/tensor/softmax.cc
+++ b/src/tensor/softmax.cc
@@ -184,6 +184,11 @@ void softmax_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &maxsumexp,
         Index axis);
 
 template
+void softmax_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &maxsumexp,
+        const Tensor<fp32_fast_fp16_t> &src, Scalar alpha, const Tensor<fp32_fast_fp16_t> &dst,
+        Index axis);
+
+template
 void softmax_async<fp64_t>(const Tensor<fp64_t> &maxsumexp,
         const Tensor<fp64_t> &src, Scalar alpha, const Tensor<fp64_t> &dst,
         Index axis);
@@ -202,6 +207,11 @@ void softmax<fp32_t>(const Tensor<fp32_t> &maxsumexp,
 template
 void softmax<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &maxsumexp,
         const Tensor<fp32_fast_tf32_t> &src, Scalar alpha, const Tensor<fp32_fast_tf32_t> &dst,
+        Index axis);
+
+template
+void softmax<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &maxsumexp,
+        const Tensor<fp32_fast_fp16_t> &src, Scalar alpha, const Tensor<fp32_fast_fp16_t> &dst,
         Index axis);
 
 template

--- a/src/tensor/softmax_inplace.cc
+++ b/src/tensor/softmax_inplace.cc
@@ -167,6 +167,10 @@ void softmax_inplace_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &max
         Scalar alpha, const Tensor<fp32_fast_tf32_t> &dst, Index axis);
 
 template
+void softmax_inplace_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &maxsumexp, Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void softmax_inplace_async<fp64_t>(const Tensor<fp64_t> &maxsumexp,
         Scalar alpha, const Tensor<fp64_t> &dst, Index axis);
 
@@ -182,6 +186,10 @@ void softmax_inplace<fp32_t>(const Tensor<fp32_t> &maxsumexp, Scalar alpha,
 template
 void softmax_inplace<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &maxsumexp, Scalar alpha,
         const Tensor<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void softmax_inplace<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &maxsumexp, Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void softmax_inplace<fp64_t>(const Tensor<fp64_t> &maxsumexp, Scalar alpha,

--- a/src/tensor/subtract_indexed_outputs.cc
+++ b/src/tensor/subtract_indexed_outputs.cc
@@ -83,6 +83,10 @@ void subtract_indexed_outputs_async<fp32_fast_tf32_t>(Scalar val,
         const Tensor<int64_t> &labels, const Tensor<fp32_fast_tf32_t> &dst);
 
 template
+void subtract_indexed_outputs_async<fp32_fast_fp16_t>(Scalar val, const Tensor<int64_t> &labels,
+        const Tensor<fp32_fast_fp16_t> &dst);
+
+template
 void subtract_indexed_outputs_async<fp64_t>(Scalar val,
         const Tensor<int64_t> &labels, const Tensor<fp64_t> &dst);
 
@@ -98,6 +102,10 @@ void subtract_indexed_outputs<fp32_t>(Scalar val, const Tensor<int64_t> &labels,
 template
 void subtract_indexed_outputs<fp32_fast_tf32_t>(Scalar val, const Tensor<int64_t> &labels,
         const Tensor<fp32_fast_tf32_t> &dst);
+
+template
+void subtract_indexed_outputs<fp32_fast_fp16_t>(Scalar val, const Tensor<int64_t> &labels,
+        const Tensor<fp32_fast_fp16_t> &dst);
 
 template
 void subtract_indexed_outputs<fp64_t>(Scalar val, const Tensor<int64_t> &labels,

--- a/src/tensor/sum_fiber.cc
+++ b/src/tensor/sum_fiber.cc
@@ -149,6 +149,11 @@ void sum_fiber_async<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32
         int redux);
 
 template
+void sum_fiber_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis, Index batch_ndim,
+        int redux);
+
+template
 void sum_fiber_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src,
         Scalar beta, const Tensor<fp64_t> &dst, Index axis, Index batch_ndim,
         int redux);
@@ -167,6 +172,11 @@ void sum_fiber<fp32_t>(Scalar alpha, const Tensor<fp32_t> &src, Scalar beta,
 template
 void sum_fiber<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src, Scalar beta,
         const Tensor<fp32_fast_tf32_t> &dst, Index axis, Index batch_ndim,
+        int redux);
+
+template
+void sum_fiber<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis, Index batch_ndim,
         int redux);
 
 template

--- a/src/tensor/sum_slice.cc
+++ b/src/tensor/sum_slice.cc
@@ -154,6 +154,10 @@ void sum_slice_async<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32
         Scalar beta, const Tensor<fp32_fast_tf32_t> &dst, Index axis, int redux);
 
 template
+void sum_slice_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis, int redux);
+
+template
 void sum_slice_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src,
         Scalar beta, const Tensor<fp64_t> &dst, Index axis, int redux);
 
@@ -169,6 +173,10 @@ void sum_slice<fp32_t>(Scalar alpha, const Tensor<fp32_t> &src, Scalar beta,
 template
 void sum_slice<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src, Scalar beta,
         const Tensor<fp32_fast_tf32_t> &dst, Index axis, int redux);
+
+template
+void sum_slice<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tensor<fp32_fast_fp16_t> &dst, Index axis, int redux);
 
 template
 void sum_slice<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src, Scalar beta,

--- a/src/tensor/sumprod_fiber.cc
+++ b/src/tensor/sumprod_fiber.cc
@@ -140,6 +140,11 @@ void sumprod_fiber_async<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_
         Index axis, int redux);
 
 template
+void sumprod_fiber_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src1,
+        const Tensor<fp32_fast_fp16_t> &src2, Scalar beta, const Tensor<fp32_fast_fp16_t> &dst,
+        Index axis, int redux);
+
+template
 void sumprod_fiber_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src1,
         const Tensor<fp64_t> &src2, Scalar beta, const Tensor<fp64_t> &dst,
         Index axis, int redux);
@@ -158,6 +163,11 @@ void sumprod_fiber<fp32_t>(Scalar alpha, const Tensor<fp32_t> &src1,
 template
 void sumprod_fiber<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src1,
         const Tensor<fp32_fast_tf32_t> &src2, Scalar beta, const Tensor<fp32_fast_tf32_t> &dst,
+        Index axis, int redux);
+
+template
+void sumprod_fiber<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src1,
+        const Tensor<fp32_fast_fp16_t> &src2, Scalar beta, const Tensor<fp32_fast_fp16_t> &dst,
         Index axis, int redux);
 
 template

--- a/src/tensor/sumprod_slice.cc
+++ b/src/tensor/sumprod_slice.cc
@@ -170,6 +170,11 @@ void sumprod_slice_async<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_
         Index axis, int redux);
 
 template
+void sumprod_slice_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src1,
+        const Tensor<fp32_fast_fp16_t> &src2, Scalar beta, const Tensor<fp32_fast_fp16_t> &dst,
+        Index axis, int redux);
+
+template
 void sumprod_slice_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src1,
         const Tensor<fp64_t> &src2, Scalar beta, const Tensor<fp64_t> &dst,
         Index axis, int redux);
@@ -188,6 +193,11 @@ void sumprod_slice<fp32_t>(Scalar alpha, const Tensor<fp32_t> &src1,
 template
 void sumprod_slice<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src1,
         const Tensor<fp32_fast_tf32_t> &src2, Scalar beta, const Tensor<fp32_fast_tf32_t> &dst,
+        Index axis, int redux);
+
+template
+void sumprod_slice<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src1,
+        const Tensor<fp32_fast_fp16_t> &src2, Scalar beta, const Tensor<fp32_fast_fp16_t> &dst,
         Index axis, int redux);
 
 template

--- a/src/tensor/total_sum_accum.cc
+++ b/src/tensor/total_sum_accum.cc
@@ -114,6 +114,12 @@ void total_sum_accum_async<fp32_fast_tf32_t>(Scalar alpha,
         const Tensor<int64_t> &class_labels, const Tensor<fp32_t> &val);
 
 template
+void total_sum_accum_async<fp32_fast_fp16_t>(Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &logsumexp,
+        const Tensor<fp32_fast_fp16_t> &src,
+        const Tensor<int64_t> &class_labels, const Tensor<fp32_t> &val);
+
+template
 void total_sum_accum_async<fp64_t>(Scalar alpha,
         const Tensor<fp64_t> &logsumexp, const Tensor<fp64_t> &src,
         const Tensor<int64_t> &class_labels, const Tensor<fp32_t> &val);
@@ -133,6 +139,12 @@ template
 void total_sum_accum<fp32_fast_tf32_t>(Scalar alpha,
         const Tensor<fp32_fast_tf32_t> &logsumexp,
         const Tensor<fp32_fast_tf32_t> &src,
+        const Tensor<int64_t> &class_labels, const Tensor<fp32_t> &val);
+
+template
+void total_sum_accum<fp32_fast_fp16_t>(Scalar alpha,
+        const Tensor<fp32_fast_fp16_t> &logsumexp,
+        const Tensor<fp32_fast_fp16_t> &src,
         const Tensor<int64_t> &class_labels, const Tensor<fp32_t> &val);
 
 template

--- a/src/tensor/transpose.cc
+++ b/src/tensor/transpose.cc
@@ -98,6 +98,10 @@ void transpose_async<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32
         const Tensor<fp32_fast_tf32_t> &dst, Index ndim);
 
 template
+void transpose_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src,
+        const Tensor<fp32_fast_fp16_t> &dst, Index ndim);
+
+template
 void transpose_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src,
         const Tensor<fp64_t> &dst, Index ndim);
 
@@ -109,6 +113,10 @@ void transpose<fp32_t>(Scalar alpha, const Tensor<fp32_t> &src,
 template
 void transpose<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src,
         const Tensor<fp32_fast_tf32_t> &dst, Index ndim);
+
+template
+void transpose<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src,
+        const Tensor<fp32_fast_fp16_t> &dst, Index ndim);
 
 template
 void transpose<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src,

--- a/src/tile/adam_step.cc
+++ b/src/tile/adam_step.cc
@@ -84,6 +84,11 @@ void adam_step_async<fp32_fast_tf32_t>(Index num_iter, Scalar beta_1, Scalar bet
                      const Tile<fp32_fast_tf32_t> &p);
 
 template
+void adam_step_async<fp32_fast_fp16_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
+               const Tile<fp32_fast_fp16_t> &grad, const Tile<fp32_fast_fp16_t> &first_moment, const Tile<fp32_fast_fp16_t> &second_moment,
+               const Tile<fp32_fast_fp16_t> &p);
+
+template
 void adam_step_async<fp64_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
                      const Tile<fp64_t> &grad, const Tile<fp64_t> &first_moment, const Tile<fp64_t> &second_moment,
                      const Tile<fp64_t> &p);
@@ -103,6 +108,11 @@ template
 void adam_step<fp32_fast_tf32_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
                const Tile<fp32_fast_tf32_t> &grad, const Tile<fp32_fast_tf32_t> &first_moment, const Tile<fp32_fast_tf32_t> &second_moment,
                const Tile<fp32_fast_tf32_t> &p);
+
+template
+void adam_step<fp32_fast_fp16_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
+               const Tile<fp32_fast_fp16_t> &grad, const Tile<fp32_fast_fp16_t> &first_moment, const Tile<fp32_fast_fp16_t> &second_moment,
+               const Tile<fp32_fast_fp16_t> &p);
 
 template
 void adam_step<fp64_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,

--- a/src/tile/adamw_step.cc
+++ b/src/tile/adamw_step.cc
@@ -84,6 +84,11 @@ void adamw_step_async<fp32_fast_tf32_t>(Index num_iter, Scalar beta_1, Scalar be
                      const Tile<fp32_fast_tf32_t> &p);
 
 template
+void adamw_step_async<fp32_fast_fp16_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
+                     const Tile<fp32_fast_fp16_t> &grad, const Tile<fp32_fast_fp16_t> &first_moment, const Tile<fp32_fast_fp16_t> &second_moment,
+                     const Tile<fp32_fast_fp16_t> &p);
+
+template
 void adamw_step_async<fp64_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
                      const Tile<fp64_t> &grad, const Tile<fp64_t> &first_moment, const Tile<fp64_t> &second_moment,
                      const Tile<fp64_t> &p);
@@ -103,6 +108,11 @@ template
 void adamw_step<fp32_fast_tf32_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
                      const Tile<fp32_fast_tf32_t> &grad, const Tile<fp32_fast_tf32_t> &first_moment, const Tile<fp32_fast_tf32_t> &second_moment,
                      const Tile<fp32_fast_tf32_t> &p);
+
+template
+void adamw_step<fp32_fast_fp16_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,
+                     const Tile<fp32_fast_fp16_t> &grad, const Tile<fp32_fast_fp16_t> &first_moment, const Tile<fp32_fast_fp16_t> &second_moment,
+                     const Tile<fp32_fast_fp16_t> &p);
 
 template
 void adamw_step<fp64_t>(Index num_iter, Scalar beta_1, Scalar beta_2, Scalar eps, Scalar lr, Scalar weight_decay,

--- a/src/tile/add.cc
+++ b/src/tile/add.cc
@@ -80,6 +80,11 @@ void add_async<fp32_fast_tf32_t>(Scalar alpha,
         const Tile<fp32_fast_tf32_t> &src2, const Tile<fp32_fast_tf32_t> &dst);
 
 template
+void add_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src1,
+        Scalar beta, const Tile<fp32_fast_fp16_t> &src2,
+        const Tile<fp32_fast_fp16_t> &dst);
+
+template
 void add_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &src1, Scalar beta,
         const Tile<fp64_t> &src2, const Tile<fp64_t> &dst);
 
@@ -96,6 +101,11 @@ template
 void add<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src1,
         Scalar beta, const Tile<fp32_fast_tf32_t> &src2,
         const Tile<fp32_fast_tf32_t> &dst);
+
+template
+void add<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src1,
+        Scalar beta, const Tile<fp32_fast_fp16_t> &src2,
+        const Tile<fp32_fast_fp16_t> &dst);
 
 template
 void add<fp64_t>(Scalar alpha, const Tile<fp64_t> &src1, Scalar beta,

--- a/src/tile/add_fiber_inplace.cc
+++ b/src/tile/add_fiber_inplace.cc
@@ -103,6 +103,10 @@ void add_fiber_inplace_async<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fas
         Scalar beta, const Tile<fp32_fast_tf32_t> &dst, Index axis, Index batch_ndim);
 
 template
+void add_fiber_inplace_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis, Index batch_ndim);
+
+template
 void add_fiber_inplace_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &src,
         Scalar beta, const Tile<fp64_t> &dst, Index axis, Index batch_ndim);
 
@@ -118,6 +122,10 @@ void add_fiber_inplace<fp32_t>(Scalar alpha, const Tile<fp32_t> &src, Scalar bet
 template
 void add_fiber_inplace<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src, Scalar beta,
         const Tile<fp32_fast_tf32_t> &dst, Index axis, Index batch_ndim);
+
+template
+void add_fiber_inplace<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis, Index batch_ndim);
 
 template
 void add_fiber_inplace<fp64_t>(Scalar alpha, const Tile<fp64_t> &src, Scalar beta,

--- a/src/tile/add_slice.cc
+++ b/src/tile/add_slice.cc
@@ -116,6 +116,10 @@ void add_slice_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &src1,
         Index axis);
 
 template
+void add_slice_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src1, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &src2, const Tile<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void add_slice_async<bf16_t>(Scalar alpha, const Tile<bf16_t> &src, Scalar beta,
         const Tile<bf16_t> &src2, const Tile<bf16_t> &dst, Index axis);
 
@@ -127,6 +131,10 @@ void add_slice<fp32_t>(Scalar alpha, const Tile<fp32_t> &src1, Scalar beta,
 template
 void add_slice<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src1, Scalar beta,
         const Tile<fp32_fast_tf32_t> &src2, const Tile<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void add_slice<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src1, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &src2, const Tile<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void add_slice<fp64_t>(Scalar alpha, const Tile<fp64_t> &src, Scalar beta,

--- a/src/tile/add_slice_inplace.cc
+++ b/src/tile/add_slice_inplace.cc
@@ -103,6 +103,10 @@ void add_slice_inplace_async<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fas
         Scalar beta, const Tile<fp32_fast_tf32_t> &dst, Index axis);
 
 template
+void add_slice_inplace_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void add_slice_inplace_async<bf16_t>(Scalar alpha, const Tile<bf16_t> &src, Scalar beta,
         const Tile<bf16_t> &dst, Index axis);
 
@@ -114,6 +118,10 @@ void add_slice_inplace<fp32_t>(Scalar alpha, const Tile<fp32_t> &src, Scalar bet
 template
 void add_slice_inplace<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src, Scalar beta,
         const Tile<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void add_slice_inplace<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void add_slice_inplace<fp64_t>(Scalar alpha, const Tile<fp64_t> &src, Scalar beta,

--- a/src/tile/clear.cc
+++ b/src/tile/clear.cc
@@ -44,6 +44,9 @@ template
 void clear_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &tile);
 
 template
+void clear_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &tile);
+
+template
 void clear_async<fp64_t>(const Tile<fp64_t> &tile);
 
 // Explicit instantiation
@@ -55,6 +58,9 @@ void clear<bf16_t>(const Tile<bf16_t> &tile);
 
 template
 void clear<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &tile);
+
+template
+void clear<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &tile);
 
 template
 void clear<fp64_t>(const Tile<fp64_t> &tile);

--- a/src/tile/fill.cc
+++ b/src/tile/fill.cc
@@ -49,6 +49,9 @@ template
 void fill_async<fp32_fast_tf32_t>(Scalar val, const Tile<fp32_fast_tf32_t> &A);
 
 template
+void fill_async<fp32_fast_fp16_t>(Scalar val, const Tile<fp32_fast_fp16_t> &A);
+
+template
 void fill_async<fp64_t>(Scalar val, const Tile<fp64_t> &A);
 
 // Explicit instantiation
@@ -60,6 +63,9 @@ void fill<bf16_t>(Scalar val, const Tile<bf16_t> &A);
 
 template
 void fill<fp32_fast_tf32_t>(Scalar val, const Tile<fp32_fast_tf32_t> &A);
+
+template
+void fill<fp32_fast_fp16_t>(Scalar val, const Tile<fp32_fast_fp16_t> &A);
 
 template
 void fill<fp64_t>(Scalar val, const Tile<fp64_t> &A);

--- a/src/tile/gelutanh.cc
+++ b/src/tile/gelutanh.cc
@@ -43,7 +43,12 @@ template
 void gelutanh_async<fp32_t>(const Tile<fp32_t> &src, const Tile<fp32_t> &dst);
 
 template
-void gelutanh_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src, const Tile<fp32_fast_tf32_t> &dst);
+void gelutanh_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src,
+                                      const Tile<fp32_fast_tf32_t> &dst);
+
+template
+void gelutanh_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src,
+                                const Tile<fp32_fast_fp16_t> &dst);
 
 template
 void gelutanh_async<fp64_t>(const Tile<fp64_t> &src, const Tile<fp64_t> &dst);
@@ -56,7 +61,12 @@ template
 void gelutanh<fp32_t>(const Tile<fp32_t> &src, const Tile<fp32_t> &dst);
 
 template
-void gelutanh<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src, const Tile<fp32_fast_tf32_t> &dst);
+void gelutanh<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src,
+                                const Tile<fp32_fast_tf32_t> &dst);
+
+template
+void gelutanh<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src,
+                                const Tile<fp32_fast_fp16_t> &dst);
 
 template
 void gelutanh<fp64_t>(const Tile<fp64_t> &src, const Tile<fp64_t> &dst);

--- a/src/tile/gelutanh_backward.cc
+++ b/src/tile/gelutanh_backward.cc
@@ -58,6 +58,10 @@ void gelutanh_backward_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &x, 
         const Tile<fp32_fast_tf32_t> &dx);
 
 template
+void gelutanh_backward_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &x, const Tile<fp32_fast_fp16_t> &dy,
+        const Tile<fp32_fast_fp16_t> &dx);
+
+template
 void gelutanh_backward_async<fp64_t>(const Tile<fp64_t> &x, const Tile<fp64_t> &dy,
         const Tile<fp64_t> &dx);
 
@@ -73,6 +77,10 @@ void gelutanh_backward<fp32_t>(const Tile<fp32_t> &x, const Tile<fp32_t> &dy,
 template
 void gelutanh_backward<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &x, const Tile<fp32_fast_tf32_t> &dy,
         const Tile<fp32_fast_tf32_t> &dx);
+
+template
+void gelutanh_backward<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &x, const Tile<fp32_fast_fp16_t> &dy,
+        const Tile<fp32_fast_fp16_t> &dx);
 
 template
 void gelutanh_backward<fp64_t>(const Tile<fp64_t> &x, const Tile<fp64_t> &dy,

--- a/src/tile/gemm.cc
+++ b/src/tile/gemm.cc
@@ -338,6 +338,12 @@ void gemm_async<fp32_fast_tf32_t>(Scalar alpha, const TransOp &transA,
         const Tile<fp32_fast_tf32_t> &C, Index ndim, Index batch_ndim);
 
 template
+void gemm_async<fp32_fast_fp16_t>(Scalar alpha, const TransOp &transA,
+        const Tile<fp32_fast_fp16_t> &A,
+        const TransOp &transB, const Tile<fp32_fast_fp16_t> &B, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &C, Index ndim, Index batch_ndim);
+
+template
 void gemm_async<fp64_t>(Scalar alpha, const TransOp &transA,
         const Tile<fp64_t> &A,
         const TransOp &transB, const Tile<fp64_t> &B, Scalar beta,
@@ -361,6 +367,12 @@ void gemm<fp32_fast_tf32_t>(Scalar alpha, const TransOp &transA,
         const Tile<fp32_fast_tf32_t> &A,
         const TransOp &transB, const Tile<fp32_fast_tf32_t> &B, Scalar beta,
         const Tile<fp32_fast_tf32_t> &C, Index ndim, Index batch_ndim);
+
+template
+void gemm<fp32_fast_fp16_t>(Scalar alpha, const TransOp &transA,
+        const Tile<fp32_fast_fp16_t> &A,
+        const TransOp &transB, const Tile<fp32_fast_fp16_t> &B, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &C, Index ndim, Index batch_ndim);
 
 template
 void gemm<fp64_t>(Scalar alpha, const TransOp &transA,

--- a/src/tile/logsumexp.cc
+++ b/src/tile/logsumexp.cc
@@ -61,7 +61,12 @@ template
 void logsumexp_async<fp32_t>(const Tile<fp32_t> &src, const Tile<fp32_t> &dst);
 
 template
-void logsumexp_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src, const Tile<fp32_fast_tf32_t> &dst);
+void logsumexp_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src,
+                                       const Tile<fp32_fast_tf32_t> &dst);
+
+template
+void logsumexp_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src,
+                                 const Tile<fp32_fast_fp16_t> &dst);
 
 
 template
@@ -75,7 +80,12 @@ template
 void logsumexp<fp32_t>(const Tile<fp32_t> &src, const Tile<fp32_t> &dst);
 
 template
-void logsumexp<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src, const Tile<fp32_fast_tf32_t> &dst);
+void logsumexp<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src,
+                                 const Tile<fp32_fast_tf32_t> &dst);
+
+template
+void logsumexp<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src,
+                                 const Tile<fp32_fast_fp16_t> &dst);
 
 template
 void logsumexp<fp64_t>(const Tile<fp64_t> &src, const Tile<fp64_t> &dst);

--- a/src/tile/mask_scalar.cc
+++ b/src/tile/mask_scalar.cc
@@ -49,6 +49,10 @@ void mask_scalar_async<fp32_fast_tf32_t>(const Tile<bool_t> &mask, Scalar val,
         const Tile<fp32_fast_tf32_t> &A);
 
 template
+void mask_scalar_async<fp32_fast_fp16_t>(const Tile<bool_t> &mask, Scalar val,
+        const Tile<fp32_fast_fp16_t> &A);
+
+template
 void mask_scalar_async<fp64_t>(const Tile<bool_t> &mask, Scalar val,
         const Tile<fp64_t> &A);
 
@@ -64,6 +68,10 @@ void mask_scalar<fp32_t>(const Tile<bool_t> &mask, Scalar val,
 template
 void mask_scalar<fp32_fast_tf32_t>(const Tile<bool_t> &mask, Scalar val,
         const Tile<fp32_fast_tf32_t> &A);
+
+template
+void mask_scalar<fp32_fast_fp16_t>(const Tile<bool_t> &mask, Scalar val,
+        const Tile<fp32_fast_fp16_t> &A);
 
 template
 void mask_scalar<fp64_t>(const Tile<bool_t> &mask, Scalar val,

--- a/src/tile/maxsumexp.cc
+++ b/src/tile/maxsumexp.cc
@@ -88,6 +88,10 @@ void maxsumexp_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src, const 
         Index axis);
 
 template
+void maxsumexp_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src, const Tile<fp32_fast_fp16_t> &dst,
+        Index axis);
+
+template
 void maxsumexp_async<fp64_t>(const Tile<fp64_t> &src, const Tile<fp64_t> &dst,
         Index axis);
 
@@ -102,6 +106,10 @@ void maxsumexp<fp32_t>(const Tile<fp32_t> &src, const Tile<fp32_t> &dst,
 
 template
 void maxsumexp<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src, const Tile<fp32_fast_tf32_t> &dst,
+        Index axis);
+
+template
+void maxsumexp<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src, const Tile<fp32_fast_fp16_t> &dst,
         Index axis);
 
 template

--- a/src/tile/norm_slice.cc
+++ b/src/tile/norm_slice.cc
@@ -84,6 +84,10 @@ void norm_slice_async<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_
         Scalar beta, const Tile<fp32_fast_tf32_t> &dst, Index axis);
 
 template
+void norm_slice_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void norm_slice_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &src,
         Scalar beta, const Tile<fp64_t> &dst, Index axis);
 
@@ -99,6 +103,10 @@ void norm_slice<fp32_t>(Scalar alpha, const Tile<fp32_t> &src, Scalar beta,
 template
 void norm_slice<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src, Scalar beta,
         const Tile<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void norm_slice<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void norm_slice<fp64_t>(Scalar alpha, const Tile<fp64_t> &src, Scalar beta,

--- a/src/tile/prod_fiber3.cc
+++ b/src/tile/prod_fiber3.cc
@@ -95,6 +95,10 @@ void prod_fiber3_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src1, Sca
         const Tile<fp32_fast_tf32_t> &src2, const Tile<fp32_fast_tf32_t> &dst, Index axis);
 
 template
+void prod_fiber3_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src1, Scalar alpha,
+        const Tile<fp32_fast_fp16_t> &src2, const Tile<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void prod_fiber3_async<fp64_t>(const Tile<fp64_t> &src1, Scalar alpha,
         const Tile<fp64_t> &src2, const Tile<fp64_t> &dst, Index axis);
 
@@ -110,6 +114,10 @@ void prod_fiber3<fp32_t>(const Tile<fp32_t> &src1, Scalar alpha,
 template
 void prod_fiber3<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src1, Scalar alpha,
         const Tile<fp32_fast_tf32_t> &src2, const Tile<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void prod_fiber3<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src1, Scalar alpha,
+        const Tile<fp32_fast_fp16_t> &src2, const Tile<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void prod_fiber3<fp64_t>(const Tile<fp64_t> &src1, Scalar alpha,

--- a/src/tile/prod_inplace.cc
+++ b/src/tile/prod_inplace.cc
@@ -55,6 +55,10 @@ void prod_inplace_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src,
         const Tile<fp32_fast_tf32_t> &dst);
 
 template
+void prod_inplace_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src,
+        const Tile<fp32_fast_fp16_t> &dst);
+
+template
 void prod_inplace_async<fp64_t>(const Tile<fp64_t> &src,
         const Tile<fp64_t> &dst);
 
@@ -69,6 +73,10 @@ void prod_inplace<fp32_t>(const Tile<fp32_t> &src, const Tile<fp32_t> &dst);
 template
 void prod_inplace<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src,
         const Tile<fp32_fast_tf32_t> &dst);
+
+template
+void prod_inplace<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src,
+        const Tile<fp32_fast_fp16_t> &dst);
 
 template
 void prod_inplace<fp64_t>(const Tile<fp64_t> &src, const Tile<fp64_t> &dst);

--- a/src/tile/prod_slice.cc
+++ b/src/tile/prod_slice.cc
@@ -96,6 +96,10 @@ void prod_slice_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src, Scala
         const Tile<fp32_fast_tf32_t> &dst, Index axis);
 
 template
+void prod_slice_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src, Scalar alpha,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void prod_slice_async<fp64_t>(const Tile<fp64_t> &src, Scalar alpha,
         const Tile<fp64_t> &dst, Index axis);
 
@@ -111,6 +115,10 @@ void prod_slice<fp32_t>(const Tile<fp32_t> &src, Scalar alpha,
 template
 void prod_slice<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src, Scalar alpha,
         const Tile<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void prod_slice<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src, Scalar alpha,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void prod_slice<fp64_t>(const Tile<fp64_t> &src, Scalar alpha,

--- a/src/tile/scal.cc
+++ b/src/tile/scal.cc
@@ -57,6 +57,10 @@ void scal_async<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &sr
         const Tile<fp32_fast_tf32_t> &dst);
 
 template
+void scal_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src,
+        const Tile<fp32_fast_fp16_t> &dst);
+
+template
 void scal_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &src,
         const Tile<fp64_t> &dst);
 
@@ -72,6 +76,10 @@ void scal<fp32_t>(Scalar alpha, const Tile<fp32_t> &src,
 template
 void scal<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src,
         const Tile<fp32_fast_tf32_t> &dst);
+
+template
+void scal<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src,
+        const Tile<fp32_fast_fp16_t> &dst);
 
 template
 void scal<fp64_t>(Scalar alpha, const Tile<fp64_t> &src,

--- a/src/tile/scal_inplace.cc
+++ b/src/tile/scal_inplace.cc
@@ -42,6 +42,9 @@ template
 void scal_inplace_async<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &data);
 
 template
+void scal_inplace_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &data);
+
+template
 void scal_inplace_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &data);
 
 // Explicit instantiation
@@ -50,6 +53,9 @@ void scal_inplace<fp32_t>(Scalar alpha, const Tile<fp32_t> &data);
 
 template
 void scal_inplace<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &data);
+
+template
+void scal_inplace<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &data);
 
 template
 void scal_inplace<fp64_t>(Scalar alpha, const Tile<fp64_t> &data);

--- a/src/tile/softmax.cc
+++ b/src/tile/softmax.cc
@@ -99,6 +99,10 @@ void softmax_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &maxsumexp,
         Index axis);
 
 template
+void softmax_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &maxsumexp, const Tile<fp32_fast_fp16_t> &src,
+        Scalar alpha, const Tile<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void softmax_async<fp64_t>(const Tile<fp64_t> &maxsumexp,
         const Tile<fp64_t> &src, Scalar alpha, const Tile<fp64_t> &dst,
         Index axis);
@@ -115,6 +119,10 @@ void softmax<fp32_t>(const Tile<fp32_t> &maxsumexp, const Tile<fp32_t> &src,
 template
 void softmax<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &maxsumexp, const Tile<fp32_fast_tf32_t> &src,
         Scalar alpha, const Tile<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void softmax<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &maxsumexp, const Tile<fp32_fast_fp16_t> &src,
+        Scalar alpha, const Tile<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void softmax<fp64_t>(const Tile<fp64_t> &maxsumexp, const Tile<fp64_t> &src,

--- a/src/tile/softmax_inplace.cc
+++ b/src/tile/softmax_inplace.cc
@@ -89,6 +89,10 @@ void softmax_inplace_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &maxsu
         const Tile<fp32_fast_tf32_t> &dst, Index axis);
 
 template
+void softmax_inplace_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &maxsumexp, Scalar alpha,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void softmax_inplace_async<fp64_t>(const Tile<fp64_t> &maxsumexp, Scalar alpha,
         const Tile<fp64_t> &dst, Index axis);
 
@@ -104,6 +108,10 @@ void softmax_inplace<fp32_t>(const Tile<fp32_t> &maxsumexp, Scalar alpha,
 template
 void softmax_inplace<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &maxsumexp, Scalar alpha,
         const Tile<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void softmax_inplace<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &maxsumexp, Scalar alpha,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void softmax_inplace<fp64_t>(const Tile<fp64_t> &maxsumexp, Scalar alpha,

--- a/src/tile/subtract_indexed_outputs.cc
+++ b/src/tile/subtract_indexed_outputs.cc
@@ -56,6 +56,10 @@ void subtract_indexed_outputs_async<fp32_fast_tf32_t>(Scalar val,
         const Tile<int64_t> &labels, const Tile<fp32_fast_tf32_t> &dst);
 
 template
+void subtract_indexed_outputs_async<fp32_fast_fp16_t>(Scalar val, const Tile<int64_t> &labels,
+        const Tile<fp32_fast_fp16_t> &dst);
+
+template
 void subtract_indexed_outputs_async<fp64_t>(Scalar val,
         const Tile<int64_t> &labels, const Tile<fp64_t> &dst);
 
@@ -71,6 +75,10 @@ void subtract_indexed_outputs<fp32_t>(Scalar val, const Tile<int64_t> &labels,
 template
 void subtract_indexed_outputs<fp32_fast_tf32_t>(Scalar val, const Tile<int64_t> &labels,
         const Tile<fp32_fast_tf32_t> &dst);
+
+template
+void subtract_indexed_outputs<fp32_fast_fp16_t>(Scalar val, const Tile<int64_t> &labels,
+        const Tile<fp32_fast_fp16_t> &dst);
 
 template
 void subtract_indexed_outputs<fp64_t>(Scalar val, const Tile<int64_t> &labels,

--- a/src/tile/sum_fiber.cc
+++ b/src/tile/sum_fiber.cc
@@ -83,6 +83,11 @@ void sum_fiber_async<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t
         Scalar beta, const Tile<fp32_fast_tf32_t> &dst, Index axis, Index batch_ndim);
 
 template
+void sum_fiber_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src,
+                                 Scalar beta, const Tile<fp32_fast_fp16_t> &dst,
+                                 Index axis, Index batch_ndim);
+
+template
 void sum_fiber_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &src,
         Scalar beta, const Tile<fp64_t> &dst, Index axis, Index batch_ndim);
 
@@ -96,8 +101,14 @@ void sum_fiber<fp32_t>(Scalar alpha, const Tile<fp32_t> &src, Scalar beta,
         const Tile<fp32_t> &dst, Index axis, Index batch_ndim);
 
 template
-void sum_fiber<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src, Scalar beta,
-        const Tile<fp32_fast_tf32_t> &dst, Index axis, Index batch_ndim);
+void sum_fiber<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src,
+                                 Scalar beta, const Tile<fp32_fast_tf32_t> &dst,
+                                 Index axis, Index batch_ndim);
+
+template
+void sum_fiber<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src,
+                                 Scalar beta, const Tile<fp32_fast_fp16_t> &dst,
+                                 Index axis, Index batch_ndim);
 
 template
 void sum_fiber<fp64_t>(Scalar alpha, const Tile<fp64_t> &src, Scalar beta,

--- a/src/tile/sum_slice.cc
+++ b/src/tile/sum_slice.cc
@@ -88,6 +88,10 @@ void sum_slice_async<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t
         Scalar beta, const Tile<fp32_fast_tf32_t> &dst, Index axis);
 
 template
+void sum_slice_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis);
+
+template
 void sum_slice_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &src,
         Scalar beta, const Tile<fp64_t> &dst, Index axis);
 
@@ -99,6 +103,10 @@ void sum_slice<fp32_t>(Scalar alpha, const Tile<fp32_t> &src, Scalar beta,
 template
 void sum_slice<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src, Scalar beta,
         const Tile<fp32_fast_tf32_t> &dst, Index axis);
+
+template
+void sum_slice<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src, Scalar beta,
+        const Tile<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void sum_slice<fp64_t>(Scalar alpha, const Tile<fp64_t> &src, Scalar beta,

--- a/src/tile/sumprod_fiber.cc
+++ b/src/tile/sumprod_fiber.cc
@@ -82,6 +82,11 @@ void sumprod_fiber_async<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf
         Index axis);
 
 template
+void sumprod_fiber_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src1,
+        const Tile<fp32_fast_fp16_t> &src2, Scalar beta, const Tile<fp32_fast_fp16_t> &dst,
+        Index axis);
+
+template
 void sumprod_fiber_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &src1,
         const Tile<fp64_t> &src2, Scalar beta, const Tile<fp64_t> &dst,
         Index axis);
@@ -100,6 +105,11 @@ void sumprod_fiber<fp32_t>(Scalar alpha, const Tile<fp32_t> &src1,
 template
 void sumprod_fiber<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src1,
         const Tile<fp32_fast_tf32_t> &src2, Scalar beta, const Tile<fp32_fast_tf32_t> &dst,
+        Index axis);
+
+template
+void sumprod_fiber<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src1,
+        const Tile<fp32_fast_fp16_t> &src2, Scalar beta, const Tile<fp32_fast_fp16_t> &dst,
         Index axis);
 
 template

--- a/src/tile/sumprod_slice.cc
+++ b/src/tile/sumprod_slice.cc
@@ -91,6 +91,11 @@ void sumprod_slice_async<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf
         Index axis);
 
 template
+void sumprod_slice_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src1,
+        const Tile<fp32_fast_fp16_t> &src2, Scalar beta, const Tile<fp32_fast_fp16_t> &dst,
+        Index axis);
+
+template
 void sumprod_slice_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &src1,
         const Tile<fp64_t> &src2, Scalar beta, const Tile<fp64_t> &dst,
         Index axis);
@@ -109,6 +114,11 @@ void sumprod_slice<fp32_t>(Scalar alpha, const Tile<fp32_t> &src1,
 template
 void sumprod_slice<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src1,
         const Tile<fp32_fast_tf32_t> &src2, Scalar beta, const Tile<fp32_fast_tf32_t> &dst,
+        Index axis);
+
+template
+void sumprod_slice<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src1,
+        const Tile<fp32_fast_fp16_t> &src2, Scalar beta, const Tile<fp32_fast_fp16_t> &dst,
         Index axis);
 
 template

--- a/src/tile/total_sum_accum.cc
+++ b/src/tile/total_sum_accum.cc
@@ -77,6 +77,12 @@ void total_sum_accum_async<fp32_fast_tf32_t>(Scalar alpha,
         const Tile<fp32_t> &val);
 
 template
+void total_sum_accum_async<fp32_fast_fp16_t>(Scalar alpha,
+        const Tile<fp32_fast_fp16_t> &logsumexp,
+        const Tile<fp32_fast_fp16_t> &src, const Tile<int64_t> &class_labels,
+        const Tile<fp32_t> &val);
+
+template
 void total_sum_accum_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &logsumexp,
         const Tile<fp64_t> &src, const Tile<int64_t> &class_labels,
         const Tile<fp32_t> &val);
@@ -96,6 +102,12 @@ template
 void total_sum_accum<fp32_fast_tf32_t>(Scalar alpha,
         const Tile<fp32_fast_tf32_t> &logsumexp,
         const Tile<fp32_fast_tf32_t> &src, const Tile<int64_t> &class_labels,
+        const Tile<fp32_t> &val);
+
+template
+void total_sum_accum<fp32_fast_fp16_t>(Scalar alpha,
+        const Tile<fp32_fast_fp16_t> &logsumexp,
+        const Tile<fp32_fast_fp16_t> &src, const Tile<int64_t> &class_labels,
         const Tile<fp32_t> &val);
 
 template

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -67,7 +67,7 @@ set(TESTS_NOT_IMPLEMENTED
     "nntile_core/test_tensor_sumprod_slice.py"
     "nntile_core/test_tensor_subtract_indexed_column.py"
     "nntile_core/test_tensor_total_sum_accum.py"
-    "nntile_core/test_tensor_add_slice3.py"
+    "nntile_core/test_tensor_add_slice_inplace.py"
     "nntile_core/test_tensor_hypot.py"
     "nntile_core/test_tensor_prod_fiber3.py"
     "nntile_core/test_tensor_scal.py"

--- a/wrappers/python/examples/gpt2_training.py
+++ b/wrappers/python/examples/gpt2_training.py
@@ -67,7 +67,8 @@ parser.add_argument(
 )
 parser.add_argument("--torch-compile", action="store_true")
 parser.add_argument(
-    "--nntile-dtype", choices=["fp32", "fp64", "tf32", "bf16"], default="fp32"
+    "--nntile-dtype", choices=["fp32", "fp64", "tf32",
+                               "bf16", "fp32_fast_fp16"], default="fp32"
 )
 parser.add_argument("--check", action="store_true")
 parser.add_argument("--check-fp64", action="store_true")

--- a/wrappers/python/nntile/functions.py
+++ b/wrappers/python/nntile/functions.py
@@ -266,6 +266,8 @@ def gelutanh_backward_async(x: Tensor, dy: Tensor, dx: Tensor) -> None:
         core_tensor.gelutanh_backward_async_fp32(x, dy, dx)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.gelutanh_backward_async_fp32_fast_tf32(x, dy, dx)
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.gelutanh_backward_async_fp32_fast_fp16(x, dy, dx)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.gelutanh_backward_async_fp64(x, dy, dx)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -712,6 +714,8 @@ def prod_inplace_async(x: Tensor, y: Tensor) -> None:
         core_tensor.prod_inplace_async_fp32(x, y)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.prod_inplace_async_fp32_fast_tf32(x, y)
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.prod_inplace_async_fp32_fast_fp16(x, y)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.prod_inplace_async_fp64(x, y)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -1527,6 +1531,19 @@ def fused_adam_step(
         )
     elif type(p) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.adam_step_async_fp32_fast_tf32(
+            num_iter,
+            beta1,
+            beta2,
+            eps,
+            lr,
+            weight_decay,
+            grad,
+            first_moment,
+            second_moment,
+            p,
+        )
+    elif type(p) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.adam_step_async_fp32_fast_fp16(
             num_iter,
             beta1,
             beta2,

--- a/wrappers/python/nntile/functions.py
+++ b/wrappers/python/nntile/functions.py
@@ -224,6 +224,8 @@ def gelutanh_async(x: Tensor, y: Tensor) -> None:
         core_tensor.gelutanh_async_fp32(x, y)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.gelutanh_async_fp32_fast_tf32(x, y)
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.gelutanh_async_fp32_fast_fp16(x, y)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.gelutanh_async_fp64(x, y)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -605,6 +607,8 @@ def softmax_async(
         core_tensor.softmax_async_fp32(maxsumexp, x, alpha, y, axis)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.softmax_async_fp32_fast_tf32(maxsumexp, x, alpha, y, axis)
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.softmax_async_fp32_fast_fp16(maxsumexp, x, alpha, y, axis)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.softmax_async_fp64(maxsumexp, x, alpha, y, axis)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -725,6 +729,8 @@ def add_async(alpha: float, x: Tensor, beta: float, y: Tensor,
         core_tensor.add_async_fp32(alpha, x, beta, y, z)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.add_async_fp32_fast_tf32(alpha, x, beta, y, z)
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.add_async_fp32_fast_fp16(alpha, x, beta, y, z)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.add_async_fp64(alpha, x, beta, y, z)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -1283,6 +1289,8 @@ def logsumexp_async(maxsumexp: Tensor, logsumexp: Tensor) -> None:
         core_tensor.logsumexp_async_fp32(maxsumexp, logsumexp)
     elif type(maxsumexp) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.logsumexp_async_fp32_fast_tf32(maxsumexp, logsumexp)
+    elif type(maxsumexp) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.logsumexp_async_fp32_fast_fp16(maxsumexp, logsumexp)
     elif type(maxsumexp) is core_tensor.Tensor_fp64:
         core_tensor.logsumexp_async_fp64(maxsumexp, logsumexp)
     elif type(maxsumexp) is core_tensor.Tensor_bf16:
@@ -1306,6 +1314,10 @@ def total_sum_accum_async(
         core_tensor.total_sum_accum_async_fp32_fast_tf32(
             alpha, logsumexp, src, class_labels, val
         )
+    elif type(logsumexp) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.total_sum_accum_async_fp32_fast_fp16(
+            alpha, logsumexp, src, class_labels, val
+        )
     elif type(logsumexp) is core_tensor.Tensor_fp64:
         core_tensor.total_sum_accum_async_fp64(
             alpha, logsumexp, src, class_labels, val
@@ -1325,6 +1337,10 @@ def subtract_indexed_outputs_async(
         core_tensor.subtract_indexed_outputs_async_fp32(val, class_labels, dst)
     elif type(dst) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.subtract_indexed_outputs_async_fp32_fast_tf32(
+            val, class_labels, dst
+        )
+    elif type(dst) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.subtract_indexed_outputs_async_fp32_fast_fp16(
             val, class_labels, dst
         )
     elif type(dst) is core_tensor.Tensor_fp64:

--- a/wrappers/python/nntile/functions.py
+++ b/wrappers/python/nntile/functions.py
@@ -76,6 +76,10 @@ def gemm_async(
         core_tensor.gemm_async_fp32_fast_tf32(
             alpha, trans_A, A, trans_B, B, beta, C, ndim, batch_ndim, redux
         )
+    elif type(A) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.gemm_async_fp32_fast_fp16(
+            alpha, trans_A, A, trans_B, B, beta, C, ndim, batch_ndim, redux
+        )
     elif type(A) is core_tensor.Tensor_bf16:
         core_tensor.gemm_async_bf16(
             alpha, trans_A, A, trans_B, B, beta, C, ndim, batch_ndim, redux
@@ -623,6 +627,10 @@ def softmax_inplace_async(
         core_tensor.softmax_inplace_async_fp32_fast_tf32(
             maxsumexp, alpha, x, axis
         )
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.softmax_inplace_async_fp32_fast_fp16(
+            maxsumexp, alpha, x, axis
+        )
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.softmax_inplace_async_fp64(maxsumexp, alpha, x, axis)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -824,6 +832,8 @@ def maxsumexp_async(
         core_tensor.maxsumexp_async_fp32(x, maxsumexp, axis, redux)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.maxsumexp_async_fp32_fast_tf32(x, maxsumexp, axis, redux)
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.maxsumexp_async_fp32_fast_fp16(x, maxsumexp, axis, redux)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.maxsumexp_async_fp64(x, maxsumexp, axis, redux)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -1366,6 +1376,8 @@ def mask_scalar_async(mask: Tensor_bool, alpha: float, x: Tensor,
         ops.mask_scalar_async_fp32(mask, alpha, x, batch_ndim)
     elif isinstance(x, Tensor_fp32_fast_tf32):
         ops.mask_scalar_async_fp32_fast_tf32(mask, alpha, x, batch_ndim)
+    elif isinstance(x, Tensor_fp32_fast_fp16):
+        ops.mask_scalar_async_fp32_fast_fp16(mask, alpha, x, batch_ndim)
     elif isinstance(x, Tensor_fp64):
         ops.mask_scalar_async_fp64(mask, alpha, x, batch_ndim)
     else:
@@ -1610,6 +1622,8 @@ def transpose_async(alpha: float, src: Tensor, dst: Tensor, ndim: int) -> None:
         core_tensor.transpose_async_fp32(alpha, src, dst, ndim)
     elif type(src) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.transpose_async_fp32_fast_tf32(alpha, src, dst, ndim)
+    elif type(src) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.transpose_async_fp32_fast_fp16(alpha, src, dst, ndim)
     elif type(src) is core_tensor.Tensor_fp64:
         core_tensor.transpose_async_fp64(alpha, src, dst, ndim)
     elif type(src) is core_tensor.Tensor_bf16:

--- a/wrappers/python/nntile/functions.py
+++ b/wrappers/python/nntile/functions.py
@@ -336,6 +336,10 @@ def sum_fiber_async(
         core_tensor.sum_fiber_async_fp32_fast_tf32(
             alpha, x, beta, sum_fiber, axis, batch_ndim, redux
         )
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.sum_fiber_async_fp32_fast_fp16(
+            alpha, x, beta, sum_fiber, axis, batch_ndim, redux
+        )
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.sum_fiber_async_fp64(
             alpha, x, beta, sum_fiber, axis, batch_ndim, redux
@@ -749,6 +753,8 @@ def add_inplace_async(alpha: float, x: Tensor, beta: float, y: Tensor) -> None:
         core_tensor.add_inplace_async_fp32(alpha, x, beta, y)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.add_inplace_async_fp32_fast_tf32(alpha, x, beta, y)
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.add_inplace_async_fp32_fast_fp16(alpha, x, beta, y)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.add_inplace_async_fp64(alpha, x, beta, y)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -1234,6 +1240,10 @@ def sumprod_slice_async(
         core_tensor.sumprod_slice_async_fp32_fast_tf32(
             alpha, src1, src2, beta, dst, axis, redux
         )
+    elif type(src1) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.sumprod_slice_async_fp32_fast_fp16(
+            alpha, src1, src2, beta, dst, axis, redux
+        )
     elif type(src1) is core_tensor.Tensor_fp64:
         core_tensor.sumprod_slice_async_fp64(
             alpha, src1, src2, beta, dst, axis, redux
@@ -1268,6 +1278,10 @@ def sumprod_fiber_async(
         )
     elif type(src1) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.sumprod_fiber_async_fp32_fast_tf32(
+            alpha, src1, src2, beta, dst, axis, redux
+        )
+    elif type(src1) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.sumprod_fiber_async_fp32_fast_fp16(
             alpha, src1, src2, beta, dst, axis, redux
         )
     elif type(src1) is core_tensor.Tensor_fp64:

--- a/wrappers/python/nntile/functions.py
+++ b/wrappers/python/nntile/functions.py
@@ -940,34 +940,6 @@ def add_slice_async(
         raise TypeError
 
 
-def add_slice3_async(
-    alpha: float, add_slice: Tensor, beta, x: Tensor, y: Tensor, axis: int
-) -> None:
-    """
-    Wrapper for multiprecision add_slice3
-    """
-    if type(add_slice) is not type(x):
-        raise TypeError
-    if type(x) is not type(y):
-        raise TypeError
-    if type(x) is core_tensor.Tensor_fp32:
-        core_tensor.add_slice3_async_fp32(alpha, add_slice, beta, x, y, axis)
-    elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
-        core_tensor.add_slice3_async_fp32_fast_tf32(
-            alpha, add_slice, beta, x, y, axis
-        )
-    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
-        core_tensor.add_slice3_async_fp32_fast_fp16(
-            alpha, add_slice, beta, x, y, axis
-        )
-    elif type(x) is core_tensor.Tensor_fp64:
-        core_tensor.add_slice3_async_fp64(alpha, add_slice, beta, x, y, axis)
-    elif type(x) is core_tensor.Tensor_bf16:
-        core_tensor.add_slice3_async_bf16(alpha, add_slice, beta, x, y, axis)
-    else:
-        raise TypeError
-
-
 def add_fiber_inplace_async(
     alpha: float, add_fiber_inplace: Tensor, beta, x: Tensor,
     axis: int, batch_ndim: int

--- a/wrappers/python/nntile/functions.py
+++ b/wrappers/python/nntile/functions.py
@@ -276,6 +276,8 @@ def fill_async(val: float, x: Tensor) -> None:
         core_tensor.fill_async_fp32(val, x)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.fill_async_fp32_fast_tf32(val, x)
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.fill_async_fp32_fast_fp16(val, x)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.fill_async_fp64(val, x)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -294,6 +296,9 @@ def sum_slice_async(alpha: float, x: Tensor, beta: float, sum_slice: Tensor,
         ops.sum_slice_async_fp32(alpha, ts[0], beta, ts[1], axis, redux)
     elif is_tensor_of(ts, Tensor_fp32_fast_tf32):
         ops.sum_slice_async_fp32_fast_tf32(alpha, ts[0], beta, ts[1], axis,
+                                           redux)
+    elif is_tensor_of(ts, Tensor_fp32_fast_fp16):
+        ops.sum_slice_async_fp32_fast_fp16(alpha, ts[0], beta, ts[1], axis,
                                            redux)
     elif is_tensor_of(ts, Tensor_fp64):
         ops.sum_slice_async_fp64(alpha, ts[0], beta, ts[1], axis, redux)
@@ -390,6 +395,10 @@ def norm_slice_async(
         )
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.norm_slice_async_fp32_fast_tf32(
+            alpha, x, beta, norm_slice, axis, redux
+        )
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.norm_slice_async_fp32_fast_fp16(
             alpha, x, beta, norm_slice, axis, redux
         )
     elif type(x) is core_tensor.Tensor_fp64:
@@ -893,6 +902,10 @@ def add_slice3_async(
         core_tensor.add_slice3_async_fp32_fast_tf32(
             alpha, add_slice, beta, x, y, axis
         )
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.add_slice3_async_fp32_fast_fp16(
+            alpha, add_slice, beta, x, y, axis
+        )
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.add_slice3_async_fp64(alpha, add_slice, beta, x, y, axis)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -919,6 +932,9 @@ def add_fiber_inplace_async(
         ops.add_fiber_inplace_async_fp32_fast_tf32(
             alpha, ts[0], beta, ts[1], axis, batch_ndim
         )
+    elif is_tensor_of(ts, Tensor_fp32_fast_fp16):
+        ops.add_fiber_inplace_async_fp32_fast_fp16(
+            alpha, ts[0], beta, ts[1], axis, batch_ndim)
     elif is_tensor_of(ts, Tensor_fp64):
         ops.add_fiber_inplace_async_fp64(
             alpha, ts[0], beta, ts[1], axis, batch_ndim
@@ -941,6 +957,8 @@ def prod_slice_async(
         core_tensor.prod_slice_async_fp32(prod_slice, alpha, x, axis)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.prod_slice_async_fp32_fast_tf32(prod_slice, alpha, x, axis)
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.prod_slice_async_fp32_fast_fp16(prod_slice, alpha, x, axis)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.prod_slice_async_fp64(prod_slice, alpha, x, axis)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -979,6 +997,10 @@ def prod_fiber3_async(
         core_tensor.prod_fiber3_async_fp32(prod_fiber, alpha, x, y, axis)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.prod_fiber3_async_fp32_fast_tf32(
+            prod_fiber, alpha, x, y, axis
+        )
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.prod_fiber3_async_fp32_fast_fp16(
             prod_fiber, alpha, x, y, axis
         )
     elif type(x) is core_tensor.Tensor_fp64:
@@ -1074,6 +1096,8 @@ def clear_async(x: Tensor) -> None:
         core_tensor.clear_async_fp32(x)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.clear_async_fp32_fast_tf32(x)
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.clear_async_fp32_fast_fp16(x)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.clear_async_fp64(x)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -1418,6 +1442,8 @@ def hypot_scalar_inverse_async(eps: float, alpha: float, x: Tensor) -> None:
         core_tensor.hypot_scalar_inverse_async_fp32(eps, alpha, x)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.hypot_scalar_inverse_async_fp32_fast_tf32(eps, alpha, x)
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.hypot_scalar_inverse_async_fp32_fast_fp16(eps, alpha, x)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.hypot_scalar_inverse_async_fp64(eps, alpha, x)
     elif type(x) is core_tensor.Tensor_bf16:

--- a/wrappers/python/nntile/functions.py
+++ b/wrappers/python/nntile/functions.py
@@ -1633,6 +1633,19 @@ def fused_adamw_step(
             second_moment,
             p,
         )
+    elif type(p) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.adamw_step_async_fp32_fast_fp16(
+            num_iter,
+            beta1,
+            beta2,
+            eps,
+            lr,
+            weight_decay,
+            grad,
+            first_moment,
+            second_moment,
+            p,
+        )
     elif type(p) is core_tensor.Tensor_fp64:
         core_tensor.adamw_step_async_fp64(
             num_iter,

--- a/wrappers/python/nntile/functions.py
+++ b/wrappers/python/nntile/functions.py
@@ -878,6 +878,10 @@ def add_slice_inplace_async(
         core_tensor.add_slice_inplace_async_fp32_fast_tf32(
             alpha, add_slice, beta, x, axis
         )
+    elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.add_slice_inplace_async_fp32_fast_fp16(
+            alpha, add_slice, beta, x, axis
+        )
     elif type(x) is core_tensor.Tensor_bf16:
         core_tensor.add_slice_inplace_async_bf16(
             alpha, add_slice, beta, x, axis
@@ -895,19 +899,19 @@ def add_slice_async(
     if type(add_slice) is not type(x):
         raise TypeError
     if type(x) is core_tensor.Tensor_fp32:
-        core_tensor.add_slice_async_fp32(alpha, add_slice, beta, x, axis)
+        core_tensor.add_slice_async_fp32(alpha, add_slice, beta, x, y, axis)
     elif type(x) is core_tensor.Tensor_fp64:
-        core_tensor.add_slice_async_fp64(alpha, add_slice, beta, x, axis)
+        core_tensor.add_slice_async_fp64(alpha, add_slice, beta, x, y, axis)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.add_slice_async_fp32_fast_tf32(
-            alpha, add_slice, beta, x, axis
+            alpha, add_slice, beta, x, y, axis
         )
     elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
         core_tensor.add_slice_async_fp32_fast_fp16(
-            alpha, add_slice, beta, x, axis
+            alpha, add_slice, beta, x, y, axis
         )
     elif type(x) is core_tensor.Tensor_bf16:
-        core_tensor.add_slice_async_bf16(alpha, add_slice, beta, x, axis)
+        core_tensor.add_slice_async_bf16(alpha, add_slice, beta, x, y, axis)
     else:
         raise TypeError
 

--- a/wrappers/python/nntile/functions.py
+++ b/wrappers/python/nntile/functions.py
@@ -481,6 +481,10 @@ def flash_softmax_gemm_async(
         core_tensor.flash_softmax_gemm_async_fp32_fast_tf32(
             Q, K, V, mask, maxsumexp, dst, tmp, redux
         )
+    elif type(Q) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.flash_softmax_gemm_async_fp32_fast_fp16(
+            Q, K, V, mask, maxsumexp, dst, tmp, redux
+        )
     elif type(Q) is core_tensor.Tensor_fp64:
         core_tensor.flash_softmax_gemm_async_fp64(
             Q, K, V, mask, maxsumexp, dst, tmp, redux
@@ -549,6 +553,22 @@ def flash_softmax_gemm_backward_async(
         )
     elif type(Q) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.flash_softmax_gemm_backward_async_fp32_fast_tf32(
+            Q,
+            dQ,
+            K,
+            dK,
+            V,
+            dV,
+            mask,
+            maxsumexp,
+            dst_grad,
+            tmp,
+            tmp_grad,
+            tmp_sumprod_slice,
+            redux,
+        )
+    elif type(Q) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.flash_softmax_gemm_backward_async_fp32_fast_fp16(
             Q,
             dQ,
             K,
@@ -822,6 +842,10 @@ def flash_maxsumexp_async(
         )
     elif type(Q) is core_tensor.Tensor_fp32_fast_tf32:
         core_tensor.flash_maxsumexp_async_fp32_fast_tf32(
+            Q, K, mask, maxsumexp, tmp, redux
+        )
+    elif type(Q) is core_tensor.Tensor_fp32_fast_fp16:
+        core_tensor.flash_maxsumexp_async_fp32_fast_fp16(
             Q, K, mask, maxsumexp, tmp, redux
         )
     elif type(Q) is core_tensor.Tensor_fp64:

--- a/wrappers/python/nntile/model/gpt2.py
+++ b/wrappers/python/nntile/model/gpt2.py
@@ -194,91 +194,28 @@ class GPT2Model(BaseModel, LLMGenerationMixin):
         )
         self.mask.from_array(mask_np)
 
-        if self.dtype == "fp32":
-            wte_layer, next_tag = Embedding.generate_simple(
-                input_ids.value,
-                Tensor_fp32,
-                0,
-                vocab_size,
-                self.embed_dim,
-                embed_dim_tile,
-                vocab_embed_dim_tile,
-                next_tag,
-            )
-        elif self.dtype == "tf32":
-            wte_layer, next_tag = Embedding.generate_simple(
-                input_ids.value,
-                Tensor_fp32_fast_tf32,
-                0,
-                vocab_size,
-                self.embed_dim,
-                embed_dim_tile,
-                vocab_embed_dim_tile,
-                next_tag,
-            )
-        elif self.dtype == "bf16":
-            wte_layer, next_tag = Embedding.generate_simple(
-                input_ids.value,
-                Tensor_bf16,
-                0,
-                vocab_size,
-                self.embed_dim,
-                embed_dim_tile,
-                vocab_embed_dim_tile,
-                next_tag,
-            )
-        elif self.dtype == "fp32_fast_fp16":
-            wte_layer, next_tag = Embedding.generate_simple(
-                input_ids.value,
-                Tensor_fp32_fast_fp16,
-                0,
-                vocab_size,
-                self.embed_dim,
-                embed_dim_tile,
-                vocab_embed_dim_tile,
-                next_tag,
-            )
+        dtype2tensor_type = {"fp32": Tensor_fp32,
+                             "tf32": Tensor_fp32_fast_tf32,
+                             "bf16": Tensor_bf16,
+                             "fp32_fast_fp16": Tensor_fp32_fast_fp16
+                            }
 
+        wte_layer, next_tag = Embedding.generate_simple(
+                                input_ids.value,
+                                dtype2tensor_type[self.dtype],
+                                0,
+                                vocab_size,
+                                self.embed_dim,
+                                embed_dim_tile,
+                                vocab_embed_dim_tile,
+                                next_tag,
+                            )
         layers.append(wte_layer)
         activations.extend(wte_layer.activations_output)
 
-        if self.dtype == "fp32":
-            wpe_layer, next_tag = Embedding.generate_simple(
+        wpe_layer, next_tag = Embedding.generate_simple(
                 positional_ids.value,
-                Tensor_fp32,
-                0,
-                max_position_embeddings,
-                self.embed_dim,
-                embed_dim_tile,
-                vocab_embed_dim_tile,
-                next_tag,
-            )
-        elif self.dtype == "tf32":
-            wpe_layer, next_tag = Embedding.generate_simple(
-                positional_ids.value,
-                Tensor_fp32_fast_tf32,
-                0,
-                max_position_embeddings,
-                self.embed_dim,
-                embed_dim_tile,
-                vocab_embed_dim_tile,
-                next_tag,
-            )
-        elif self.dtype == "fp32_fast_fp16":
-            wpe_layer, next_tag = Embedding.generate_simple(
-                positional_ids.value,
-                Tensor_fp32_fast_fp16,
-                0,
-                max_position_embeddings,
-                self.embed_dim,
-                embed_dim_tile,
-                vocab_embed_dim_tile,
-                next_tag,
-            )
-        elif self.dtype == "bf16":
-            wpe_layer, next_tag = Embedding.generate_simple(
-                positional_ids.value,
-                Tensor_bf16,
+                dtype2tensor_type[self.dtype],
                 0,
                 max_position_embeddings,
                 self.embed_dim,

--- a/wrappers/python/nntile/nntile_core.cc
+++ b/wrappers/python/nntile/nntile_core.cc
@@ -577,10 +577,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("sum_fiber_async_bf16", &sum_fiber_async<bf16_t>);
     m.def("sum_fiber_async_fp32", &sum_fiber_async<fp32_t>);
     m.def("sum_fiber_async_fp32_fast_tf32", &sum_fiber_async<fp32_fast_tf32_t>);
+    m.def("sum_fiber_async_fp32_fast_fp16", &sum_fiber_async<fp32_fast_fp16_t>);
     m.def("sum_fiber_fp64", &sum_fiber<fp64_t>);
     m.def("sum_fiber_fp32", &sum_fiber<fp32_t>);
     m.def("sum_fiber_bf16", &sum_fiber<bf16_t>);
     m.def("sum_fiber_fp32_fast_tf32", &sum_fiber<fp32_fast_tf32_t>);
+    m.def("sum_fiber_fp32_fast_fp16", &sum_fiber<fp32_fast_fp16_t>);
 
     m.def("norm_fiber_async_fp64", &norm_fiber_async<fp64_t>);
     m.def("norm_fiber_async_bf16", &norm_fiber_async<bf16_t>);
@@ -766,11 +768,13 @@ void def_mod_tensor(py::module_ &m)
     m.def("add_inplace_async_fp64", &add_inplace_async<fp64_t>);
     m.def("add_inplace_async_fp32", &add_inplace_async<fp32_t>);
     m.def("add_inplace_async_fp32_fast_tf32", &add_inplace_async<fp32_fast_tf32_t>);
+    m.def("add_inplace_async_fp32_fast_fp16", &add_inplace_async<fp32_fast_fp16_t>);
     m.def("add_inplace_async_bf16", &add_inplace_async<bf16_t>);
     m.def("add_inplace_fp64", &add_inplace<fp64_t>);
     m.def("add_inplace_bf16", &add_inplace<bf16_t>);
     m.def("add_inplace_fp32", &add_inplace<fp32_t>);
     m.def("add_inplace_fp32_fast_tf32", &add_inplace<fp32_fast_tf32_t>);
+    m.def("add_inplace_fp32_fast_fp16", &add_inplace<fp32_fast_fp16_t>);
 
     m.def("add_scalar_async_fp64", &add_scalar_async<fp64_t>);
     m.def("add_scalar_async_fp32", &add_scalar_async<fp32_t>);
@@ -990,19 +994,23 @@ void def_mod_tensor(py::module_ &m)
     m.def("sumprod_slice_async_bf16", &sumprod_slice_async<bf16_t>);
     m.def("sumprod_slice_async_fp32", &sumprod_slice_async<fp32_t>);
     m.def("sumprod_slice_async_fp32_fast_tf32", &sumprod_slice_async<fp32_fast_tf32_t>);
+    m.def("sumprod_slice_async_fp32_fast_fp16", &sumprod_slice_async<fp32_fast_fp16_t>);
     m.def("sumprod_slice_fp64", &sumprod_slice<fp64_t>);
     m.def("sumprod_slice_fp32", &sumprod_slice<fp32_t>);
     m.def("sumprod_slice_bf16", &sumprod_slice<bf16_t>);
     m.def("sumprod_slice_fp32_fast_tf32", &sumprod_slice<fp32_fast_tf32_t>);
+    m.def("sumprod_slice_fp32_fast_fp16", &sumprod_slice<fp32_fast_fp16_t>);
 
     m.def("sumprod_fiber_async_fp64", &sumprod_fiber_async<fp64_t>);
     m.def("sumprod_fiber_async_bf16", &sumprod_fiber_async<bf16_t>);
     m.def("sumprod_fiber_async_fp32", &sumprod_fiber_async<fp32_t>);
     m.def("sumprod_fiber_async_fp32_fast_tf32", &sumprod_fiber_async<fp32_fast_tf32_t>);
+    m.def("sumprod_fiber_async_fp32_fast_fp16", &sumprod_fiber_async<fp32_fast_fp16_t>);
     m.def("sumprod_fiber_fp64", &sumprod_fiber<fp64_t>);
     m.def("sumprod_fiber_fp32", &sumprod_fiber<fp32_t>);
     m.def("sumprod_fiber_bf16", &sumprod_fiber<bf16_t>);
     m.def("sumprod_fiber_fp32_fast_tf32", &sumprod_fiber<fp32_fast_tf32_t>);
+    m.def("sumprod_fiber_fp32_fast_fp16", &sumprod_fiber<fp32_fast_fp16_t>);
 
     // gelu and dgelu
     m.def("gelu_async_fp64", &gelu_async<fp64_t>);

--- a/wrappers/python/nntile/nntile_core.cc
+++ b/wrappers/python/nntile/nntile_core.cc
@@ -634,10 +634,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("softmax_async_bf16", &softmax_async<bf16_t>);
     m.def("softmax_async_fp32", &softmax_async<fp32_t>);
     m.def("softmax_async_fp32_fast_tf32", &softmax_async<fp32_fast_tf32_t>);
+    m.def("softmax_async_fp32_fast_fp16", &softmax_async<fp32_fast_fp16_t>);
     m.def("softmax_fp64", &softmax<fp64_t>);
     m.def("softmax_fp32", &softmax<fp32_t>);
     m.def("softmax_bf16", &softmax<bf16_t>);
     m.def("softmax_fp32_fast_tf32", &softmax<fp32_fast_tf32_t>);
+    m.def("softmax_fp32_fast_fp16", &softmax<fp32_fast_fp16_t>);
 
     m.def("softmax_inplace_async_fp64", &softmax_inplace_async<fp64_t>);
     m.def("softmax_inplace_async_bf16", &softmax_inplace_async<bf16_t>);
@@ -753,11 +755,13 @@ void def_mod_tensor(py::module_ &m)
     m.def("add_async_fp64", &add_async<fp64_t>);
     m.def("add_async_fp32", &add_async<fp32_t>);
     m.def("add_async_fp32_fast_tf32", &add_async<fp32_fast_tf32_t>);
+    m.def("add_async_fp32_fast_fp16", &add_async<fp32_fast_fp16_t>);
     m.def("add_async_bf16", &add_async<bf16_t>);
     m.def("add_fp64", &add<fp64_t>);
     m.def("add_bf16", &add<bf16_t>);
     m.def("add_fp32", &add<fp32_t>);
     m.def("add_fp32_fast_tf32", &add<fp32_fast_tf32_t>);
+    m.def("add_fp32_fast_fp16", &add<fp32_fast_fp16_t>);
 
     m.def("add_inplace_async_fp64", &add_inplace_async<fp64_t>);
     m.def("add_inplace_async_fp32", &add_inplace_async<fp32_t>);
@@ -909,19 +913,23 @@ void def_mod_tensor(py::module_ &m)
     m.def("logsumexp_async_bf16", &logsumexp_async<bf16_t>);
     m.def("logsumexp_async_fp32", &logsumexp_async<fp32_t>);
     m.def("logsumexp_async_fp32_fast_tf32", &logsumexp_async<fp32_fast_tf32_t>);
+    m.def("logsumexp_async_fp32_fast_fp16", &logsumexp_async<fp32_fast_fp16_t>);
     m.def("logsumexp_fp64", &logsumexp<fp64_t>);
     m.def("logsumexp_bf16", &logsumexp<bf16_t>);
     m.def("logsumexp_fp32", &logsumexp<fp32_t>);
     m.def("logsumexp_fp32_fast_tf32", &logsumexp<fp32_fast_tf32_t>);
+    m.def("logsumexp_fp32_fast_fp16", &logsumexp<fp32_fast_fp16_t>);
 
     m.def("total_sum_accum_async_fp64", &total_sum_accum_async<fp64_t>);
     m.def("total_sum_accum_async_bf16", &total_sum_accum_async<bf16_t>);
     m.def("total_sum_accum_async_fp32", &total_sum_accum_async<fp32_t>);
     m.def("total_sum_accum_async_fp32_fast_tf32", &total_sum_accum_async<fp32_fast_tf32_t>);
+    m.def("total_sum_accum_async_fp32_fast_fp16", &total_sum_accum_async<fp32_fast_fp16_t>);
     m.def("total_sum_accum_fp64", &total_sum_accum<fp64_t>);
     m.def("total_sum_accum_fp32", &total_sum_accum<fp32_t>);
     m.def("total_sum_accum_bf16", &total_sum_accum<bf16_t>);
     m.def("total_sum_accum_fp32_fast_tf32", &total_sum_accum<fp32_fast_tf32_t>);
+    m.def("total_sum_accum_fp32_fast_fp16", &total_sum_accum<fp32_fast_fp16_t>);
 
     m.def("subtract_indexed_outputs_async_fp64",
             &subtract_indexed_outputs_async<fp64_t>);
@@ -931,10 +939,13 @@ void def_mod_tensor(py::module_ &m)
             &subtract_indexed_outputs_async<fp32_t>);
     m.def("subtract_indexed_outputs_async_fp32_fast_tf32",
             &subtract_indexed_outputs_async<fp32_fast_tf32_t>);
+    m.def("subtract_indexed_outputs_async_fp32_fast_fp16",
+            &subtract_indexed_outputs_async<fp32_fast_fp16_t>);
     m.def("subtract_indexed_outputs_fp64", &subtract_indexed_outputs<fp64_t>);
     m.def("subtract_indexed_outputs_bf16", &subtract_indexed_outputs<bf16_t>);
     m.def("subtract_indexed_outputs_fp32", &subtract_indexed_outputs<fp32_t>);
     m.def("subtract_indexed_outputs_fp32_fast_tf32", &subtract_indexed_outputs<fp32_fast_tf32_t>);
+    m.def("subtract_indexed_outputs_fp32_fast_fp16", &subtract_indexed_outputs<fp32_fast_fp16_t>);
 
     m.def("scal_async_fp64", &scal_async<fp64_t>);
     m.def("scal_async_bf16", &scal_async<bf16_t>);
@@ -1007,10 +1018,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("gelutanh_async_bf16", &gelutanh_async<bf16_t>);
     m.def("gelutanh_async_fp32", &gelutanh_async<fp32_t>);
     m.def("gelutanh_async_fp32_fast_tf32", &gelutanh_async<fp32_fast_tf32_t>);
+    m.def("gelutanh_async_fp32_fast_fp16", &gelutanh_async<fp32_fast_fp16_t>);
     m.def("gelutanh_fp64", &gelutanh<fp64_t>);
     m.def("gelutanh_fp32", &gelutanh<fp32_t>);
     m.def("gelutanh_bf16", &gelutanh<bf16_t>);
     m.def("gelutanh_fp32_fast_tf32", &gelutanh<fp32_fast_tf32_t>);
+    m.def("gelutanh_fp32_fast_fp16", &gelutanh<fp32_fast_fp16_t>);
 
     m.def("gelutanh_inplace_async_fp64", &gelutanh_inplace_async<fp64_t>);
     m.def("gelutanh_inplace_async_fp32", &gelutanh_inplace_async<fp32_t>);

--- a/wrappers/python/nntile/nntile_core.cc
+++ b/wrappers/python/nntile/nntile_core.cc
@@ -688,10 +688,13 @@ void def_mod_tensor(py::module_ &m)
     m.def("prod_inplace_async_fp32", &prod_inplace_async<fp32_t>);
     m.def("prod_inplace_async_fp32_fast_tf32",
             &prod_inplace_async<fp32_fast_tf32_t>);
+    m.def("prod_inplace_async_fp32_fast_fp16",
+            &prod_inplace_async<fp32_fast_fp16_t>);
     m.def("prod_inplace_fp64", &prod_inplace<fp64_t>);
     m.def("prod_inplace_fp32", &prod_inplace<fp32_t>);
     m.def("prod_inplace_bf16", &prod_inplace<bf16_t>);
     m.def("prod_inplace_fp32_fast_tf32", &prod_inplace<fp32_fast_tf32_t>);
+    m.def("prod_inplace_fp32_fast_fp16", &prod_inplace<fp32_fast_fp16_t>);
 
     m.def("nrm2_async_fp64", &nrm2_async<fp64_t>);
     m.def("nrm2_async_fp32", &nrm2_async<fp32_t>);
@@ -966,10 +969,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("adam_step_async_bf16", &adam_step_async<bf16_t>);
     m.def("adam_step_async_fp32", &adam_step_async<fp32_t>);
     m.def("adam_step_async_fp32_fast_tf32", &adam_step_async<fp32_fast_tf32_t>);
+    m.def("adam_step_async_fp32_fast_fp16", &adam_step_async<fp32_fast_fp16_t>);
     m.def("adam_step_fp64", &adam_step<fp64_t>);
     m.def("adam_step_bf16", &adam_step<bf16_t>);
     m.def("adam_step_fp32", &adam_step<fp32_t>);
     m.def("adam_step_fp32_fast_tf32", &adam_step<fp32_fast_tf32_t>);
+    m.def("adam_step_fp32_fast_fp16", &adam_step<fp32_fast_fp16_t>);
 
     m.def("adamw_step_async_fp64", &adamw_step_async<fp64_t>);
     m.def("adamw_step_async_bf16", &adamw_step_async<bf16_t>);
@@ -1042,10 +1047,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("gelutanh_backward_async_bf16", &gelutanh_backward_async<bf16_t>);
     m.def("gelutanh_backward_async_fp32", &gelutanh_backward_async<fp32_t>);
     m.def("gelutanh_backward_async_fp32_fast_tf32", &gelutanh_backward_async<fp32_fast_tf32_t>);
+    m.def("gelutanh_backward_async_fp32_fast_fp16", &gelutanh_backward_async<fp32_fast_fp16_t>);
     m.def("gelutanh_backward_fp64", &gelutanh_backward<fp64_t>);
     m.def("gelutanh_backward_fp32", &gelutanh_backward<fp32_t>);
     m.def("gelutanh_backward_bf16", &gelutanh_backward<bf16_t>);
     m.def("gelutanh_backward_fp32_fast_tf32", &gelutanh_backward<fp32_fast_tf32_t>);
+    m.def("gelutanh_backward_fp32_fast_fp16", &gelutanh_backward<fp32_fast_fp16_t>);
 
     m.def("dgelu_async_fp64", &dgelu_async<fp64_t>);
     m.def("dgelu_async_fp32", &dgelu_async<fp32_t>);

--- a/wrappers/python/nntile/nntile_core.cc
+++ b/wrappers/python/nntile/nntile_core.cc
@@ -618,19 +618,23 @@ void def_mod_tensor(py::module_ &m)
     m.def("flash_softmax_gemm_async_bf16", &flash_softmax_gemm_async<bf16_t>);
     m.def("flash_softmax_gemm_async_fp32", &flash_softmax_gemm_async<fp32_t>);
     m.def("flash_softmax_gemm_async_fp32_fast_tf32", &flash_softmax_gemm_async<fp32_fast_tf32_t>);
+    m.def("flash_softmax_gemm_async_fp32_fast_fp16", &flash_softmax_gemm_async<fp32_fast_fp16_t>);
     m.def("flash_softmax_gemm_fp64", &flash_softmax_gemm<fp64_t>);
     m.def("flash_softmax_gemm_bf16", &flash_softmax_gemm<bf16_t>);
     m.def("flash_softmax_gemm_fp32", &flash_softmax_gemm<fp32_t>);
     m.def("flash_softmax_gemm_fp32_fast_tf32", &flash_softmax_gemm<fp32_fast_tf32_t>);
+    m.def("flash_softmax_gemm_fp32_fast_fp16", &flash_softmax_gemm<fp32_fast_fp16_t>);
 
     m.def("flash_softmax_gemm_backward_async_fp64", &flash_softmax_gemm_backward_async<fp64_t>);
     m.def("flash_softmax_gemm_backward_async_bf16", &flash_softmax_gemm_backward_async<bf16_t>);
     m.def("flash_softmax_gemm_backward_async_fp32", &flash_softmax_gemm_backward_async<fp32_t>);
     m.def("flash_softmax_gemm_backward_async_fp32_fast_tf32", &flash_softmax_gemm_backward_async<fp32_fast_tf32_t>);
+    m.def("flash_softmax_gemm_backward_async_fp32_fast_fp16", &flash_softmax_gemm_backward_async<fp32_fast_fp16_t>);
     m.def("flash_softmax_gemm_backward_fp64", &flash_softmax_gemm_backward<fp64_t>);
     m.def("flash_softmax_gemm_backward_fp32", &flash_softmax_gemm_backward<fp32_t>);
     m.def("flash_softmax_gemm_backward_bf16", &flash_softmax_gemm_backward<bf16_t>);
     m.def("flash_softmax_gemm_backward_fp32_fast_tf32", &flash_softmax_gemm_backward<fp32_fast_tf32_t>);
+    m.def("flash_softmax_gemm_backward_fp32_fast_fp16", &flash_softmax_gemm_backward<fp32_fast_fp16_t>);
 
     m.def("softmax_async_fp64", &softmax_async<fp64_t>);
     m.def("softmax_async_bf16", &softmax_async<bf16_t>);
@@ -710,10 +714,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("flash_maxsumexp_async_bf16", &flash_maxsumexp_async<bf16_t>);
     m.def("flash_maxsumexp_async_fp32", &flash_maxsumexp_async<fp32_t>);
     m.def("flash_maxsumexp_async_fp32_fast_tf32", &flash_maxsumexp_async<fp32_fast_tf32_t>);
+    m.def("flash_maxsumexp_async_fp32_fast_fp16", &flash_maxsumexp_async<fp32_fast_fp16_t>);
     m.def("flash_maxsumexp_fp64", &flash_maxsumexp<fp64_t>);
     m.def("flash_maxsumexp_fp32", &flash_maxsumexp<fp32_t>);
     m.def("flash_maxsumexp_bf16", &flash_maxsumexp<bf16_t>);
     m.def("flash_maxsumexp_fp32_fast_tf32", &flash_maxsumexp<fp32_fast_tf32_t>);
+    m.def("flash_maxsumexp_fp32_fast_fp16", &flash_maxsumexp<fp32_fast_fp16_t>);
 
     m.def("maxsumexp_async_fp64", &maxsumexp_async<fp64_t>);
     m.def("maxsumexp_async_bf16", &maxsumexp_async<bf16_t>);

--- a/wrappers/python/nntile/nntile_core.cc
+++ b/wrappers/python/nntile/nntile_core.cc
@@ -971,10 +971,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("adamw_step_async_bf16", &adamw_step_async<bf16_t>);
     m.def("adamw_step_async_fp32", &adamw_step_async<fp32_t>);
     m.def("adamw_step_async_fp32_fast_tf32", &adamw_step_async<fp32_fast_tf32_t>);
+    m.def("adamw_step_async_fp32_fast_fp16", &adamw_step_async<fp32_fast_fp16_t>);
     m.def("adamw_step_fp64", &adamw_step<fp64_t>);
     m.def("adamw_step_bf16", &adamw_step<bf16_t>);
     m.def("adamw_step_fp32", &adamw_step<fp32_t>);
     m.def("adamw_step_fp32_fast_tf32", &adamw_step<fp32_fast_tf32_t>);
+    m.def("adamw_step_fp32_fast_fp16", &adamw_step<fp32_fast_fp16_t>);
 
     m.def("scal_inplace_async_fp64", &scal_inplace_async<fp64_t>);
     m.def("scal_inplace_async_fp32", &scal_inplace_async<fp32_t>);

--- a/wrappers/python/nntile/nntile_core.cc
+++ b/wrappers/python/nntile/nntile_core.cc
@@ -491,12 +491,14 @@ void def_mod_tensor(py::module_ &m)
     m.def("gemm_async_fp64", &gemm_async<fp64_t>);
     m.def("gemm_async_fp32", &gemm_async<fp32_t>);
     m.def("gemm_async_fp32_fast_tf32", &gemm_async<fp32_fast_tf32_t>);
+    m.def("gemm_async_fp32_fast_fp16", &gemm_async<fp32_fast_fp16_t>);
     m.def("gemm_async_bf16", &gemm_async<bf16_t>);
     //m.def("gemm_async_fp16", &gemm_async<fp16_t>);
 
     m.def("gemm_fp64", &gemm<fp64_t>);
     m.def("gemm_fp32", &gemm<fp32_t>);
     m.def("gemm_fp32_fast_tf32", &gemm<fp32_fast_tf32_t>);
+    m.def("gemm_fp32_fast_fp16", &gemm<fp32_fast_fp16_t>);
     m.def("gemm_bf16", &gemm<bf16_t>);
     //m.def("gemm_fp16", &gemm<fp16_t>);
 
@@ -641,10 +643,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("softmax_inplace_async_bf16", &softmax_inplace_async<bf16_t>);
     m.def("softmax_inplace_async_fp32", &softmax_inplace_async<fp32_t>);
     m.def("softmax_inplace_async_fp32_fast_tf32", &softmax_inplace_async<fp32_fast_tf32_t>);
+    m.def("softmax_inplace_async_fp32_fast_fp16", &softmax_inplace_async<fp32_fast_fp16_t>);
     m.def("softmax_inplace_fp64", &softmax_inplace<fp64_t>);
     m.def("softmax_inplace_bf16", &softmax_inplace<bf16_t>);
     m.def("softmax_inplace_fp32", &softmax_inplace<fp32_t>);
     m.def("softmax_inplace_fp32_fast_tf32", &softmax_inplace<fp32_fast_tf32_t>);
+    m.def("softmax_inplace_fp32_fast_fp16", &softmax_inplace<fp32_fast_fp16_t>);
 
     m.def("scatter_async_fp64", &scatter_async<fp64_t>);
     m.def("scatter_async_fp32", &scatter_async<fp32_t>);
@@ -708,10 +712,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("maxsumexp_async_bf16", &maxsumexp_async<bf16_t>);
     m.def("maxsumexp_async_fp32", &maxsumexp_async<fp32_t>);
     m.def("maxsumexp_async_fp32_fast_tf32", &maxsumexp_async<fp32_fast_tf32_t>);
+    m.def("maxsumexp_async_fp32_fast_fp16", &maxsumexp_async<fp32_fast_fp16_t>);
     m.def("maxsumexp_fp64", &maxsumexp<fp64_t>);
     m.def("maxsumexp_bf16", &maxsumexp<bf16_t>);
     m.def("maxsumexp_fp32", &maxsumexp<fp32_t>);
     m.def("maxsumexp_fp32_fast_tf32", &maxsumexp<fp32_fast_tf32_t>);
+    m.def("maxsumexp_fp32_fast_fp16", &maxsumexp<fp32_fast_fp16_t>);
 
     m.def("add_slice_inplace_async_fp64", &add_slice_inplace_async<fp64_t>);
     m.def("add_slice_inplace_async_bf16", &add_slice_inplace_async<bf16_t>);
@@ -1061,10 +1067,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("mask_scalar_async_bf16", &mask_scalar_async<bf16_t>);
     m.def("mask_scalar_async_fp32", &mask_scalar_async<fp32_t>);
     m.def("mask_scalar_async_fp32_fast_tf32", &mask_scalar_async<fp32_fast_tf32_t>);
+    m.def("mask_scalar_async_fp32_fast_fp16", &mask_scalar_async<fp32_fast_fp16_t>);
     m.def("mask_scalar_fp64", &mask_scalar<fp64_t>);
     m.def("mask_scalar_fp32", &mask_scalar<fp32_t>);
     m.def("mask_scalar_bf16", &mask_scalar<bf16_t>);
     m.def("mask_scalar_fp32_fast_tf32", &mask_scalar<fp32_fast_tf32_t>);
+    m.def("mask_scalar_fp32_fast_fp16", &mask_scalar<fp32_fast_fp16_t>);
 
     m.def("hypot_async_fp64", &hypot_async<fp64_t>);
     m.def("hypot_async_bf16", &hypot_async<bf16_t>);
@@ -1090,10 +1098,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("transpose_async_bf16", &transpose_async<bf16_t>);
     m.def("transpose_async_fp32", &transpose_async<fp32_t>);
     m.def("transpose_async_fp32_fast_tf32", &transpose_async<fp32_fast_tf32_t>);
+    m.def("transpose_async_fp32_fast_fp16", &transpose_async<fp32_fast_fp16_t>);
     m.def("transpose_fp64", &transpose<fp64_t>);
     m.def("transpose_fp32", &transpose<fp32_t>);
     m.def("transpose_bf16", &transpose<bf16_t>);
     m.def("transpose_fp32_fast_tf32", &transpose<fp32_fast_tf32_t>);
+    m.def("transpose_fp32_fast_fp16", &transpose<fp32_fast_fp16_t>);
 
     m.def("conv2d_inplace_async_fp64", &conv2d_inplace_async<fp64_t>);
     m.def("conv2d_inplace_async_fp32", &conv2d_inplace_async<fp32_t>);

--- a/wrappers/python/nntile/nntile_core.cc
+++ b/wrappers/python/nntile/nntile_core.cc
@@ -236,6 +236,7 @@ void def_mod_tile(py::module_ &m)
     // Define wrappers for Tile<T>
     def_class_tile<fp32_t>(m, "Tile_fp32");
     def_class_tile<fp32_fast_tf32_t>(m, "Tile_fp32_fast_tf32");
+    def_class_tile<fp32_fast_fp16_t>(m, "Tile_fp32_fast_fp16");
     def_class_tile<fp64_t>(m, "Tile_fp64");
     def_class_tile<bf16_t>(m, "Tile_bf16");
 }
@@ -478,6 +479,7 @@ void def_mod_tensor(py::module_ &m)
     def_class_tensor<bool_t>(m, "Tensor_bool");
     def_class_tensor<fp64_t>(m, "Tensor_fp64");
     def_class_tensor<fp32_fast_tf32_t>(m, "Tensor_fp32_fast_tf32");
+    def_class_tensor<fp32_fast_fp16_t>(m, "Tensor_fp32_fast_fp16");
     def_class_tensor<fp32_t>(m, "Tensor_fp32");
     def_class_tensor<bf16_t>(m, "Tensor_bf16");
     // def_class_tensor<fp16_t>(m, "Tensor_fp16");
@@ -718,10 +720,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("add_slice_async_bf16", &add_slice_async<bf16_t>);
     m.def("add_slice_async_fp32", &add_slice_async<fp32_t>);
     m.def("add_slice_async_fp32_fast_tf32", &add_slice_async<fp32_fast_tf32_t>);
+    m.def("add_slice_async_fp32_fast_fp16", &add_slice_async<fp32_fast_fp16_t>);
     m.def("add_slice_fp64", &add_slice<fp64_t>);
     m.def("add_slice_fp32", &add_slice<fp32_t>);
     m.def("add_slice_bf16", &add_slice<bf16_t>);
     m.def("add_slice_fp32_fast_tf32", &add_slice<fp32_fast_tf32_t>);
+    m.def("add_slice_fp32_fast_fp16", &add_slice<fp32_fast_fp16_t>);
 
     m.def("add_async_fp64", &add_async<fp64_t>);
     m.def("add_async_fp32", &add_async<fp32_t>);
@@ -803,12 +807,14 @@ void def_mod_tensor(py::module_ &m)
     m.def("copy_async_bf16", &copy_async<bf16_t>);
     m.def("copy_async_fp32", &copy_async<fp32_t>);
     m.def("copy_async_fp32_fast_tf32", &copy_async<fp32_fast_tf32_t>);
+    m.def("copy_async_fp32_fast_fp16", &copy_async<fp32_fast_fp16_t>);
     m.def("copy_async_int64", &copy_async<nntile::int64_t>);
 
     m.def("copy_fp64", &copy<fp64_t>);
     m.def("copy_bf16", &copy<bf16_t>);
     m.def("copy_fp32", &copy<fp32_t>);
     m.def("copy_fp32_fast_tf32", &copy<fp32_fast_tf32_t>);
+    m.def("copy_fp32_fast_fp16", &copy<fp32_fast_fp16_t>);
     m.def("copy_int64", &copy<nntile::int64_t>);
 
     m.def("clear_async_fp64", &clear_async<fp64_t>);
@@ -903,10 +909,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("scal_async_bf16", &scal_async<bf16_t>);
     m.def("scal_async_fp32", &scal_async<fp32_t>);
     m.def("scal_async_fp32_fast_tf32", &scal_async<fp32_fast_tf32_t>);
+    m.def("scal_async_fp32_fast_fp16", &scal_async<fp32_fast_fp16_t>);
     m.def("scal_fp64", &scal<fp64_t>);
     m.def("scal_fp32", &scal<fp32_t>);
     m.def("scal_bf16", &scal<bf16_t>);
     m.def("scal_fp32_fast_tf32", &scal<fp32_fast_tf32_t>);
+    m.def("scal_fp32_fast_fp16", &scal<fp32_fast_fp16_t>);
 
     m.def("adam_step_async_fp64", &adam_step_async<fp64_t>);
     m.def("adam_step_async_bf16", &adam_step_async<bf16_t>);
@@ -929,9 +937,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("scal_inplace_async_fp64", &scal_inplace_async<fp64_t>);
     m.def("scal_inplace_async_fp32", &scal_inplace_async<fp32_t>);
     m.def("scal_inplace_async_fp32_fast_tf32", &scal_inplace_async<fp32_fast_tf32_t>);
+    m.def("scal_inplace_async_fp32_fast_fp16", &scal_inplace_async<fp32_fast_fp16_t>);
+    m.def("scal_inplace_fp64", &scal_inplace<fp64_t>);
     m.def("scal_inplace_fp64", &scal_inplace<fp64_t>);
     m.def("scal_inplace_fp32", &scal_inplace<fp32_t>);
     m.def("scal_inplace_fp32_fast_tf32", &scal_inplace<fp32_fast_tf32_t>);
+    m.def("scal_inplace_fp32_fast_fp16", &scal_inplace<fp32_fast_fp16_t>);
 
     m.def("sumprod_slice_async_fp64", &sumprod_slice_async<fp64_t>);
     m.def("sumprod_slice_async_bf16", &sumprod_slice_async<bf16_t>);
@@ -998,20 +1009,24 @@ void def_mod_tensor(py::module_ &m)
     m.def("embedding_async_fp32", &embedding_async<fp32_t>);
     m.def("embedding_async_bf16", &embedding_async<bf16_t>);
     m.def("embedding_async_fp32_fast_tf32", &embedding_async<fp32_fast_tf32_t>);
+    m.def("embedding_async_fp32_fast_fp16", &embedding_async<fp32_fast_fp16_t>);
     m.def("embedding_fp64", &embedding<fp64_t>);
     m.def("embedding_fp32", &embedding<fp32_t>);
     m.def("embedding_bf16", &embedding<bf16_t>);
     m.def("embedding_fp32_fast_tf32", &embedding<fp32_fast_tf32_t>);
+    m.def("embedding_fp32_fast_fp16", &embedding<fp32_fast_fp16_t>);
 
     // Embedding backward pass
     m.def("embedding_backward_async_fp64", &embedding_backward_async<fp64_t>);
     m.def("embedding_backward_async_bf16", &embedding_backward_async<bf16_t>);
     m.def("embedding_backward_async_fp32", &embedding_backward_async<fp32_t>);
     m.def("embedding_backward_async_fp32_fast_tf32", &embedding_backward_async<fp32_fast_tf32_t>);
+    m.def("embedding_backward_async_fp32_fast_fp16", &embedding_backward_async<fp32_fast_fp16_t>);
     m.def("embedding_backward_fp64", &embedding_backward<fp64_t>);
     m.def("embedding_backward_fp32", &embedding_backward<fp32_t>);
     m.def("embedding_backward_bf16", &embedding_backward<bf16_t>);
     m.def("embedding_backward_fp32_fast_tf32", &embedding_backward<fp32_fast_tf32_t>);
+    m.def("embedding_backward_fp32_fast_fp16", &embedding_backward<fp32_fast_fp16_t>);
 
     // FP32 <-> FP16
     //m.def("fp32_to_fp16_async", &fp32_to_fp16_async);

--- a/wrappers/python/nntile/nntile_core.cc
+++ b/wrappers/python/nntile/nntile_core.cc
@@ -553,18 +553,22 @@ void def_mod_tensor(py::module_ &m)
     m.def("fill_async_bf16", &fill_async<bf16_t>);
     m.def("fill_async_fp32", &fill_async<fp32_t>);
     m.def("fill_async_fp32_fast_tf32", &fill_async<fp32_fast_tf32_t>);
+    m.def("fill_async_fp32_fast_fp16", &fill_async<fp32_fast_fp16_t>);
     m.def("fill_fp64", &fill<fp64_t>);
     m.def("fill_bf16", &fill<bf16_t>);
     m.def("fill_fp32", &fill<fp32_t>);
     m.def("fill_fp32_fast_tf32", &fill<fp32_fast_tf32_t>);
+    m.def("fill_fp32_fast_fp16", &fill<fp32_fast_fp16_t>);
 
     m.def("sum_slice_async_fp64", &sum_slice_async<fp64_t>);
     m.def("sum_slice_async_bf16", &sum_slice_async<bf16_t>);
     m.def("sum_slice_async_fp32", &sum_slice_async<fp32_t>);
     m.def("sum_slice_async_fp32_fast_tf32", &sum_slice_async<fp32_fast_tf32_t>);
+    m.def("sum_slice_async_fp32_fast_fp16", &sum_slice_async<fp32_fast_fp16_t>);
     m.def("sum_slice_fp64", &sum_slice<fp64_t>);
     m.def("sum_slice_fp32", &sum_slice<fp32_t>);
     m.def("sum_slice_fp32_fast_tf32", &sum_slice<fp32_fast_tf32_t>);
+    m.def("sum_slice_fp32_fast_fp16", &sum_slice<fp32_fast_fp16_t>);
     m.def("sum_slice_bf16", &sum_slice<bf16_t>);
 
     m.def("sum_fiber_async_fp64", &sum_fiber_async<fp64_t>);
@@ -589,10 +593,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("norm_slice_async_bf16", &norm_slice_async<bf16_t>);
     m.def("norm_slice_async_fp32", &norm_slice_async<fp32_t>);
     m.def("norm_slice_async_fp32_fast_tf32", &norm_slice_async<fp32_fast_tf32_t>);
+    m.def("norm_slice_async_fp32_fast_fp16", &norm_slice_async<fp32_fast_fp16_t>);
     m.def("norm_slice_fp64", &norm_slice<fp64_t>);
     m.def("norm_slice_fp32", &norm_slice<fp32_t>);
     m.def("norm_slice_bf16", &norm_slice<bf16_t>);
     m.def("norm_slice_fp32_fast_tf32", &norm_slice<fp32_fast_tf32_t>);
+    m.def("norm_slice_fp32_fast_fp16", &norm_slice<fp32_fast_fp16_t>);
 
     m.def("pow_async_fp64", &pow_async<fp64_t>);
     m.def("pow_async_fp32", &pow_async<fp32_t>);
@@ -727,6 +733,17 @@ void def_mod_tensor(py::module_ &m)
     m.def("add_slice_fp32_fast_tf32", &add_slice<fp32_fast_tf32_t>);
     m.def("add_slice_fp32_fast_fp16", &add_slice<fp32_fast_fp16_t>);
 
+    m.def("add_slice3_async_fp64", &add_slice3_async<fp64_t>);
+    m.def("add_slice3_async_bf16", &add_slice3_async<bf16_t>);
+    m.def("add_slice3_async_fp32", &add_slice3_async<fp32_t>);
+    m.def("add_slice3_async_fp32_fast_tf32", &add_slice3_async<fp32_fast_tf32_t>);
+    m.def("add_slice3_async_fp32_fast_fp16", &add_slice3_async<fp32_fast_fp16_t>);
+    m.def("add_slice3_fp64", &add_slice3<fp64_t>);
+    m.def("add_slice3_fp32", &add_slice3<fp32_t>);
+    m.def("add_slice3_bf16", &add_slice3<bf16_t>);
+    m.def("add_slice3_fp32_fast_tf32", &add_slice3<fp32_fast_tf32_t>);
+    m.def("add_slice3_fp32_fast_fp16", &add_slice3<fp32_fast_fp16_t>);
+
     m.def("add_async_fp64", &add_async<fp64_t>);
     m.def("add_async_fp32", &add_async<fp32_t>);
     m.def("add_async_fp32_fast_tf32", &add_async<fp32_fast_tf32_t>);
@@ -754,19 +771,23 @@ void def_mod_tensor(py::module_ &m)
     m.def("add_fiber_inplace_async_bf16", &add_fiber_inplace_async<bf16_t>);
     m.def("add_fiber_inplace_async_fp32", &add_fiber_inplace_async<fp32_t>);
     m.def("add_fiber_inplace_async_fp32_fast_tf32", &add_fiber_inplace_async<fp32_fast_tf32_t>);
+    m.def("add_fiber_inplace_async_fp32_fast_fp16", &add_fiber_inplace_async<fp32_fast_fp16_t>);
     m.def("add_fiber_inplace_fp64", &add_fiber_inplace<fp64_t>);
     m.def("add_fiber_inplace_fp32", &add_fiber_inplace<fp32_t>);
     m.def("add_fiber_inplace_bf16", &add_fiber_inplace<bf16_t>);
     m.def("add_fiber_inplace_fp32_fast_tf32", &add_fiber_inplace<fp32_fast_tf32_t>);
+    m.def("add_fiber_inplace_fp32_fast_fp16", &add_fiber_inplace<fp32_fast_fp16_t>);
 
     m.def("prod_slice_async_fp64", &prod_slice_async<fp64_t>);
     m.def("prod_slice_async_bf16", &prod_slice_async<bf16_t>);
     m.def("prod_slice_async_fp32", &prod_slice_async<fp32_t>);
     m.def("prod_slice_async_fp32_fast_tf32", &prod_slice_async<fp32_fast_tf32_t>);
+    m.def("prod_slice_async_fp32_fast_fp16", &prod_slice_async<fp32_fast_fp16_t>);
     m.def("prod_slice_fp64", &prod_slice<fp64_t>);
     m.def("prod_slice_fp32", &prod_slice<fp32_t>);
     m.def("prod_slice_bf16", &prod_slice<bf16_t>);
     m.def("prod_slice_fp32_fast_tf32", &prod_slice<fp32_fast_tf32_t>);
+    m.def("prod_slice_fp32_fast_fp16", &prod_slice<fp32_fast_fp16_t>);
 
     m.def("prod_fiber_async_fp64", &prod_fiber_async<fp64_t>);
     m.def("prod_fiber_async_fp32", &prod_fiber_async<fp32_t>);
@@ -777,10 +798,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("prod_fiber3_async_bf16", &prod_fiber3_async<bf16_t>);
     m.def("prod_fiber3_async_fp32", &prod_fiber3_async<fp32_t>);
     m.def("prod_fiber3_async_fp32_fast_tf32", &prod_fiber3_async<fp32_fast_tf32_t>);
+    m.def("prod_fiber3_async_fp32_fast_fp16", &prod_fiber3_async<fp32_fast_fp16_t>);
     m.def("prod_fiber3_fp64", &prod_fiber3<fp64_t>);
     m.def("prod_fiber3_fp32", &prod_fiber3<fp32_t>);
     m.def("prod_fiber3_bf16", &prod_fiber3<bf16_t>);
     m.def("prod_fiber3_fp32_fast_tf32", &prod_fiber3<fp32_fast_tf32_t>);
+    m.def("prod_fiber3_fp32_fast_fp16", &prod_fiber3<fp32_fast_fp16_t>);
 
     m.def("gather_async_fp64", &gather_async<fp64_t>);
     m.def("gather_async_fp32", &gather_async<fp32_t>);
@@ -820,12 +843,14 @@ void def_mod_tensor(py::module_ &m)
     m.def("clear_async_fp64", &clear_async<fp64_t>);
     m.def("clear_async_fp32", &clear_async<fp32_t>);
     m.def("clear_async_fp32_fast_tf32", &clear_async<fp32_fast_tf32_t>);
+    m.def("clear_async_fp32_fast_fp16", &clear_async<fp32_fast_fp16_t>);
     m.def("clear_async_bf16", &clear_async<bf16_t>);
     //m.def("clear_async_fp16", &clear_async<fp16_t>);
     m.def("clear_fp64", &clear<fp64_t>);
     m.def("clear_fp32", &clear<fp32_t>);
     m.def("clear_bf16", &clear<bf16_t>);
     m.def("clear_fp32_fast_tf32", &clear<fp32_fast_tf32_t>);
+    m.def("clear_fp32_fast_fp16", &clear<fp32_fast_fp16_t>);
     //m.def("clear_fp16", &clear<fp16_t>);
 
     m.def("axpy_async_fp64", py::overload_cast<Scalar, const Tensor<fp64_t>&,
@@ -1054,10 +1079,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("hypot_scalar_inverse_async_bf16", &hypot_scalar_inverse_async<bf16_t>);
     m.def("hypot_scalar_inverse_async_fp32", &hypot_scalar_inverse_async<fp32_t>);
     m.def("hypot_scalar_inverse_async_fp32_fast_tf32", &hypot_scalar_inverse_async<fp32_fast_tf32_t>);
+    m.def("hypot_scalar_inverse_async_fp32_fast_fp16", &hypot_scalar_inverse_async<fp32_fast_fp16_t>);
     m.def("hypot_scalar_inverse_fp64", &hypot_scalar_inverse<fp64_t>);
     m.def("hypot_scalar_inverse_bf16", &hypot_scalar_inverse<bf16_t>);
     m.def("hypot_scalar_inverse_fp32", &hypot_scalar_inverse<fp32_t>);
     m.def("hypot_scalar_inverse_fp32_fast_tf32", &hypot_scalar_inverse<fp32_fast_tf32_t>);
+    m.def("hypot_scalar_inverse_fp32_fast_fp16", &hypot_scalar_inverse<fp32_fast_fp16_t>);
 
     m.def("transpose_async_fp64", &transpose_async<fp64_t>);
     m.def("transpose_async_bf16", &transpose_async<bf16_t>);

--- a/wrappers/python/nntile/nntile_core.cc
+++ b/wrappers/python/nntile/nntile_core.cc
@@ -730,10 +730,12 @@ void def_mod_tensor(py::module_ &m)
     m.def("add_slice_inplace_async_bf16", &add_slice_inplace_async<bf16_t>);
     m.def("add_slice_inplace_async_fp32", &add_slice_inplace_async<fp32_t>);
     m.def("add_slice_inplace_async_fp32_fast_tf32", &add_slice_inplace_async<fp32_fast_tf32_t>);
+    m.def("add_slice_inplace_async_fp32_fast_fp16", &add_slice_inplace_async<fp32_fast_fp16_t>);
     m.def("add_slice_inplace_fp64", &add_slice_inplace<fp64_t>);
     m.def("add_slice_inplace_bf16", &add_slice_inplace<bf16_t>);
     m.def("add_slice_inplace_fp32", &add_slice_inplace<fp32_t>);
     m.def("add_slice_inplace_fp32_fast_tf32", &add_slice_inplace<fp32_fast_tf32_t>);
+    m.def("add_slice_inplace_fp32_fast_fp16", &add_slice_inplace<fp32_fast_fp16_t>);
 
     m.def("add_slice_async_fp64", &add_slice_async<fp64_t>);
     m.def("add_slice_async_bf16", &add_slice_async<bf16_t>);
@@ -745,17 +747,6 @@ void def_mod_tensor(py::module_ &m)
     m.def("add_slice_bf16", &add_slice<bf16_t>);
     m.def("add_slice_fp32_fast_tf32", &add_slice<fp32_fast_tf32_t>);
     m.def("add_slice_fp32_fast_fp16", &add_slice<fp32_fast_fp16_t>);
-
-    m.def("add_slice3_async_fp64", &add_slice3_async<fp64_t>);
-    m.def("add_slice3_async_bf16", &add_slice3_async<bf16_t>);
-    m.def("add_slice3_async_fp32", &add_slice3_async<fp32_t>);
-    m.def("add_slice3_async_fp32_fast_tf32", &add_slice3_async<fp32_fast_tf32_t>);
-    m.def("add_slice3_async_fp32_fast_fp16", &add_slice3_async<fp32_fast_fp16_t>);
-    m.def("add_slice3_fp64", &add_slice3<fp64_t>);
-    m.def("add_slice3_fp32", &add_slice3<fp32_t>);
-    m.def("add_slice3_bf16", &add_slice3<bf16_t>);
-    m.def("add_slice3_fp32_fast_tf32", &add_slice3<fp32_fast_tf32_t>);
-    m.def("add_slice3_fp32_fast_fp16", &add_slice3<fp32_fast_fp16_t>);
 
     m.def("add_async_fp64", &add_async<fp64_t>);
     m.def("add_async_fp32", &add_async<fp32_t>);

--- a/wrappers/python/nntile/tensor.py
+++ b/wrappers/python/nntile/tensor.py
@@ -17,7 +17,7 @@
 from .functions import *
 from .nntile_core import TransOp, notrans, trans
 from .nntile_core.tensor import (
-    Tensor_bf16, Tensor_bool, Tensor_fp32, Tensor_fp32_fast_tf32, Tensor_fp64,
-    Tensor_int64, TensorTraits)
+    Tensor_bf16, Tensor_bool, Tensor_fp32, Tensor_fp32_fast_fp16,
+    Tensor_fp32_fast_tf32, Tensor_fp64, Tensor_int64, TensorTraits)
 from .types import *
 from .utils.constructors import *

--- a/wrappers/python/nntile/types.py
+++ b/wrappers/python/nntile/types.py
@@ -20,8 +20,8 @@ else:
     from typing_extensions import Buffer
 
 from .nntile_core.tensor import (
-    Tensor_bf16, Tensor_fp32, Tensor_fp32_fast_tf32, Tensor_fp64, Tensor_int64,
-    TensorTraits)
+    Tensor_bf16, Tensor_fp32, Tensor_fp32_fast_fp16, Tensor_fp32_fast_tf32,
+    Tensor_fp64, Tensor_int64, TensorTraits)
 from .nntile_core.tile import TileTraits
 
 if TYPE_CHECKING:

--- a/wrappers/python/nntile/types.py
+++ b/wrappers/python/nntile/types.py
@@ -20,8 +20,8 @@ else:
     from typing_extensions import Buffer
 
 from .nntile_core.tensor import (
-    Tensor_bf16, Tensor_fp32, Tensor_fp32_fast_fp16, Tensor_fp32_fast_tf32,
-    Tensor_fp64, Tensor_int64, TensorTraits)
+    Tensor_bf16, Tensor_fp32, Tensor_fp32_fast_tf32, Tensor_fp64, Tensor_int64,
+    TensorTraits)
 from .nntile_core.tile import TileTraits
 
 if TYPE_CHECKING:

--- a/wrappers/python/nntile/utils/constructors.py
+++ b/wrappers/python/nntile/utils/constructors.py
@@ -18,8 +18,8 @@ import numpy as np
 
 from nntile.functions import clear_async, copy_async, fill_async, gather_async
 from nntile.nntile_core.tensor import (
-    Tensor_bf16, Tensor_bool, Tensor_fp32, Tensor_fp32_fast_tf32, Tensor_fp64,
-    Tensor_int64, TensorTraits)
+    Tensor_bf16, Tensor_bool, Tensor_fp32, Tensor_fp32_fast_fp16,
+    Tensor_fp32_fast_tf32, Tensor_fp64, Tensor_int64, TensorTraits)
 from nntile.types import Tensor
 
 nnt2np_type_mapping = {
@@ -28,7 +28,8 @@ nnt2np_type_mapping = {
     Tensor_bf16: np.float32,
     Tensor_fp64: np.float64,
     Tensor_int64: np.int64,
-    Tensor_bool: bool
+    Tensor_bool: bool,
+    Tensor_fp32_fast_fp16: np.float32,
 }
 
 np2nnt_type_mapping = {

--- a/wrappers/python/tests/model/test_gpt2_block.py
+++ b/wrappers/python/tests/model/test_gpt2_block.py
@@ -31,12 +31,14 @@ dtype2nntile = {
         'fp32': nntile.tensor.Tensor_fp32,
         'fp32_fast_tf32': nntile.tensor.Tensor_fp32_fast_tf32,
         'bf16': nntile.tensor.Tensor_bf16,
+        'fp32_fast_fp16': nntile.tensor.Tensor_fp32_fast_fp16
 }
 
 dtype2tol = {
         'fp32': {'rtol': 1e-6},
         'fp32_fast_tf32': {'rtol': 8e-4},
         'bf16': {'rtol': 1.6e-2},
+        'fp32_fast_fp16': {'rtol': 8e-4},
 }
 
 nocuda = pytest.mark.skipif(not torch.cuda.is_available(), reason='no cuda')
@@ -138,6 +140,7 @@ def generate_inputs(params: GPT2BlockTestParams,
     'fp32',
     pytest.param('fp32_fast_tf32', marks=nocuda),
     pytest.param('bf16', marks=nocuda),
+    pytest.param('fp32_fast_fp16', marks=nocuda),
 ])
 class TestGPT2Decoder:
     def test_coercion(self, starpu_simple, torch_rng,

--- a/wrappers/python/tests/model/test_gpt2_mlp.py
+++ b/wrappers/python/tests/model/test_gpt2_mlp.py
@@ -31,12 +31,14 @@ dtype2nntile = {
         'fp32': nntile.tensor.Tensor_fp32,
         'fp32_fast_tf32': nntile.tensor.Tensor_fp32_fast_tf32,
         'bf16': nntile.tensor.Tensor_bf16,
+        'fp32_fast_fp16': nntile.tensor.Tensor_fp32_fast_fp16,
 }
 
 dtype2tol = {
         'fp32': {'rtol': 1e-6},
         'fp32_fast_tf32': {'rtol': 6e-4},
         'bf16': {'rtol': 1.6e-2},
+        'fp32_fast_fp16': {'rtol': 6e-4},
 }
 
 nocuda = pytest.mark.skipif(not torch.cuda.is_available(), reason='no cuda')
@@ -132,6 +134,7 @@ def generate_inputs(params: GPT2MLPTestParams, dtype: str):
     'fp32',
     pytest.param('fp32_fast_tf32', marks=nocuda),
     pytest.param('bf16', marks=nocuda),
+    pytest.param('fp32_fast_fp16', marks=nocuda),
 ])
 class TestGPT2MLP:
 


### PR DESCRIPTION
This PR extends the existing functions necessary in training the GPT2 model to support the fp32_fast_fp16 type. This type performs all operations in the fp32 type except the gemm operation, which is done in fp16 in GPUs.