### PR TITLE
Test add_scalar kernel operation and update docs

### DIFF
--- a/src/kernel/add_scalar/cpu.cc
+++ b/src/kernel/add_scalar/cpu.cc
@@ -19,22 +19,25 @@ namespace nntile::kernel::add_scalar
 {
 
 template<typename T>
-void cpu(Index num_elements, Scalar alpha_, Scalar beta_, T* dst)
+void cpu(Index num_elements, Scalar alpha, Scalar beta, T* dst)
     noexcept
-//! Add scalar to buffer buffers on CPU
-/*! dst[i] = alpha + beta*dst[i], where alpha and beta are scalars
+//! Add scalar to buffer on CPU
+/*! Perform element-wise operation: dst[i] = alpha + beta * dst[i]
  *
- * @param[in] num_elements: Size of the src and dst tensors
- * @param[in] alpha_: Scalar bias for the dst tensor
- * @param[in] beta_: Scalar multiplier for the dst tensor
- * @param[inout] dst_: Destination of the add_scalar operation
+ * This operation modifies the destination buffer in-place by adding a scalar
+ * value (alpha) and scaling the existing values by a scalar factor (beta).
+ *
+ * @param[in] num_elements: Number of elements in the destination buffer
+ * @param[in] alpha: Scalar value to add to each element
+ * @param[in] beta: Scalar multiplier for each element before adding alpha
+ * @param[inout] dst: Destination buffer to modify in-place
  * */
 {
     using Y = typename T::repr_t;
-    const Y alpha{alpha_}, beta{beta_};
+    const Y alpha_val{alpha}, beta_val{beta};
     for(Index i = 0; i < num_elements; ++i)
     {
-        dst[i] = T{alpha + beta*Y{dst[i]}};
+        dst[i] = T{alpha_val + beta_val * Y{dst[i]}};
     }
 }
 
@@ -45,6 +48,10 @@ void cpu<fp32_t>(Index num_elements, Scalar alpha, Scalar beta, fp32_t* dst)
 
 template
 void cpu<fp64_t>(Index num_elements, Scalar alpha, Scalar beta, fp64_t* dst)
+    noexcept;
+
+template
+void cpu<fp16_t>(Index num_elements, Scalar alpha, Scalar beta, fp16_t* dst)
     noexcept;
 
 template

--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -18,7 +18,6 @@ set(TESTS
     "add_fiber"
     "add_fiber_inplace"
     "add_inplace"
-    "add_scalar"
     "add_slice"
     "add_slice_inplace"
     "addcdiv"
@@ -78,7 +77,6 @@ set(TESTS
 # Describe all tests that are not yet implemented
 set(TESTS_NOT_IMPLEMENTED
     "accumulate_maxsumexp"
-    "add_scalar"
     "add_slice"
     "conv2d_bwd_input_inplace"
     "conv2d_bwd_weight_inplace"
@@ -138,6 +136,7 @@ endforeach()
 set(TESTS_CATCH2
     "adam_step"
     "adamw_step"
+    "add_scalar"
 )
 
 foreach(test IN LISTS TESTS_CATCH2)

--- a/tests/kernel/add_scalar.cc
+++ b/tests/kernel/add_scalar.cc
@@ -7,21 +7,331 @@
  * distributed-memory heterogeneous systems based on StarPU runtime system.
  *
  * @file tests/kernel/add_scalar.cc
- * Placeholder for add_scalar kernel test
+ * Add scalar operation on buffer
  *
  * @version 1.1.0
  * */
 
+// Corresponding header
 #include "nntile/kernel/add_scalar.hh"
-#include "../testing.hh"
-#include <iostream>
 
+// Standard libraries
+#include <vector>
+#include <stdexcept>
+#include <limits>
+#include <iostream>
+#include <cmath>
+#include <random>
+#include <string>
+
+// Third-party libraries
+#include <catch2/catch_all.hpp>
+
+// Use namespaces for shorter code
+using namespace Catch;
+
+// Use tested NNTile namespaces
 using namespace nntile;
 using namespace nntile::kernel;
+using namespace nntile::kernel::add_scalar;
 
-int main(int argc, char **argv)
+// Type to acquire reference values
+using ref_t = double;
+
+// Struct to hold test data and reference results
+template<typename T>
+struct TestData
 {
-    // This is a placeholder test.
-    std::cout << "STUB: This is a placeholder for the add_scalar kernel test." << std::endl;
-    return 0;
+    using Y = typename T::repr_t;
+    Index num_elems; // Number of data elements
+    Scalar alpha;
+    Scalar beta;
+    Scalar eps_check;
+
+    std::vector<T> dst_init;
+    std::vector<T> dst_ref;
+};
+
+// Reference implementation of the add_scalar operation
+template<typename T>
+void reference_add_scalar(TestData<T>& data)
+{
+    using Y = typename T::repr_t;
+    if (data.num_elems == 0)
+    {
+        return;
+    }
+    const ref_t alpha_r = data.alpha;
+    const ref_t beta_r = data.beta;
+
+    for(Index i = 0; i < data.num_elems; ++i)
+    {
+        ref_t dst_val = static_cast<Y>(data.dst_init[i]);
+        ref_t result = alpha_r + beta_r * dst_val;
+        data.dst_ref[i] = static_cast<T>(static_cast<Y>(result));
+    }
+}
+
+// Enum for data generation strategies
+enum class DataGen
+{
+    PRESET,
+    RANDOM
+};
+
+// Generates data with preset, deterministic values
+template<typename T>
+void generate_data(TestData<T>& data, Index num_elems, DataGen strategy)
+{
+    using Y = typename T::repr_t;
+    data.num_elems = num_elems;
+
+    data.dst_init.resize(num_elems);
+
+    switch(strategy)
+    {
+        // Non-random input generation
+        case DataGen::PRESET:
+            for(Index i = 0; i < num_elems; ++i)
+            {
+                data.dst_init[i] = Y(2 * i + 1 - num_elems);
+            }
+            break;
+        // Specific random initialization
+        case DataGen::RANDOM:
+            std::mt19937 gen(42);
+            std::uniform_real_distribution<Y> dist(-2.0, 2.0);
+            for(Index i = 0; i < num_elems; ++i)
+            {
+                data.dst_init[i] = dist(gen);
+            }
+    }
+}
+
+// Get test data and reference results
+template<typename T>
+TestData<T> get_test_data(
+    Index num_elems,
+    Scalar alpha,
+    Scalar beta,
+    DataGen strategy
+)
+{
+    TestData<T> data;
+    // Generate data by a provided strategy
+    generate_data(data, num_elems, strategy);
+    // Fill in remaining fields of TestData
+    data.alpha = alpha;
+    data.beta = beta;
+    // Set accuracy threshold for each precision
+    if (std::is_same_v<T, bf16_t>)
+    {
+        data.eps_check = 1e-1;
+    }
+    else if (std::is_same_v<T, fp16_t>)
+    {
+        data.eps_check = 1e-2;
+    }
+    else if (std::is_same_v<T, fp32_t>)
+    {
+        data.eps_check = 3.1e-3;
+    }
+    else if (std::is_same_v<T, fp64_t>)
+    {
+        data.eps_check = 1e-7;
+    }
+    else
+    {
+        throw std::runtime_error("Unsupported data type");
+    }
+    // Compute reference outputs
+    data.dst_ref = data.dst_init;
+    reference_add_scalar(data);
+    return data;
+}
+
+// Helper function to verify results
+template<typename T>
+void verify_results(
+    const TestData<T>& data,
+    const std::vector<T>& dst_out
+)
+{
+    using Y = typename T::repr_t;
+    for(Index i = 0; i < data.num_elems; ++i)
+    {
+        Y dst_ref = static_cast<Y>(data.dst_ref[i]);
+        auto dst_approx = Approx(dst_ref).epsilon(data.eps_check);
+        REQUIRE(static_cast<Y>(dst_out[i]) == dst_approx);
+    }
+}
+
+// Helper function to run CPU test and verify results
+template<typename T, bool run_bench>
+void run_cpu_test(TestData<T>& data)
+{
+    std::vector<T> dst_cpu(data.dst_init);
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][add_scalar][cpu][nelems=" +
+            std::to_string(data.num_elems) +
+            "][alpha=" +
+            std::to_string(data.alpha) +
+            "][beta=" +
+            std::to_string(data.beta) +
+            "]"
+        )
+        {
+            cpu<T>(
+                data.num_elems,
+                data.alpha,
+                data.beta,
+                &dst_cpu[0]
+            );
+        };
+    }
+    else
+    {
+        cpu<T>(
+            data.num_elems,
+            data.alpha,
+            data.beta,
+            &dst_cpu[0]
+        );
+        verify_results(data, dst_cpu);
+    }
+}
+
+#ifdef NNTILE_USE_CUDA
+// Helper function to run CUDA test and verify results
+template<typename T, bool run_bench>
+void run_cuda_test(TestData<T>& data)
+{
+    T *dev_dst;
+    cudaMalloc(&dev_dst, sizeof(T) * data.num_elems);
+
+    std::vector<T> dst_cuda(data.dst_init);
+
+    cudaMemcpy(dev_dst, &dst_cuda[0], sizeof(T) * data.num_elems,
+        cudaMemcpyHostToDevice);
+
+    cudaStream_t stream;
+    cudaStreamCreate(&stream);
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][add_scalar][cuda][nelems=" +
+            std::to_string(data.num_elems) +
+            "][alpha=" +
+            std::to_string(data.alpha) +
+            "][beta=" +
+            std::to_string(data.beta) +
+            "]"
+        )
+        {
+            cuda<T>(
+                stream,
+                data.num_elems,
+                data.alpha,
+                data.beta,
+                dev_dst
+            );
+            cudaStreamSynchronize(stream);
+        };
+    }
+    else
+    {
+        cuda<T>(
+            stream,
+            data.num_elems,
+            data.alpha,
+            data.beta,
+            dev_dst
+        );
+        cudaStreamSynchronize(stream);
+
+        cudaMemcpy(&dst_cuda[0], dev_dst, sizeof(T) * data.num_elems,
+            cudaMemcpyDeviceToHost);
+
+        verify_results(data, dst_cuda);
+    }
+
+    cudaFree(dev_dst);
+    cudaStreamDestroy(stream);
+}
+#endif
+
+// Catch2-based tests
+TEMPLATE_TEST_CASE(
+    "Add Scalar Kernel Verification",
+    "[add_scalar]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index num_elems = GENERATE(5, 129);
+    const Scalar alpha = GENERATE(-2.0, -1.0, 0.0, 1.0, 2.0);
+    const Scalar beta = GENERATE(0.5, 1.0, 2.0);
+    const DataGen strategy = GENERATE(DataGen::PRESET, DataGen::RANDOM);
+
+    auto data = get_test_data<T>(
+        num_elems,
+        alpha,
+        beta,
+        strategy
+    );
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, false>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, false>(data);
+    }
+#endif
+}
+
+// Catch2-based benchmarks
+TEMPLATE_TEST_CASE(
+    "Add Scalar Kernel Benchmark",
+    "[add_scalar][!benchmark]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index num_elems = GENERATE(512, 1024*1024, 4096*16384);
+    const Scalar alpha = GENERATE(1.0);
+    const Scalar beta = GENERATE(1.0);
+    const DataGen strategy = GENERATE(DataGen::PRESET);
+
+    auto data = get_test_data<T>(
+        num_elems,
+        alpha,
+        beta,
+        strategy
+    );
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, true>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, true>(data);
+    }
+#endif
 }


### PR DESCRIPTION
Add comprehensive Catch2 tests for the `add_scalar` kernel, including `fp16_t` support and updated docstrings.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8f527fb-9b30-4a50-9fd8-63e5ce52630c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8f527fb-9b30-4a50-9fd8-63e5ce52630c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

