### PR TITLE
GPT2 training supports fp32_fast_bf16 type

### DIFF
--- a/include/nntile/base_types.hh
+++ b/include/nntile/base_types.hh
@@ -350,6 +350,62 @@ inline std::ostream &operator<<(std::ostream &os,
     return os;
 }
 
+class fp32_fast_bf16_t
+{
+public:
+    //! Basic type that must have the same size, as this type
+    using storage_t = float;
+    //! Basic type that must cover all possible values of this type
+    using repr_t = float;
+    //! Flag if copy from repr_t does not require conversion
+    static const bool trivial_copy_from_compat = true;
+    //! String to represent this type
+    static constexpr const char *type_repr = "fp32_fast_bf16_t";
+    //! Internal value of this type to hold actual data
+    storage_t value;
+    //! Constructor
+    NNTILE_HOST_DEVICE fp32_fast_bf16_t() = default;
+    //! Constructor from another value of this type
+    NNTILE_HOST_DEVICE fp32_fast_bf16_t(const fp32_fast_bf16_t &other) = default;
+    //! Constructor from a repr_t value
+    NNTILE_HOST_DEVICE explicit fp32_fast_bf16_t(const repr_t &other):
+        value(other)
+    {
+    }
+    //! Assignment from another value of this type
+    NNTILE_HOST_DEVICE fp32_fast_bf16_t &operator=(const fp32_fast_bf16_t &other) = default;
+    //! Assignment from a repr_t value
+    NNTILE_HOST_DEVICE fp32_fast_bf16_t &operator=(const repr_t &other)
+    {
+        value = other;
+        return *this;
+    }
+    //! Conversion to repr_t value
+    NNTILE_HOST_DEVICE explicit operator repr_t() const
+    {
+        return value;
+    }
+    //! Machine precision of this type
+    static repr_t epsilon()
+    {
+        // Init 1.0 and 1.0+eps identically
+        fp32_fast_bf16_t one{1.0}, one_p_eps{1.0};
+        auto uintptr = reinterpret_cast<std::uint32_t *>(&one_p_eps);
+        // Add a bit into mantissa of 1+eps to get actual value of 1+eps
+        *uintptr += 0x10000;
+        // Output difference of 1+eps and 1
+        return static_cast<repr_t>(one_p_eps) - static_cast<repr_t>(one);
+    }
+};
+
+//! Print function for nntile::fp32_fast_bf16_t
+inline std::ostream &operator<<(std::ostream &os,
+        const fp32_fast_bf16_t &value)
+{
+    os << static_cast<typename fp32_fast_bf16_t::repr_t>(value);
+    return os;
+}
+
 //! NNTile wrapper type BrainFloat16 type inside tensors
 class bf16_t
 {

--- a/include/nntile/starpu/accumulate.hh
+++ b/include/nntile/starpu/accumulate.hh
@@ -34,7 +34,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-               codelet_bf16, codelet_fp32_fast_fp16;
+               codelet_bf16, codelet_fp32_fast_fp16, codelet_fp32_fast_bf16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -59,6 +59,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_fp16_t>()
 {
     return &codelet_fp32_fast_fp16;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_bf16_t>()
+{
+    return &codelet_fp32_fast_bf16;
 }
 
 template<>

--- a/include/nntile/starpu/accumulate_hypot.hh
+++ b/include/nntile/starpu/accumulate_hypot.hh
@@ -34,7 +34,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-               codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16, codelet_fp32_fast_bf16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -71,6 +71,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_fp16_t>()
 {
     return &codelet_fp32_fast_fp16;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_bf16_t>()
+{
+    return &codelet_fp32_fast_bf16;
 }
 
 void init();

--- a/include/nntile/starpu/accumulate_maxsumexp.hh
+++ b/include/nntile/starpu/accumulate_maxsumexp.hh
@@ -34,7 +34,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-               codelet_bf16, codelet_fp32_fast_fp16;
+               codelet_bf16, codelet_fp32_fast_fp16, codelet_fp32_fast_bf16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -59,6 +59,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_fp16_t>()
 {
     return &codelet_fp32_fast_fp16;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_bf16_t>()
+{
+    return &codelet_fp32_fast_bf16;
 }
 
 template<>

--- a/include/nntile/starpu/fill.hh
+++ b/include/nntile/starpu/fill.hh
@@ -41,7 +41,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 extern Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-               codelet_fp32_fast_fp16;
+               codelet_fp32_fast_fp16, codelet_fp32_fast_bf16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -72,6 +72,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_fp16_t>()
 {
     return &codelet_fp32_fast_fp16;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_bf16_t>()
+{
+    return &codelet_fp32_fast_bf16;
 }
 
 template<>

--- a/include/nntile/starpu/subcopy.hh
+++ b/include/nntile/starpu/subcopy.hh
@@ -28,7 +28,7 @@ void cpu(void *buffers[], void *cl_args)
 //extern Codelet codelet_fp16;
 extern Codelet codelet_fp32, codelet_fp64, codelet_int64,
        codelet_bool, codelet_fp32_fast_tf32, codelet_bf16,
-       codelet_fp32_fast_fp16;
+       codelet_fp32_fast_fp16, codelet_fp32_fast_bf16;
 
 template<typename T>
 constexpr Codelet *codelet()
@@ -83,6 +83,12 @@ template<>
 constexpr Codelet *codelet<fp32_fast_fp16_t>()
 {
     return &codelet_fp32_fast_fp16;
+}
+
+template<>
+constexpr Codelet *codelet<fp32_fast_bf16_t>()
+{
+    return &codelet_fp32_fast_bf16;
 }
 
 void init();

--- a/src/starpu/accumulate.cc
+++ b/src/starpu/accumulate.cc
@@ -59,7 +59,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32,
-        codelet_bf16, codelet_fp32_fast_fp16;
+        codelet_bf16, codelet_fp32_fast_fp16, codelet_fp32_fast_bf16;
 
 void init()
 {
@@ -119,6 +119,20 @@ void init()
             STARPU_RW | STARPU_COMMUTE);
     codelet_fp32_fast_fp16.modes[1] = STARPU_R;
 
+    codelet_fp32_fast_bf16.init("nntile_accumulate_fp32_fast_bf16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+    codelet_fp32_fast_bf16.nbuffers = 2;
+    codelet_fp32_fast_bf16.modes[0] = static_cast<starpu_data_access_mode>(
+            STARPU_RW | STARPU_COMMUTE);
+    codelet_fp32_fast_bf16.modes[1] = STARPU_R;
+
 
     codelet_fp64.init("nntile_accumulate_fp64",
             nullptr,
@@ -140,6 +154,7 @@ void restrict_where(uint32_t where)
     codelet_fp32.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
     codelet_fp32_fast_fp16.restrict_where(where);
+    codelet_fp32_fast_bf16.restrict_where(where);
     codelet_fp64.restrict_where(where);
     codelet_bf16.restrict_where(where);
 }
@@ -149,6 +164,7 @@ void restore_where()
     codelet_fp32.restore_where();
     codelet_fp32_fast_tf32.restore_where();
     codelet_fp32_fast_fp16.restore_where();
+    codelet_fp32_fast_bf16.restore_where();
     codelet_fp64.restore_where();
     codelet_bf16.restore_where();
 }
@@ -184,6 +200,9 @@ void submit<fp32_fast_tf32_t>(Handle src, Handle dst);
 
 template
 void submit<fp32_fast_fp16_t>(Handle src, Handle dst);
+
+template
+void submit<fp32_fast_bf16_t>(Handle src, Handle dst);
 
 template
 void submit<fp64_t>(Handle src, Handle dst);

--- a/src/starpu/accumulate_hypot.cc
+++ b/src/starpu/accumulate_hypot.cc
@@ -59,7 +59,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-        codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16, codelet_fp32_fast_bf16;
 
 void init()
 {
@@ -120,6 +120,20 @@ void init()
             STARPU_RW | STARPU_COMMUTE);
     codelet_fp32_fast_fp16.modes[1] = STARPU_R;
 
+    codelet_fp32_fast_bf16.init("nntile_accumulate_hypot_fp32_fast_bf16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+    codelet_fp32_fast_bf16.nbuffers = 2;
+    codelet_fp32_fast_bf16.modes[0] = static_cast<starpu_data_access_mode>(
+            STARPU_RW | STARPU_COMMUTE);
+    codelet_fp32_fast_bf16.modes[1] = STARPU_R;
+
     codelet_fp64.init("nntile_accumulate_hypot_fp64",
             nullptr,
             {cpu<fp64_t>},
@@ -142,6 +156,7 @@ void restrict_where(uint32_t where)
     codelet_fp64.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
     codelet_fp32_fast_fp16.restrict_where(where);
+    codelet_fp32_fast_bf16.restrict_where(where);
 }
 
 void restore_where()
@@ -151,6 +166,7 @@ void restore_where()
     codelet_fp64.restore_where();
     codelet_fp32_fast_tf32.restore_where();
     codelet_fp32_fast_fp16.restore_where();
+    codelet_fp32_fast_bf16.restore_where();
 }
 
 template<typename T>
@@ -187,6 +203,9 @@ void submit<fp32_fast_tf32_t>(Handle src, Handle dst);
 
 template
 void submit<fp32_fast_fp16_t>(Handle src, Handle dst);
+
+template
+void submit<fp32_fast_bf16_t>(Handle src, Handle dst);
 
 template
 void submit<fp64_t>(Handle src, Handle dst);

--- a/src/starpu/accumulate_maxsumexp.cc
+++ b/src/starpu/accumulate_maxsumexp.cc
@@ -59,7 +59,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-        codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16, codelet_fp32_fast_bf16;
 
 void init()
 {
@@ -105,6 +105,20 @@ void init()
             STARPU_RW | STARPU_COMMUTE);
     codelet_fp32_fast_fp16.modes[1] = STARPU_R;
 
+    codelet_fp32_fast_bf16.init("nntile_accumulate_maxsumexp_fp32_fast_bf16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+    codelet_fp32_fast_bf16.nbuffers = 2;
+    codelet_fp32_fast_bf16.modes[0] = static_cast<starpu_data_access_mode>(
+            STARPU_RW | STARPU_COMMUTE);
+    codelet_fp32_fast_bf16.modes[1] = STARPU_R;
+
 
     codelet_fp64.init("nntile_accumulate_maxsumexp_fp64",
             nullptr,
@@ -141,6 +155,7 @@ void restrict_where(uint32_t where)
     codelet_fp64.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
     codelet_fp32_fast_fp16.restrict_where(where);
+    codelet_fp32_fast_bf16.restrict_where(where);
     codelet_bf16.restrict_where(where);
 }
 
@@ -151,6 +166,7 @@ void restore_where()
     codelet_fp64.restore_where();
     codelet_fp32_fast_tf32.restore_where();
     codelet_fp32_fast_fp16.restore_where();
+    codelet_fp32_fast_bf16.restore_where();
 }
 
 template<typename T>
@@ -184,6 +200,9 @@ void submit<fp32_fast_tf32_t>(Handle src, Handle dst);
 
 template
 void submit<fp32_fast_fp16_t>(Handle src, Handle dst);
+
+template
+void submit<fp32_fast_bf16_t>(Handle src, Handle dst);
 
 template
 void submit<fp64_t>(Handle src, Handle dst);

--- a/src/starpu/fill.cc
+++ b/src/starpu/fill.cc
@@ -57,7 +57,7 @@ void cuda(void *buffers[], void *cl_args)
 #endif // NNTILE_USE_CUDA
 
 Codelet codelet_fp32, codelet_fp64, codelet_fp32_fast_tf32, codelet_bf16,
-        codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16, codelet_fp32_fast_bf16;
 
 void init()
 {
@@ -101,6 +101,16 @@ void init()
 #endif // NNTILE_USE_CUDA
             );
 
+    codelet_fp32_fast_bf16.init("nntile_fill_fp32_fast_bf16",
+            nullptr,
+            {cpu<fp32_t>},
+#ifdef NNTILE_USE_CUDA
+            {cuda<fp32_t>}
+#else // NNTILE_USE_CUDA
+            {}
+#endif // NNTILE_USE_CUDA
+            );
+
     codelet_fp64.init("nntile_fill_fp64",
             nullptr,
             {cpu<fp64_t>},
@@ -118,6 +128,7 @@ void restrict_where(uint32_t where)
     codelet_bf16.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
     codelet_fp32_fast_fp16.restrict_where(where);
+    codelet_fp32_fast_bf16.restrict_where(where);
     codelet_fp64.restrict_where(where);
 }
 
@@ -127,6 +138,7 @@ void restore_where()
     codelet_bf16.restore_where();
     codelet_fp32_fast_tf32.restore_where();
     codelet_fp32_fast_fp16.restore_where();
+    codelet_fp32_fast_bf16.restore_where();
     codelet_fp64.restore_where();
 }
 
@@ -166,6 +178,9 @@ void submit<fp32_fast_tf32_t>(Index nelems, Scalar val, Handle data);
 
 template
 void submit<fp32_fast_fp16_t>(Index nelems, Scalar val, Handle data);
+
+template
+void submit<fp32_fast_bf16_t>(Index nelems, Scalar val, Handle data);
 
 template
 void submit<fp64_t>(Index nelems, Scalar val, Handle data);

--- a/src/starpu/subcopy.cc
+++ b/src/starpu/subcopy.cc
@@ -84,7 +84,7 @@ uint32_t footprint(struct starpu_task *task)
 //Codelet codelet_fp16;
 Codelet codelet_fp32, codelet_fp64, codelet_int64,
         codelet_bool, codelet_fp32_fast_tf32, codelet_bf16,
-        codelet_fp32_fast_fp16;
+        codelet_fp32_fast_fp16, codelet_fp32_fast_bf16;
 
 void init()
 {
@@ -142,6 +142,15 @@ void init()
             {}
 #endif // NNTILE_USE_CUDA
             );
+    codelet_fp32_fast_bf16.init("nntile_subcopy_fp32_fast_bf16",
+                footprint,
+                {cpu<fp32_t>},
+        #ifdef NNTILE_USE_CUDA
+                {cuda<fp32_t>}
+        #else // NNTILE_USE_CUDA
+                {}
+        #endif // NNTILE_USE_CUDA
+                );
     codelet_bf16.init("nntile_subcopy_bf16",
             footprint,
             {cpu<bf16_t>},
@@ -162,6 +171,7 @@ void restrict_where(uint32_t where)
     codelet_bool.restrict_where(where);
     codelet_fp32_fast_tf32.restrict_where(where);
     codelet_fp32_fast_fp16.restrict_where(where);
+    codelet_fp32_fast_bf16.restrict_where(where);
     codelet_bf16.restrict_where(where);
 }
 
@@ -174,6 +184,7 @@ void restore_where()
     codelet_bool.restore_where();
     codelet_fp32_fast_tf32.restore_where();
     codelet_fp32_fast_fp16.restore_where();
+    codelet_fp32_fast_bf16.restore_where();
     codelet_bf16.restore_where();
 }
 
@@ -233,6 +244,14 @@ void submit<fp32_fast_tf32_t>(Index ndim, const std::vector<Index> &src_start,
 
 template
 void submit<fp32_fast_fp16_t>(Index ndim, const std::vector<Index> &src_start,
+        const std::vector<Index> &src_stride,
+        const std::vector<Index> &dst_start,
+        const std::vector<Index> &dst_stride,
+        const std::vector<Index> &copy_shape, Handle src, Handle dst,
+        Handle tmp_index, starpu_data_access_mode mode);
+
+template
+void submit<fp32_fast_bf16_t>(Index ndim, const std::vector<Index> &src_start,
         const std::vector<Index> &src_stride,
         const std::vector<Index> &dst_start,
         const std::vector<Index> &dst_stride,

--- a/src/tensor/clear.cc
+++ b/src/tensor/clear.cc
@@ -54,6 +54,9 @@ template
 void clear_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &dst);
 
 template
+void clear_async<fp32_fast_bf16_t>(const Tensor<fp32_fast_bf16_t> &dst);
+
+template
 void clear_async<fp64_t>(const Tensor<fp64_t> &dst);
 
 template
@@ -71,6 +74,9 @@ void clear<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &dst);
 
 template
 void clear<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &dst);
+
+template
+void clear<fp32_fast_bf16_t>(const Tensor<fp32_fast_bf16_t> &dst);
 
 template
 void clear<fp64_t>(const Tensor<fp64_t> &dst);

--- a/src/tensor/fill.cc
+++ b/src/tensor/fill.cc
@@ -65,6 +65,9 @@ template
 void fill_async<fp32_fast_fp16_t>(Scalar val, const Tensor<fp32_fast_fp16_t> &A);
 
 template
+void fill_async<fp32_fast_bf16_t>(Scalar val, const Tensor<fp32_fast_bf16_t> &A);
+
+template
 void fill_async<fp64_t>(Scalar val, const Tensor<fp64_t> &A);
 
 // Explicit instantiation
@@ -79,6 +82,9 @@ void fill<fp32_fast_tf32_t>(Scalar val, const Tensor<fp32_fast_tf32_t> &A);
 
 template
 void fill<fp32_fast_fp16_t>(Scalar val, const Tensor<fp32_fast_fp16_t> &A);
+
+template
+void fill<fp32_fast_bf16_t>(Scalar val, const Tensor<fp32_fast_bf16_t> &A);
 
 template
 void fill<fp64_t>(Scalar val, const Tensor<fp64_t> &A);

--- a/src/tensor/gather.cc
+++ b/src/tensor/gather.cc
@@ -170,6 +170,10 @@ void gather<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
                               const Tensor<fp32_fast_fp16_t> &dst);
 
 template
+void gather<fp32_fast_bf16_t>(const Tensor<fp32_fast_bf16_t> &src,
+                              const Tensor<fp32_fast_bf16_t> &dst);
+
+template
 void gather<fp64_t>(const Tensor<fp64_t> &src, const Tensor<fp64_t> &dst);
 
 template

--- a/src/tensor/scatter.cc
+++ b/src/tensor/scatter.cc
@@ -200,6 +200,10 @@ void scatter<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
                                const Tensor<fp32_fast_fp16_t> &dst);
 
 template
