### PR TITLE
Install Python dependencies with `uv` in CI pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @daskol

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -203,20 +203,19 @@ jobs:
           ln -rs \
             build/wrappers/python/nntile/nntile_core.so \
             wrappers/python/nntile/nntile_core.so
-      # TODO(@daskol): Clean up and prepare `pyproject.toml` for packaging and
-      # proper dependency resolution. We must reuse dependency list from
-      # `pyproject.toml`.
+      # TODO(@daskol): We should rely on `uv` or any other package managing
+      # utility here.
       - name: Install Python dependencies
         run: |
-          python -m pip install -U pip
-          # Mandatory dependencies.
-          python -m pip install fastapi 'numpy<2' pydantic uvicorn
-          # Optional dependencies.
-          python -m pip install -i https://download.pytorch.org/whl/cpu \
-            torch torchvision
-          python -m pip install datasets scipy tokenizers transformers sentencepiece
-          # Testing dependencies.
-          python -m pip install mypy 'pytest>=8.2' pytest-cov pytest-dirty
+          # Use `uv` for syncing dependencies directly from `pyproject.toml`
+          # (but without`uv.lock` file at the moment).
+          python -m pip install uv --root-user-action=ignore
+          uv sync --extra ci --extra test \
+            --no-install-project --no-build-isolation \
+            --default-index https://download.pytorch.org/whl/cpu \
+            --index https://download.pytorch.org/whl/cpu \
+            --index https://pypi.org/simple \
+            --index-strategy unsafe-best-match
       - name: Run dirty tests with PyTest
         if: 'github.event.pull_request'
         run: |

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -155,20 +155,19 @@ jobs:
           ln -rs \
             build/wrappers/python/nntile/nntile_core.so \
             wrappers/python/nntile/nntile_core.so
-      # TODO(@daskol): Clean up and prepare `pyproject.toml` for packaging and
-      # proper dependency resolution. We must reuse dependency list from
-      # `pyproject.toml`.
+      # TODO(@daskol): We should rely on `uv` or any other package managing
+      # utility here.
       - name: Install Python dependencies
         run: |
-          python -m pip install -U pip
-          # Mandatory dependencies.
-          python -m pip install fastapi 'numpy<2' pydantic uvicorn
-          # Optional dependencies.
-          python -m pip install -i https://download.pytorch.org/whl/cpu \
-            torch torchvision
-          python -m pip install datasets scipy tokenizers transformers
-          # Testing dependencies.
-          python -m pip install mypy 'pytest>=8.2' pytest-cov pytest-dirty
+          # Use `uv` for syncing dependencies directly from `pyproject.toml`
+          # (but without`uv.lock` file at the moment).
+          python -m pip install uv --root-user-action=ignore
+          uv sync --extra ci --extra test \
+            --no-install-project --no-build-isolation \
+            --default-index https://download.pytorch.org/whl/cpu \
+            --index https://download.pytorch.org/whl/cpu \
+            --index https://pypi.org/simple \
+            --index-strategy unsafe-best-match
       - name: Run all tests with PyTest
         run: |
           export PYTHON_TAG=$(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,15 @@ classifiers = [
 ]
 dependencies = [
     "fastapi",
+    "numpy>=1.21",
+    "numpy>=1.21.2; python_version>='3.10'",
+    "numpy>=1.23.3; python_version>='3.11'",
+    "numpy>=1.26.0; python_version>='3.12'",
+    "numpy>=2.1.0; python_version>='3.13'",
     "pydantic",
-    "numpy",
+    "scipy",
+    "torch",
+    "transformers",
     "typing_extensions>=4.6.0; python_version<'3.12'",
     "uvicorn",
 ]
@@ -58,7 +65,22 @@ requires-python = ">=3.10,<4"
 [project.optional-dependencies]
 dev = ["isort", "mypy", "ruff"]
 test = [
-    "datasets", "pytest>=8.2", "scipy", "torch", "torchvision", "transformers",
+    "datasets", "pytest>=8.2", "sentencepiece", "tokenizers", "torchvision",
+]
+ci = [
+    "mypy",
+    "pytest-cov",
+    "pytest-dirty",
+    # Fancy-pancy `uv` is absolute nightmare. It resolve dependencies across
+    # all extra dependencies and extra index URLs. Consequently, it resolve
+    # mandatory dependency `torch` to `torch==2.7.1+cpu` since it is
+    # explicitely specified in extras despite tha is extra (i.e. optional).
+    # Wtf?!
+    "torch==2.7.1+cpu",
+    # For some reason, PyTorch's package index provides only cp313 wheel for
+    # `markupsafe==3.0.2` and `uv` could to discover older version and fails!
+    # Wtf!?
+    "markupsafe<3",
 ]
 
 [project.urls]


### PR DESCRIPTION
Related to #231.

Silence annoying nightly build failures like [this one][1].

[1]: https://github.com/nntile/nntile/actions/runs/15503852547/job/43656071300