### PR TITLE
Add cuda error checking and tests

### DIFF
--- a/include/nntile/kernel/cuda.hh
+++ b/include/nntile/kernel/cuda.hh
@@ -122,6 +122,15 @@ const typename CUDAComputeType<T>::value *cast_pointer_cuda(const T *ptr)
     return reinterpret_cast<const typename CUDAComputeType<T>::value *>(ptr);
 }
 
+//! Check CUDA error and throw runtime_error if error occurs
+#define CUDA_CHECK(error, message) \
+    do { \
+        cudaError_t _err = (error); \
+        if (_err != cudaSuccess) { \
+            throw std::runtime_error(std::string(message) + ": " + cudaGetErrorString(_err)); \
+        } \
+    } while (0)
+
 } // namespace nntile::kernel
 
 #endif // NNTILE_USE_CUDA

--- a/tests/kernel/adam_step.cc
+++ b/tests/kernel/adam_step.cc
@@ -282,54 +282,38 @@ void run_cpu_test(TestData<T>& data)
 }
 
 #ifdef NNTILE_USE_CUDA
-// Helper function to check CUDA errors
-void check_cuda_error(cudaError_t error, const char* message)
-{
-    if (error != cudaSuccess)
-    {
-        throw std::runtime_error(std::string(message) + ": " + cudaGetErrorString(error));
-    }
-}
 
 // Helper function to run CUDA test and verify results
 template<typename T, bool run_bench>
 void run_cuda_test(TestData<T>& data)
 {
     T *dev_grad, *dev_first_moment, *dev_second_moment, *dev_p;
-    check_cuda_error(cudaMalloc(&dev_grad, sizeof(T) * data.num_elems),
-                     "cudaMalloc dev_grad");
-    check_cuda_error(cudaMalloc(&dev_first_moment,
-                               sizeof(T) * data.num_elems),
-                     "cudaMalloc dev_first_moment");
-    check_cuda_error(cudaMalloc(&dev_second_moment,
-                               sizeof(T) * data.num_elems),
-                     "cudaMalloc dev_second_moment");
-    check_cuda_error(cudaMalloc(&dev_p, sizeof(T) * data.num_elems),
-                     "cudaMalloc dev_p");
+    CUDA_CHECK(cudaMalloc(&dev_grad, sizeof(T) * data.num_elems),
+               "cudaMalloc dev_grad");
+    CUDA_CHECK(cudaMalloc(&dev_first_moment, sizeof(T) * data.num_elems),
+               "cudaMalloc dev_first_moment");
+    CUDA_CHECK(cudaMalloc(&dev_second_moment, sizeof(T) * data.num_elems),
+               "cudaMalloc dev_second_moment");
+    CUDA_CHECK(cudaMalloc(&dev_p, sizeof(T) * data.num_elems),
+               "cudaMalloc dev_p");
 
     std::vector<T> p_cuda(data.p_init);
     std::vector<T> first_moment_cuda(data.first_moment_init);
     std::vector<T> second_moment_cuda(data.second_moment_init);
 
-    check_cuda_error(cudaMemcpy(dev_grad, &data.grad[0],
-                               sizeof(T) * data.num_elems,
-                               cudaMemcpyHostToDevice),
-                     "cudaMemcpy dev_grad");
-    check_cuda_error(cudaMemcpy(dev_first_moment, &first_moment_cuda[0],
-                               sizeof(T) * data.num_elems,
-                               cudaMemcpyHostToDevice),
-                     "cudaMemcpy dev_first_moment");
-    check_cuda_error(cudaMemcpy(dev_second_moment, &second_moment_cuda[0],
-                               sizeof(T) * data.num_elems,
-                               cudaMemcpyHostToDevice),
-                     "cudaMemcpy dev_second_moment");
-    check_cuda_error(cudaMemcpy(dev_p, &p_cuda[0],
-                               sizeof(T) * data.num_elems,
-                               cudaMemcpyHostToDevice),
-                     "cudaMemcpy dev_p");
+    CUDA_CHECK(cudaMemcpy(dev_grad, &data.grad[0], sizeof(T) * data.num_elems,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_grad");
+    CUDA_CHECK(cudaMemcpy(dev_first_moment, &first_moment_cuda[0],
+                          sizeof(T) * data.num_elems, cudaMemcpyHostToDevice),
+               "cudaMemcpy dev_first_moment");
+    CUDA_CHECK(cudaMemcpy(dev_second_moment, &second_moment_cuda[0],
+                          sizeof(T) * data.num_elems, cudaMemcpyHostToDevice),
+               "cudaMemcpy dev_second_moment");
+    CUDA_CHECK(cudaMemcpy(dev_p, &p_cuda[0], sizeof(T) * data.num_elems,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_p");
 
     cudaStream_t stream;
-    check_cuda_error(cudaStreamCreate(&stream), "cudaStreamCreate");
+    CUDA_CHECK(cudaStreamCreate(&stream), "cudaStreamCreate");
 
     if constexpr (run_bench)
     {
@@ -374,33 +358,25 @@ void run_cuda_test(TestData<T>& data)
             dev_second_moment,
             dev_p
         );
-        check_cuda_error(cudaStreamSynchronize(stream),
-                         "cudaStreamSynchronize");
+        CUDA_CHECK(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
 
-        check_cuda_error(cudaMemcpy(&first_moment_cuda[0], dev_first_moment,
-                                   sizeof(T) * data.num_elems,
-                                   cudaMemcpyDeviceToHost),
-                         "cudaMemcpy first_moment_cuda");
-        check_cuda_error(cudaMemcpy(&second_moment_cuda[0], dev_second_moment,
-                                   sizeof(T) * data.num_elems,
-                                   cudaMemcpyDeviceToHost),
-                         "cudaMemcpy second_moment_cuda");
-        check_cuda_error(cudaMemcpy(&p_cuda[0], dev_p,
-                                   sizeof(T) * data.num_elems,
-                                   cudaMemcpyDeviceToHost),
-                         "cudaMemcpy p_cuda");
+        CUDA_CHECK(cudaMemcpy(&first_moment_cuda[0], dev_first_moment,
+                              sizeof(T) * data.num_elems, cudaMemcpyDeviceToHost),
+                   "cudaMemcpy first_moment_cuda");
+        CUDA_CHECK(cudaMemcpy(&second_moment_cuda[0], dev_second_moment,
+                              sizeof(T) * data.num_elems, cudaMemcpyDeviceToHost),
+                   "cudaMemcpy second_moment_cuda");
+        CUDA_CHECK(cudaMemcpy(&p_cuda[0], dev_p, sizeof(T) * data.num_elems,
+                              cudaMemcpyDeviceToHost), "cudaMemcpy p_cuda");
 
         verify_results(data, p_cuda, first_moment_cuda, second_moment_cuda);
     }
 
-    check_cuda_error(cudaFree(dev_grad), "cudaFree dev_grad");
-    check_cuda_error(cudaFree(dev_first_moment),
-                     "cudaFree dev_first_moment");
-    check_cuda_error(cudaFree(dev_second_moment),
-                     "cudaFree dev_second_moment");
-    check_cuda_error(cudaFree(dev_p), "cudaFree dev_p");
-    check_cuda_error(cudaStreamDestroy(stream),
-                     "cudaStreamDestroy");
+    CUDA_CHECK(cudaFree(dev_grad), "cudaFree dev_grad");
+    CUDA_CHECK(cudaFree(dev_first_moment), "cudaFree dev_first_moment");
+    CUDA_CHECK(cudaFree(dev_second_moment), "cudaFree dev_second_moment");
+    CUDA_CHECK(cudaFree(dev_p), "cudaFree dev_p");
+    CUDA_CHECK(cudaStreamDestroy(stream), "cudaStreamDestroy");
 }
 #endif
 

--- a/tests/kernel/adamw_step.cc
+++ b/tests/kernel/adamw_step.cc
@@ -285,54 +285,38 @@ void run_cpu_test(TestData<T>& data)
 }
 
 #ifdef NNTILE_USE_CUDA
-// Helper function to check CUDA errors
-void check_cuda_error(cudaError_t error, const char* message)
-{
-    if (error != cudaSuccess)
-    {
-        throw std::runtime_error(std::string(message) + ": " + cudaGetErrorString(error));
-    }
-}
 
 // Helper function to run CUDA test and verify results
 template<typename T, bool run_bench>
 void run_cuda_test(TestData<T>& data)
 {
     T *dev_grad, *dev_first_moment, *dev_second_moment, *dev_p;
-    check_cuda_error(cudaMalloc(&dev_grad, sizeof(T) * data.num_elems),
-                     "cudaMalloc dev_grad");
-    check_cuda_error(cudaMalloc(&dev_first_moment,
-                               sizeof(T) * data.num_elems),
-                     "cudaMalloc dev_first_moment");
-    check_cuda_error(cudaMalloc(&dev_second_moment,
-                               sizeof(T) * data.num_elems),
-                     "cudaMalloc dev_second_moment");
-    check_cuda_error(cudaMalloc(&dev_p, sizeof(T) * data.num_elems),
-                     "cudaMalloc dev_p");
+    CUDA_CHECK(cudaMalloc(&dev_grad, sizeof(T) * data.num_elems),
+               "cudaMalloc dev_grad");
+    CUDA_CHECK(cudaMalloc(&dev_first_moment, sizeof(T) * data.num_elems),
+               "cudaMalloc dev_first_moment");
+    CUDA_CHECK(cudaMalloc(&dev_second_moment, sizeof(T) * data.num_elems),
+               "cudaMalloc dev_second_moment");
+    CUDA_CHECK(cudaMalloc(&dev_p, sizeof(T) * data.num_elems),
+               "cudaMalloc dev_p");
 
     std::vector<T> p_cuda(data.p_init);
     std::vector<T> first_moment_cuda(data.first_moment_init);
     std::vector<T> second_moment_cuda(data.second_moment_init);
 
-    check_cuda_error(cudaMemcpy(dev_grad, &data.grad[0],
-                               sizeof(T) * data.num_elems,
-                               cudaMemcpyHostToDevice),
-                     "cudaMemcpy dev_grad");
-    check_cuda_error(cudaMemcpy(dev_first_moment, &first_moment_cuda[0],
-                               sizeof(T) * data.num_elems,
-                               cudaMemcpyHostToDevice),
-                     "cudaMemcpy dev_first_moment");
-    check_cuda_error(cudaMemcpy(dev_second_moment, &second_moment_cuda[0],
-                               sizeof(T) * data.num_elems,
-                               cudaMemcpyHostToDevice),
-                     "cudaMemcpy dev_second_moment");
-    check_cuda_error(cudaMemcpy(dev_p, &p_cuda[0],
-                               sizeof(T) * data.num_elems,
-                               cudaMemcpyHostToDevice),
-                     "cudaMemcpy dev_p");
+    CUDA_CHECK(cudaMemcpy(dev_grad, &data.grad[0], sizeof(T) * data.num_elems,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_grad");
+    CUDA_CHECK(cudaMemcpy(dev_first_moment, &first_moment_cuda[0],
+                          sizeof(T) * data.num_elems, cudaMemcpyHostToDevice),
+               "cudaMemcpy dev_first_moment");
+    CUDA_CHECK(cudaMemcpy(dev_second_moment, &second_moment_cuda[0],
+                          sizeof(T) * data.num_elems, cudaMemcpyHostToDevice),
+               "cudaMemcpy dev_second_moment");
+    CUDA_CHECK(cudaMemcpy(dev_p, &p_cuda[0], sizeof(T) * data.num_elems,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_p");
 
     cudaStream_t stream;
-    check_cuda_error(cudaStreamCreate(&stream), "cudaStreamCreate");
+    CUDA_CHECK(cudaStreamCreate(&stream), "cudaStreamCreate");
 
     if constexpr (run_bench)
     {
@@ -377,33 +361,25 @@ void run_cuda_test(TestData<T>& data)
             dev_second_moment,
             dev_p
         );
-        check_cuda_error(cudaStreamSynchronize(stream),
-                         "cudaStreamSynchronize");
+        CUDA_CHECK(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
 
-        check_cuda_error(cudaMemcpy(&first_moment_cuda[0], dev_first_moment,
-                                   sizeof(T) * data.num_elems,
-                                   cudaMemcpyDeviceToHost),
-                         "cudaMemcpy first_moment_cuda");
-        check_cuda_error(cudaMemcpy(&second_moment_cuda[0], dev_second_moment,
-                                   sizeof(T) * data.num_elems,
-                                   cudaMemcpyDeviceToHost),
-                         "cudaMemcpy second_moment_cuda");
-        check_cuda_error(cudaMemcpy(&p_cuda[0], dev_p,
-                                   sizeof(T) * data.num_elems,
-                                   cudaMemcpyDeviceToHost),
-                         "cudaMemcpy p_cuda");
+        CUDA_CHECK(cudaMemcpy(&first_moment_cuda[0], dev_first_moment,
+                              sizeof(T) * data.num_elems, cudaMemcpyDeviceToHost),
+                   "cudaMemcpy first_moment_cuda");
+        CUDA_CHECK(cudaMemcpy(&second_moment_cuda[0], dev_second_moment,
+                              sizeof(T) * data.num_elems, cudaMemcpyDeviceToHost),
+                   "cudaMemcpy second_moment_cuda");
+        CUDA_CHECK(cudaMemcpy(&p_cuda[0], dev_p, sizeof(T) * data.num_elems,
+                              cudaMemcpyDeviceToHost), "cudaMemcpy p_cuda");
 
         verify_results(data, p_cuda, first_moment_cuda, second_moment_cuda);
     }
 
-    check_cuda_error(cudaFree(dev_grad), "cudaFree dev_grad");
-    check_cuda_error(cudaFree(dev_first_moment),
-                     "cudaFree dev_first_moment");
-    check_cuda_error(cudaFree(dev_second_moment),
-                     "cudaFree dev_second_moment");
-    check_cuda_error(cudaFree(dev_p), "cudaFree dev_p");
-    check_cuda_error(cudaStreamDestroy(stream),
-                     "cudaStreamDestroy");
+    CUDA_CHECK(cudaFree(dev_grad), "cudaFree dev_grad");
+    CUDA_CHECK(cudaFree(dev_first_moment), "cudaFree dev_first_moment");
+    CUDA_CHECK(cudaFree(dev_second_moment), "cudaFree dev_second_moment");
+    CUDA_CHECK(cudaFree(dev_p), "cudaFree dev_p");
+    CUDA_CHECK(cudaStreamDestroy(stream), "cudaStreamDestroy");
 }
 #endif
 


### PR DESCRIPTION
Add a `CUDA_CHECK` macro and refactor kernel tests (`adam_step`, `adamw_step`, `add_scalar`) to use it, centralizing CUDA error handling for improved consistency and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-430c68fb-5a10-4612-988d-32dfff05674f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-430c68fb-5a10-4612-988d-32dfff05674f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