+void scatter<fp32_fast_bf16_t>(const Tensor<fp32_fast_bf16_t> &src,
+                               const Tensor<fp32_fast_bf16_t> &dst);
+
+template
 void scatter<fp64_t>(const Tensor<fp64_t> &src, const Tensor<fp64_t> &dst);
 
 template

--- a/src/tile/clear.cc
+++ b/src/tile/clear.cc
@@ -47,6 +47,9 @@ template
 void clear_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &tile);
 
 template
+void clear_async<fp32_fast_bf16_t>(const Tile<fp32_fast_bf16_t> &tile);
+
+template
 void clear_async<fp64_t>(const Tile<fp64_t> &tile);
 
 // Explicit instantiation
@@ -61,6 +64,9 @@ void clear<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &tile);
 
 template
 void clear<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &tile);
+
+template
+void clear<fp32_fast_bf16_t>(const Tile<fp32_fast_bf16_t> &tile);
 
 template
 void clear<fp64_t>(const Tile<fp64_t> &tile);

--- a/src/tile/fill.cc
+++ b/src/tile/fill.cc
@@ -52,6 +52,9 @@ template
 void fill_async<fp32_fast_fp16_t>(Scalar val, const Tile<fp32_fast_fp16_t> &A);
 
 template
+void fill_async<fp32_fast_bf16_t>(Scalar val, const Tile<fp32_fast_bf16_t> &A);
+
+template
 void fill_async<fp64_t>(Scalar val, const Tile<fp64_t> &A);
 
 // Explicit instantiation
@@ -66,6 +69,9 @@ void fill<fp32_fast_tf32_t>(Scalar val, const Tile<fp32_fast_tf32_t> &A);
 
 template
 void fill<fp32_fast_fp16_t>(Scalar val, const Tile<fp32_fast_fp16_t> &A);
+
+template
+void fill<fp32_fast_bf16_t>(Scalar val, const Tile<fp32_fast_bf16_t> &A);
 
 template
 void fill<fp64_t>(Scalar val, const Tile<fp64_t> &A);

--- a/wrappers/python/examples/gpt2_training.py
+++ b/wrappers/python/examples/gpt2_training.py
@@ -68,8 +68,8 @@ parser.add_argument(
 parser.add_argument("--torch-compile", action="store_true")
 parser.add_argument(
     "--nntile-dtype", choices=["fp32", "fp64", "tf32",
-                               "bf16", "fp32_fast_fp16"], default="fp32"
-)
+                               "bf16", "fp32_fast_fp16",
+                               "fp32_fast_bf16"], default="fp32")
 parser.add_argument("--check", action="store_true")
 parser.add_argument("--check-fp64", action="store_true")
 parser.add_argument("--torch-nforward", type=int, default=0)

--- a/wrappers/python/nntile/functions.py
+++ b/wrappers/python/nntile/functions.py
@@ -286,6 +286,8 @@ def fill_async(val: float, x: Tensor) -> None:
         core_tensor.fill_async_fp32_fast_tf32(val, x)
     elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
         core_tensor.fill_async_fp32_fast_fp16(val, x)
+    elif type(x) is core_tensor.Tensor_fp32_fast_bf16:
+        core_tensor.fill_async_fp32_fast_bf16(val, x)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.fill_async_fp64(val, x)
     elif type(x) is core_tensor.Tensor_bf16:
@@ -685,6 +687,8 @@ def scatter_async(x: TensorFloatOrInt, y: TensorFloatOrInt) -> None:
         core_tensor.scatter_async_bool(x, y)
     elif type(x) is core_tensor.Tensor_bf16:
         core_tensor.scatter_async_bf16(x, y)
+    elif type(x) is core_tensor.Tensor_fp32_fast_bf16:
+        core_tensor.scatter_async_fp32_fast_bf16(x, y)
     else:
         raise TypeError
 
@@ -1065,6 +1069,8 @@ def gather_async(x: TensorFloatOrInt, y: TensorFloatOrInt) -> None:
         core_tensor.gather_async_bool(x, y)
     elif type(x) is core_tensor.Tensor_bf16:
         core_tensor.gather_async_bf16(x, y)
+    elif type(x) is core_tensor.Tensor_fp32_fast_bf16:
+        core_tensor.gather_async_fp32_fast_bf16(x, y)
     else:
         raise TypeError
 
@@ -1124,6 +1130,8 @@ def clear_async(x: Tensor) -> None:
         core_tensor.clear_async_fp32_fast_tf32(x)
     elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
         core_tensor.clear_async_fp32_fast_fp16(x)
+    elif type(x) is core_tensor.Tensor_fp32_fast_bf16:
+        core_tensor.clear_async_fp32_fast_bf16(x)
     elif type(x) is core_tensor.Tensor_fp64:
         core_tensor.clear_async_fp64(x)
     elif type(x) is core_tensor.Tensor_bf16:

--- a/wrappers/python/nntile/model/gpt2.py
+++ b/wrappers/python/nntile/model/gpt2.py
@@ -26,8 +26,9 @@ from nntile.layer.cache_utils import KVCache
 from nntile.model.base_model import BaseModel
 from nntile.model.generation.llm import LLMGenerationMixin
 from nntile.tensor import (
-    Tensor, Tensor_bf16, Tensor_bool, Tensor_fp32, Tensor_fp32_fast_fp16,
-    Tensor_fp32_fast_tf32, Tensor_int64, TensorMoments, TensorTraits, notrans)
+    Tensor, Tensor_bf16, Tensor_bool, Tensor_fp32, Tensor_fp32_fast_bf16,
+    Tensor_fp32_fast_fp16, Tensor_fp32_fast_tf32, Tensor_int64, TensorMoments,
+    TensorTraits, notrans)
 
 
 class GPT2Config(Dict):
@@ -168,8 +169,11 @@ class GPT2Model(BaseModel, LLMGenerationMixin):
         self.dtype = config["dtype"]
         self.eos_token_id = config["eos_token_id"]
 
-        if self.dtype not in ["fp32", "tf32", "bf16", "fp32_fast_fp16"]:
-            raise TypeError("Only fp32, tf32 and bf16 are"
+        if self.dtype not in ["fp32", "tf32",
+                              "bf16", "fp32_fast_fp16",
+                              "fp32_fast_bf16"]:
+            raise TypeError("Only fp32, tf32, bf16, fp32_fast_fp16,"
+                            "fp32_fast_bf16 are"
                             "supported for weight type")
 
         if self.n_head == 1:
@@ -197,7 +201,8 @@ class GPT2Model(BaseModel, LLMGenerationMixin):
         dtype2tensor_type = {"fp32": Tensor_fp32,
                              "tf32": Tensor_fp32_fast_tf32,
                              "bf16": Tensor_bf16,
-                             "fp32_fast_fp16": Tensor_fp32_fast_fp16
+                             "fp32_fast_fp16": Tensor_fp32_fast_fp16,
+                             "fp32_fast_bf16": Tensor_fp32_fast_bf16
                             }
 
         wte_layer, next_tag = Embedding.generate_simple(

--- a/wrappers/python/nntile/nntile_core.cc
+++ b/wrappers/python/nntile/nntile_core.cc
@@ -237,6 +237,7 @@ void def_mod_tile(py::module_ &m)
     def_class_tile<fp32_t>(m, "Tile_fp32");
     def_class_tile<fp32_fast_tf32_t>(m, "Tile_fp32_fast_tf32");
     def_class_tile<fp32_fast_fp16_t>(m, "Tile_fp32_fast_fp16");
+    def_class_tile<fp32_fast_bf16_t>(m, "Tile_fp32_fast_bf16");
     def_class_tile<fp64_t>(m, "Tile_fp64");
     def_class_tile<bf16_t>(m, "Tile_bf16");
 }
@@ -480,6 +481,7 @@ void def_mod_tensor(py::module_ &m)
     def_class_tensor<fp64_t>(m, "Tensor_fp64");
     def_class_tensor<fp32_fast_tf32_t>(m, "Tensor_fp32_fast_tf32");
     def_class_tensor<fp32_fast_fp16_t>(m, "Tensor_fp32_fast_fp16");
+    def_class_tensor<fp32_fast_bf16_t>(m, "Tensor_fp32_fast_bf16");
     def_class_tensor<fp32_t>(m, "Tensor_fp32");
     def_class_tensor<bf16_t>(m, "Tensor_bf16");
     // def_class_tensor<fp16_t>(m, "Tensor_fp16");
@@ -556,11 +558,13 @@ void def_mod_tensor(py::module_ &m)
     m.def("fill_async_fp32", &fill_async<fp32_t>);
     m.def("fill_async_fp32_fast_tf32", &fill_async<fp32_fast_tf32_t>);
     m.def("fill_async_fp32_fast_fp16", &fill_async<fp32_fast_fp16_t>);
+    m.def("fill_async_fp32_fast_bf16", &fill_async<fp32_fast_bf16_t>);
     m.def("fill_fp64", &fill<fp64_t>);
     m.def("fill_bf16", &fill<bf16_t>);
     m.def("fill_fp32", &fill<fp32_t>);
     m.def("fill_fp32_fast_tf32", &fill<fp32_fast_tf32_t>);
     m.def("fill_fp32_fast_fp16", &fill<fp32_fast_fp16_t>);
+    m.def("fill_fp32_fast_bf16", &fill<fp32_fast_bf16_t>);
 
     m.def("sum_slice_async_fp64", &sum_slice_async<fp64_t>);
     m.def("sum_slice_async_bf16", &sum_slice_async<bf16_t>);
@@ -663,11 +667,13 @@ void def_mod_tensor(py::module_ &m)
     m.def("scatter_async_int64", &scatter_async<nntile::int64_t>);
     m.def("scatter_async_bool", &scatter_async<bool_t>);
     m.def("scatter_async_bf16", &scatter_async<bf16_t>);
+    m.def("scatter_async_fp32_fast_bf16", &scatter_async<fp32_fast_bf16_t>);
     m.def("scatter_fp64", &scatter<fp64_t>);
     m.def("scatter_fp32", &scatter<fp32_t>);
     m.def("scatter_int64", &scatter<nntile::int64_t>);
     m.def("scatter_bool", &scatter<bool_t>);
     m.def("scatter_bf16", &scatter<bf16_t>);
+    m.def("scatter_fp32_fast_bf16", &scatter<fp32_fast_bf16_t>);
 
     m.def("randn_async_fp64", &randn_async<fp64_t>);
     m.def("randn_async_fp32", &randn_async<fp32_t>);
@@ -824,11 +830,13 @@ void def_mod_tensor(py::module_ &m)
     m.def("gather_async_int64", &gather_async<nntile::int64_t>);
     m.def("gather_async_bool", &gather_async<bool_t>);
     m.def("gather_async_bf16", &gather_async<bf16_t>);
+    m.def("gather_async_fp32_fast_bf16", &gather_async<fp32_fast_bf16_t>);
     m.def("gather_fp64", &gather<fp64_t>);
     m.def("gather_fp32", &gather<fp32_t>);
     m.def("gather_int64", &gather<nntile::int64_t>);
     m.def("gather_bool", &gather<bool_t>);
     m.def("gather_bf16", &gather<bf16_t>);
+    m.def("gather_fp32_fast_bf16", &gather<fp32_fast_bf16_t>);
 
     m.def("copy_intersection_async_bool", &copy_intersection_async<bool_t>);
     m.def("copy_intersection_async_fp64", &copy_intersection_async<fp64_t>);
@@ -858,6 +866,7 @@ void def_mod_tensor(py::module_ &m)
     m.def("clear_async_fp32", &clear_async<fp32_t>);
     m.def("clear_async_fp32_fast_tf32", &clear_async<fp32_fast_tf32_t>);
     m.def("clear_async_fp32_fast_fp16", &clear_async<fp32_fast_fp16_t>);
+    m.def("clear_async_fp32_fast_bf16", &clear_async<fp32_fast_bf16_t>);
     m.def("clear_async_bf16", &clear_async<bf16_t>);
     //m.def("clear_async_fp16", &clear_async<fp16_t>);
     m.def("clear_fp64", &clear<fp64_t>);
@@ -865,6 +874,7 @@ void def_mod_tensor(py::module_ &m)
     m.def("clear_bf16", &clear<bf16_t>);
     m.def("clear_fp32_fast_tf32", &clear<fp32_fast_tf32_t>);
     m.def("clear_fp32_fast_fp16", &clear<fp32_fast_fp16_t>);
+    m.def("clear_fp32_fast_bf16", &clear<fp32_fast_bf16_t>);
     //m.def("clear_fp16", &clear<fp16_t>);
 
     m.def("axpy_async_fp64", py::overload_cast<Scalar, const Tensor<fp64_t>&,

--- a/wrappers/python/nntile/tensor.py
+++ b/wrappers/python/nntile/tensor.py
@@ -17,7 +17,8 @@
 from .functions import *
 from .nntile_core import TransOp, notrans, trans
 from .nntile_core.tensor import (
-    Tensor_bf16, Tensor_bool, Tensor_fp32, Tensor_fp32_fast_fp16,
-    Tensor_fp32_fast_tf32, Tensor_fp64, Tensor_int64, TensorTraits)
+    Tensor_bf16, Tensor_bool, Tensor_fp32, Tensor_fp32_fast_bf16,
+    Tensor_fp32_fast_fp16, Tensor_fp32_fast_tf32, Tensor_fp64, Tensor_int64,
+    TensorTraits)
 from .types import *
 from .utils.constructors import *


### PR DESCRIPTION
This PR aims to add support for training the gpt2 model in the fp32_fast_bf16 type, i.e., all operations are in the fp32 type, but gemm will be done in bf16 via proper calling CUDA kernel for it.