### PR TITLE
Add kernel tests for accumulate_maxsumexp and others

### DIFF
--- a/src/kernel/accumulate_maxsumexp/cpu.cc
+++ b/src/kernel/accumulate_maxsumexp/cpu.cc
@@ -75,4 +75,8 @@ template
 void cpu<bf16_t>(Index nelems, const bf16_t* src, bf16_t* dst)
     noexcept;
 
+template
+void cpu<fp16_t>(Index nelems, const fp16_t* src, fp16_t* dst)
+    noexcept;
+
 } // namespace nntile::kernel::accumulate_maxsumexp

--- a/src/kernel/accumulate_maxsumexp/cuda.cu
+++ b/src/kernel/accumulate_maxsumexp/cuda.cu
@@ -97,4 +97,9 @@ void cuda<bf16_t>(cudaStream_t stream, Index nelems, const bf16_t *src,
         bf16_t *dst)
     noexcept;
 
+template
+void cuda<fp16_t>(cudaStream_t stream, Index nelems, const fp16_t *src,
+        fp16_t *dst)
+    noexcept;
+
 } // namespace nntile::kernel::accumulate_maxsumexp

--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -13,12 +13,7 @@
 
 # All unit tests without arguments to test executable
 set(TESTS
-    "accumulate_maxsumexp"
     "add"
-    "add_fiber"
-    "add_fiber_inplace"
-    "add_inplace"
-    "add_slice_inplace"
     "addcdiv"
     "conv2d_bwd_input_inplace"
     "conv2d_bwd_weight_inplace"
@@ -60,7 +55,6 @@ set(TESTS
 
 # Describe all tests that are not yet implemented
 set(TESTS_NOT_IMPLEMENTED
-    "accumulate_maxsumexp"
     "conv2d_bwd_input_inplace"
     "conv2d_bwd_weight_inplace"
     "conv2d_inplace"
@@ -102,6 +96,11 @@ foreach(test IN LISTS TESTS)
 endforeach()
 
 set(TESTS_CATCH2
+    "accumulate_maxsumexp"
+    "add_fiber"
+    "add_fiber_inplace"
+    "add_inplace"
+    "add_slice_inplace"
     "adam_step"
     "adamw_step"
     "add_scalar"

--- a/tests/kernel/accumulate_maxsumexp.cc
+++ b/tests/kernel/accumulate_maxsumexp.cc
@@ -12,16 +12,332 @@
  * @version 1.1.0
  * */
 
+// Corresponding header
 #include "nntile/kernel/accumulate_maxsumexp.hh"
-#include "../testing.hh"
-#include <iostream>
 
+// Standard libraries
+#include <vector>
+#include <stdexcept>
+#include <limits>
+#include <iostream>
+#include <cmath>
+#include <random>
+#include <string>
+
+// Third-party libraries
+#include <catch2/catch_all.hpp>
+
+// Other NNTile headers
+// CUDA_CHECK definition
+#include <nntile/kernel/cuda.hh>
+
+// Use namespaces for shorter code
+using namespace Catch;
+using namespace Catch::Matchers;
+
+// Use tested NNTile namespaces
 using namespace nntile;
 using namespace nntile::kernel;
+using namespace nntile::kernel::accumulate_maxsumexp;
 
-int main(int argc, char **argv)
+// Type to acquire reference values
+using ref_t = double;
+
+// Struct to hold test data and reference results
+template<typename T>
+struct TestData
 {
-    // This is a placeholder test.
-    std::cout << "STUB: This is a placeholder for the accumulate_maxsumexp kernel test." << std::endl;
-    return 0;
+    using Y = typename T::repr_t;
+    Index nelems; // Number of (max,sumexp) pairs
+
+    std::vector<T> src;
+    std::vector<T> dst_init;
+
+    std::vector<T> dst_ref;
+};
+
+// Reference implementation of the accumulate maxsumexp operation
+template<typename T>
+void reference_accumulate_maxsumexp(TestData<T>& data)
+{
+    using Y = typename T::repr_t;
+    if (data.nelems == 0)
+    {
+        return;
+    }
+
+    data.dst_ref = data.dst_init; // Copy initial destination
+
+    for(Index i = 0; i < data.nelems; ++i)
+    {
+        const ref_t src_max = static_cast<Y>(data.src[2*i]);
+        const ref_t src_sumexp = static_cast<Y>(data.src[2*i+1]);
+        const ref_t dst_max = static_cast<Y>(data.dst_ref[2*i]);
+        const ref_t dst_sumexp = static_cast<Y>(data.dst_ref[2*i+1]);
+
+        // Do nothing if sum of exponents of source is zero
+        if(src_sumexp != 0.0)
+        {
+            // Overwrite if old value of sum is zero
+            if(dst_sumexp == 0.0)
+            {
+                data.dst_ref[2*i] = data.src[2*i];
+                data.dst_ref[2*i+1] = data.src[2*i+1];
+            }
+            // Otherwise update based on maximum
+            else if(dst_max < src_max)
+            {
+                const ref_t diff = dst_max - src_max;
+                const ref_t new_sumexp = src_sumexp + dst_sumexp * std::exp(diff);
+                data.dst_ref[2*i+1] = static_cast<T>(new_sumexp);
+                data.dst_ref[2*i] = data.src[2*i];
+            }
+            else
+            {
+                const ref_t diff = src_max - dst_max;
+                const ref_t new_sumexp = dst_sumexp + src_sumexp * std::exp(diff);
+                data.dst_ref[2*i+1] = static_cast<T>(new_sumexp);
+            }
+        }
+    }
+}
+
+// Enum for data generation strategies
+enum class DataGen
+{
+    PRESET,
+    RANDOM
+};
+
+// Generates data with preset, deterministic values
+template<typename T>
+void generate_data(TestData<T>& data, Index nelems, DataGen strategy)
+{
+    using Y = typename T::repr_t;
+    data.nelems = nelems;
+
+    data.src.resize(2 * nelems);
+    data.dst_init.resize(2 * nelems);
+    data.dst_ref.resize(2 * nelems);
+
+    switch(strategy)
+    {
+        // Non-random input generation
+        case DataGen::PRESET:
+            for(Index i = 0; i < nelems; ++i)
+            {
+                // Set src values - mix of positive and negative values
+                data.src[2*i] = Y(-2.0 + i * 0.5); // max values
+                data.src[2*i+1] = Y(0.1 + i * 0.1); // sumexp values
+
+                // Set initial dst values
+                data.dst_init[2*i] = Y(-1.0 + i * 0.3); // max values
+                data.dst_init[2*i+1] = Y(0.05 + i * 0.05); // sumexp values
+            }
+            break;
+        // Specific random initialization
+        case DataGen::RANDOM:
+            std::mt19937 gen(42);
+            std::uniform_real_distribution<Y> dist_max(-3.0, 3.0);
+            std::uniform_real_distribution<Y> dist_sumexp(0.01, 2.0);
+            for(Index i = 0; i < nelems; ++i)
+            {
+                data.src[2*i] = dist_max(gen);
+                data.src[2*i+1] = dist_sumexp(gen);
+                data.dst_init[2*i] = dist_max(gen);
+                data.dst_init[2*i+1] = dist_sumexp(gen);
+            }
+            break;
+    }
+}
+
+// Get test data and reference results
+template<typename T>
+TestData<T> get_test_data(Index nelems, DataGen strategy)
+{
+    TestData<T> data;
+    // Generate data by a provided strategy
+    generate_data(data, nelems, strategy);
+
+    // Compute reference outputs
+    reference_accumulate_maxsumexp(data);
+    return data;
+}
+
+// Helper function to verify results
+template<typename T>
+void verify_results(const TestData<T>& data, const std::vector<T>& dst_out)
+{
+    using Y = typename T::repr_t;
+
+    // Set accuracy threshold for each precision
+    ref_t eps_check;
+    if (std::is_same_v<T, bf16_t>)
+    {
+        eps_check = 1e-1;
+    }
+    else if (std::is_same_v<T, fp16_t>)
+    {
+        eps_check = 1e-2;
+    }
+    else if (std::is_same_v<T, fp32_t>)
+    {
+        eps_check = 1e-5;
+    }
+    else if (std::is_same_v<T, fp64_t>)
+    {
+        eps_check = 1e-12;
+    }
+    else
+    {
+        throw std::runtime_error("Unsupported data type");
+    }
+
+    for(Index i = 0; i < data.nelems; ++i)
+    {
+        Y dst_max_ref = static_cast<Y>(data.dst_ref[2*i]);
+        Y dst_sumexp_ref = static_cast<Y>(data.dst_ref[2*i+1]);
+
+        REQUIRE_THAT(
+            static_cast<Y>(dst_out[2*i]),
+            WithinAbs(dst_max_ref, eps_check) || WithinRel(dst_max_ref, eps_check)
+        );
+        REQUIRE_THAT(
+            static_cast<Y>(dst_out[2*i+1]),
+            WithinAbs(dst_sumexp_ref, eps_check) || WithinRel(dst_sumexp_ref, eps_check)
+        );
+    }
+}
+
+// Helper function to run CPU test and verify results
+template<typename T, bool run_bench>
+void run_cpu_test(TestData<T>& data)
+{
+    std::vector<T> dst_cpu(data.dst_init);
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][accumulate_maxsumexp][cpu][nelems=" +
+            std::to_string(data.nelems) +
+            "]"
+        )
+        {
+            cpu<T>(data.nelems, &data.src[0], &dst_cpu[0]);
+        };
+    }
+    else
+    {
+        cpu<T>(data.nelems, &data.src[0], &dst_cpu[0]);
+        verify_results(data, dst_cpu);
+    }
+}
+
+#ifdef NNTILE_USE_CUDA
+
+// Helper function to run CUDA test and verify results
+template<typename T, bool run_bench>
+void run_cuda_test(TestData<T>& data)
+{
+    T *dev_src, *dev_dst;
+    CUDA_CHECK(cudaMalloc(&dev_src, sizeof(T) * 2 * data.nelems),
+               "cudaMalloc dev_src");
+    CUDA_CHECK(cudaMalloc(&dev_dst, sizeof(T) * 2 * data.nelems),
+               "cudaMalloc dev_dst");
+
+    std::vector<T> dst_cuda(data.dst_init);
+
+    CUDA_CHECK(cudaMemcpy(dev_src, &data.src[0], sizeof(T) * 2 * data.nelems,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_src");
+    CUDA_CHECK(cudaMemcpy(dev_dst, &dst_cuda[0], sizeof(T) * 2 * data.nelems,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_dst");
+
+    cudaStream_t stream;
+    CUDA_CHECK(cudaStreamCreate(&stream), "cudaStreamCreate");
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][accumulate_maxsumexp][cuda][nelems=" +
+            std::to_string(data.nelems) +
+            "]"
+        )
+        {
+            cuda<T>(stream, data.nelems, dev_src, dev_dst);
+            cudaStreamSynchronize(stream);
+        };
+    }
+    else
+    {
+        cuda<T>(stream, data.nelems, dev_src, dev_dst);
+        CUDA_CHECK(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
+
+        CUDA_CHECK(cudaMemcpy(&dst_cuda[0], dev_dst, sizeof(T) * 2 * data.nelems,
+                              cudaMemcpyDeviceToHost), "cudaMemcpy dst_cuda");
+
+        verify_results(data, dst_cuda);
+    }
+
+    CUDA_CHECK(cudaFree(dev_src), "cudaFree dev_src");
+    CUDA_CHECK(cudaFree(dev_dst), "cudaFree dev_dst");
+    CUDA_CHECK(cudaStreamDestroy(stream), "cudaStreamDestroy");
+}
+#endif
+
+// Catch2-based tests
+TEMPLATE_TEST_CASE(
+    "Accumulate MaxSumExp Kernel Verification",
+    "[accumulate_maxsumexp]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index nelems = GENERATE(1, 5, 10, 20);
+    const DataGen strategy = GENERATE(DataGen::PRESET, DataGen::RANDOM);
+
+    auto data = get_test_data<T>(nelems, strategy);
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, false>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, false>(data);
+    }
+#endif
+}
+
+// Catch2-based benchmarks
+TEMPLATE_TEST_CASE(
+    "Accumulate MaxSumExp Kernel Benchmark",
+    "[accumulate_maxsumexp][!benchmark]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index nelems = GENERATE(100, 1000, 10000);
+    const DataGen strategy = GENERATE(DataGen::PRESET);
+
+    auto data = get_test_data<T>(nelems, strategy);
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, true>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, true>(data);
+    }
+#endif
 }

--- a/tests/kernel/add_fiber.cc
+++ b/tests/kernel/add_fiber.cc
@@ -12,23 +12,36 @@
  * @version 1.1.0
  * */
 
+// Corresponding header
 #include "nntile/kernel/add_fiber.hh"
-#include "../testing.hh"
+
+// Standard libraries
 #include <vector>
 #include <stdexcept>
 #include <limits>
 #include <iostream>
+#include <cmath>
 #include <random>
-#include "nntile/kernel/cpu.hh"
-#include "nntile/kernel/cuda.hh"
+#include <string>
 
-#ifdef NNTILE_USE_CUDA
-#include <cuda_runtime.h>
-#endif // NNTILE_USE_CUDA
+// Third-party libraries
+#include <catch2/catch_all.hpp>
 
+// Other NNTile headers
+// CUDA_CHECK definition
+#include <nntile/kernel/cuda.hh>
+
+// Use namespaces for shorter code
+using namespace Catch;
+using namespace Catch::Matchers;
+
+// Use tested NNTile namespaces
 using namespace nntile;
 using namespace nntile::kernel;
 using namespace nntile::kernel::add_fiber;
+
+// Type to acquire reference values
+using ref_t = double;
 
 #ifdef NNTILE_USE_CUDA
 template<typename T>
@@ -76,114 +89,320 @@ void run_cuda(Index m, Index n, Index k, Index batch, Scalar alpha,
 }
 #endif // NNTILE_USE_CUDA
 
-// Templated validation
+// Struct to hold test data and reference results
 template<typename T>
-void validate(Index m, Index n, Index k, Index batch)
+struct TestData
 {
     using Y = typename T::repr_t;
-    const Y eps = 2 * T::epsilon;
-    // Init test input
-    Scalar alpha = 1.0;
-    Scalar beta = -1.0;
-    std::vector<T> src1(k*batch), src2(m*n*k*batch), dst(m*n*k*batch);
+    Index m, n, k, batch; // Tensor dimensions
+    Scalar alpha, beta;   // Scalar factors
 
-    // Init random generator
-    std::mt19937 rng(42);
-    std::uniform_real_distribution<Y> dist(-1.0, 1.0);
+    std::vector<T> src1;
+    std::vector<T> src2;
+    std::vector<T> dst_ref;
+};
 
-    for(Index i = 0; i < k*batch; ++i)
+// Reference implementation of the add fiber operation
+template<typename T>
+void reference_add_fiber(TestData<T>& data)
+{
+    using Y = typename T::repr_t;
+
+    for(Index b = 0; b < data.batch; ++b)
     {
-        src1[i] = dist(rng);
-    }
-    for(Index i = 0; i < m*n*k*batch; ++i)
-    {
-        src2[i] = dist(rng);
-        dst[i] = dist(rng);
-    }
-    std::vector<T> dst_save(dst);
-    std::cout << "Run kernel::add_fiber::cpu<" << T::short_name << ">\n";
-    cpu<T>(m, n, k, batch, alpha, &src1[0], beta, &src2[0], &dst[0]);
-    for(Index b = 0; b < batch; ++b)
-    {
-        for(Index i2 = 0; i2 < k; ++i2)
+        for(Index i2 = 0; i2 < data.k; ++i2)
         {
-            Y src1_val = Y(src1[i2+b*k]);
-            for(Index i1 = 0; i1 < n; ++i1)
+            const Y src1_val = data.alpha * static_cast<Y>(data.src1[i2 + b * data.k]);
+
+            for(Index i1 = 0; i1 < data.n; ++i1)
             {
-                for(Index i0 = 0; i0 < m; ++i0)
+                for(Index i0 = 0; i0 < data.m; ++i0)
                 {
-                    Index linear_idx = ((i1+b*n)*k+i2)*m+i0;
-                    Y val_ref = alpha*src1_val + beta*Y(src2[linear_idx]);
-                    Y val = Y(dst[linear_idx]);
-                    if (std::abs(val_ref) > 10 * eps)
+                    Index src2_idx = ((i1 + b * data.n) * data.k + i2) * data.m + i0;
+                    Index dst_idx = ((i1 + b * data.n) * data.k + i2) * data.m + i0;
+
+                    Y src2_val = static_cast<Y>(data.src2[src2_idx]);
+                    Y& dst_val = reinterpret_cast<Y&>(data.dst_ref[dst_idx]);
+
+                    if(data.beta == 0.0)
                     {
-                        TEST_ASSERT(
-                            std::abs(val-val_ref)/std::abs(val_ref) <= eps);
+                        dst_val = src1_val;
                     }
                     else
                     {
-                        TEST_ASSERT(std::abs(val-val_ref) <= eps);
+                        dst_val = data.beta * src2_val + src1_val;
                     }
                 }
             }
         }
     }
-    std::cout << "OK: kernel::add_fiber::cpu<" << T::short_name << ">\n";
-#ifdef NNTILE_USE_CUDA
-    // Check low-level CUDA kernel
-    dst = dst_save;
-    std::cout << "Run kernel::add_fiber::cuda<" << T::short_name << ">\n";
-    run_cuda<T>(m, n, k, batch, alpha, src1, beta, src2, dst);
-    for(Index b = 0; b < batch; ++b)
-    {
-        for(Index i2 = 0; i2 < k; ++i2)
-        {
-            Y src1_val = Y(src1[i2+b*k]);
-            for(Index i1 = 0; i1 < n; ++i1)
-            {
-                for(Index i0 = 0; i0 < m; ++i0)
-                {
-                    Index linear_idx = ((i1+b*n)*k+i2)*m+i0;
-                    Y val_ref = alpha*src1_val + beta*Y(src2[linear_idx]);
-                    Y val = Y(dst[linear_idx]);
-                    if (std::abs(val_ref) > 10 * eps)
-                    {
-                        TEST_ASSERT(
-                            std::abs(val-val_ref)/std::abs(val_ref) <= eps);
-                    }
-                    else
-                    {
-                        TEST_ASSERT(std::abs(val-val_ref) <= eps);
-                    }
-                }
-            }
-        }
-    }
-    std::cout << "OK: kernel::add_fiber::cuda<" << T::short_name << ">\n";
-#endif // NNTILE_USE_CUDA
 }
 
-int main(int argc, char **argv)
+// Enum for data generation strategies
+enum class DataGen
 {
-    const Index test_m[] = {1, 5};
-    const Index test_n[] = {1, 3};
-    const Index test_k[] = {1, 10};
-    const Index test_batch[] = {1, 4};
+    PRESET,
+    RANDOM
+};
 
-    for(Index m : test_m)
+// Generates data with preset, deterministic values
+template<typename T>
+void generate_data(TestData<T>& data, DataGen strategy)
+{
+    using Y = typename T::repr_t;
+
+    data.src1.resize(data.k * data.batch);
+    data.src2.resize(data.m * data.n * data.k * data.batch);
+    data.dst_ref.resize(data.m * data.n * data.k * data.batch);
+
+    switch(strategy)
     {
-        for(Index n : test_n)
-        {
-            for(Index k : test_k)
+        // Non-random input generation
+        case DataGen::PRESET:
+            for(Index i = 0; i < data.k * data.batch; ++i)
             {
-                for(Index batch : test_batch)
+                data.src1[i] = Y(2 * i + 1 - data.k * data.batch);
+            }
+            for(Index i = 0; i < data.m * data.n * data.k * data.batch; ++i)
+            {
+                data.src2[i] = Y(5 * data.m * data.n * data.k * data.batch - 2 * i);
+            }
+            break;
+        // Specific random initialization
+        case DataGen::RANDOM:
+            std::mt19937 gen(42);
+            std::uniform_real_distribution<Y> dist(-2.0, 2.0);
+            for(Index i = 0; i < data.k * data.batch; ++i)
+            {
+                data.src1[i] = dist(gen);
+            }
+            for(Index i = 0; i < data.m * data.n * data.k * data.batch; ++i)
+            {
+                data.src2[i] = dist(gen);
+            }
+            break;
+    }
+}
+
+// Get test data and reference results
+template<typename T>
+TestData<T> get_test_data(Index m, Index n, Index k, Index batch,
+                         Scalar alpha, Scalar beta, DataGen strategy)
+{
+    TestData<T> data;
+    data.m = m;
+    data.n = n;
+    data.k = k;
+    data.batch = batch;
+    data.alpha = alpha;
+    data.beta = beta;
+
+    // Generate data by a provided strategy
+    generate_data(data, strategy);
+
+    // Compute reference outputs
+    reference_add_fiber(data);
+    return data;
+}
+
+// Helper function to verify results
+template<typename T>
+void verify_results(const TestData<T>& data, const std::vector<T>& dst_out)
+{
+    using Y = typename T::repr_t;
+
+    // Set accuracy threshold for each precision
+    ref_t eps_check;
+    if (std::is_same_v<T, bf16_t>)
+    {
+        eps_check = 1e-1;
+    }
+    else if (std::is_same_v<T, fp16_t>)
+    {
+        eps_check = 1e-2;
+    }
+    else if (std::is_same_v<T, fp32_t>)
+    {
+        eps_check = 1e-6;
+    }
+    else if (std::is_same_v<T, fp64_t>)
+    {
+        eps_check = 1e-12;
+    }
+    else
+    {
+        throw std::runtime_error("Unsupported data type");
+    }
+
+    for(Index b = 0; b < data.batch; ++b)
+    {
+        for(Index i2 = 0; i2 < data.k; ++i2)
+        {
+            const Y src1_val = data.alpha * static_cast<Y>(data.src1[i2 + b * data.k]);
+
+            for(Index i1 = 0; i1 < data.n; ++i1)
+            {
+                for(Index i0 = 0; i0 < data.m; ++i0)
                 {
-                    validate<fp32_t>(m, n, k, batch);
-                    validate<fp64_t>(m, n, k, batch);
-                    validate<bf16_t>(m, n, k, batch);
-                    validate<fp16_t>(m, n, k, batch);
+                    Index dst_idx = ((i1 + b * data.n) * data.k + i2) * data.m + i0;
+                    Y dst_ref = reinterpret_cast<const Y&>(data.dst_ref[dst_idx]);
+
+                    REQUIRE_THAT(
+                        static_cast<Y>(dst_out[dst_idx]),
+                        WithinAbs(dst_ref, eps_check) || WithinRel(dst_ref, eps_check)
+                    );
                 }
             }
         }
     }
+}
+
+// Helper function to run CPU test and verify results
+template<typename T, bool run_bench>
+void run_cpu_test(TestData<T>& data)
+{
+    std::vector<T> dst_cpu(data.m * data.n * data.k * data.batch);
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][add_fiber][cpu][m=" +
+            std::to_string(data.m) + "][n=" + std::to_string(data.n) +
+            "][k=" + std::to_string(data.k) + "][batch=" + std::to_string(data.batch) +
+            "][alpha=" + std::to_string(data.alpha) + "][beta=" + std::to_string(data.beta) + "]"
+        )
+        {
+            cpu<T>(data.m, data.n, data.k, data.batch, data.alpha, &data.src1[0], data.beta, &data.src2[0], &dst_cpu[0]);
+        };
+    }
+    else
+    {
+        cpu<T>(data.m, data.n, data.k, data.batch, data.alpha, &data.src1[0], data.beta, &data.src2[0], &dst_cpu[0]);
+        verify_results(data, dst_cpu);
+    }
+}
+
+#ifdef NNTILE_USE_CUDA
+
+// Helper function to run CUDA test and verify results
+template<typename T, bool run_bench>
+void run_cuda_test(TestData<T>& data)
+{
+    T *dev_src1, *dev_src2, *dev_dst;
+    CUDA_CHECK(cudaMalloc(&dev_src1, sizeof(T) * data.k * data.batch),
+               "cudaMalloc dev_src1");
+    CUDA_CHECK(cudaMalloc(&dev_src2, sizeof(T) * data.m * data.n * data.k * data.batch),
+               "cudaMalloc dev_src2");
+    CUDA_CHECK(cudaMalloc(&dev_dst, sizeof(T) * data.m * data.n * data.k * data.batch),
+               "cudaMalloc dev_dst");
+
+    std::vector<T> dst_cuda(data.m * data.n * data.k * data.batch);
+
+    CUDA_CHECK(cudaMemcpy(dev_src1, &data.src1[0], sizeof(T) * data.k * data.batch,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_src1");
+    CUDA_CHECK(cudaMemcpy(dev_src2, &data.src2[0], sizeof(T) * data.m * data.n * data.k * data.batch,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_src2");
+    CUDA_CHECK(cudaMemcpy(dev_dst, &dst_cuda[0], sizeof(T) * data.m * data.n * data.k * data.batch,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_dst");
+
+    cudaStream_t stream;
+    CUDA_CHECK(cudaStreamCreate(&stream), "cudaStreamCreate");
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][add_fiber][cuda][m=" +
+            std::to_string(data.m) + "][n=" + std::to_string(data.n) +
+            "][k=" + std::to_string(data.k) + "][batch=" + std::to_string(data.batch) +
+            "][alpha=" + std::to_string(data.alpha) + "][beta=" + std::to_string(data.beta) + "]"
+        )
+        {
+            cuda<T>(stream, data.m, data.n, data.k, data.batch, data.alpha, dev_src1, data.beta, dev_src2, dev_dst);
+            cudaStreamSynchronize(stream);
+        };
+    }
+    else
+    {
+        cuda<T>(stream, data.m, data.n, data.k, data.batch, data.alpha, dev_src1, data.beta, dev_src2, dev_dst);
+        CUDA_CHECK(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
+
+        CUDA_CHECK(cudaMemcpy(&dst_cuda[0], dev_dst, sizeof(T) * data.m * data.n * data.k * data.batch,
+                              cudaMemcpyDeviceToHost), "cudaMemcpy dst_cuda");
+
+        verify_results(data, dst_cuda);
+    }
+
+    CUDA_CHECK(cudaFree(dev_src1), "cudaFree dev_src1");
+    CUDA_CHECK(cudaFree(dev_src2), "cudaFree dev_src2");
+    CUDA_CHECK(cudaFree(dev_dst), "cudaFree dev_dst");
+    CUDA_CHECK(cudaStreamDestroy(stream), "cudaStreamDestroy");
+}
+#endif
+
+// Catch2-based tests
+TEMPLATE_TEST_CASE(
+    "Add Fiber Kernel Verification",
+    "[add_fiber]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index m = GENERATE(1, 5);
+    const Index n = GENERATE(1, 3);
+    const Index k = GENERATE(1, 10);
+    const Index batch = GENERATE(1, 4);
+    const Scalar alpha = GENERATE(0.5, 1.0, 2.0);
+    const Scalar beta = GENERATE(0.0, 0.5, -1.0);
+    const DataGen strategy = GENERATE(DataGen::PRESET, DataGen::RANDOM);
+
+    auto data = get_test_data<T>(m, n, k, batch, alpha, beta, strategy);
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, false>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, false>(data);
+    }
+#endif
+}
+
+// Catch2-based benchmarks
+TEMPLATE_TEST_CASE(
+    "Add Fiber Kernel Benchmark",
+    "[add_fiber][!benchmark]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index m = GENERATE(64, 256);
+    const Index n = GENERATE(64, 256);
+    const Index k = GENERATE(32, 128);
+    const Index batch = GENERATE(4, 16);
+    const Scalar alpha = GENERATE(1.0);
+    const Scalar beta = GENERATE(-1.0);
+    const DataGen strategy = GENERATE(DataGen::PRESET);
+
+    auto data = get_test_data<T>(m, n, k, batch, alpha, beta, strategy);
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, true>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, true>(data);
+    }
+#endif
 }

--- a/tests/kernel/add_fiber_inplace.cc
+++ b/tests/kernel/add_fiber_inplace.cc
@@ -12,157 +12,346 @@
  * @version 1.1.0
  * */
 
+// Corresponding header
 #include "nntile/kernel/add_fiber_inplace.hh"
-#include "../testing.hh"
+
+// Standard libraries
 #include <vector>
 #include <stdexcept>
 #include <limits>
 #include <iostream>
-#include "nntile/kernel/cpu.hh"
-#include "nntile/kernel/cuda.hh"
+#include <cmath>
+#include <random>
+#include <string>
 
-#ifdef NNTILE_USE_CUDA
-#include <cuda_runtime.h>
-#endif // NNTILE_USE_CUDA
+// Third-party libraries
+#include <catch2/catch_all.hpp>
 
+// Other NNTile headers
+// CUDA_CHECK definition
+#include <nntile/kernel/cuda.hh>
+
+// Use namespaces for shorter code
+using namespace Catch;
+using namespace Catch::Matchers;
+
+// Use tested NNTile namespaces
 using namespace nntile;
 using namespace nntile::kernel;
 using namespace nntile::kernel::add_fiber_inplace;
 
 #ifdef NNTILE_USE_CUDA
-template<typename T>
-void run_cuda(Index m, Index n, Index k, Index batch, Scalar alpha,
-    const std::vector<T> &src, Scalar beta, std::vector<T> &dst)
-{
-    // Copy to device
-    T *dev_src, *dev_dst;
-    cudaError_t cuda_err = cudaMalloc(&dev_src, sizeof(T)*k*batch);
-    TEST_ASSERT(cuda_err == cudaSuccess);
-    cuda_err = cudaMalloc(&dev_dst, sizeof(T)*m*n*k*batch);
-    TEST_ASSERT(cuda_err == cudaSuccess);
-    cuda_err = cudaMemcpy(dev_src, src.data(), sizeof(T)*k*batch,
-            cudaMemcpyHostToDevice);
-    TEST_ASSERT(cuda_err == cudaSuccess);
-    cuda_err = cudaMemcpy(dev_dst, dst.data(), sizeof(T)*m*n*k*batch,
-            cudaMemcpyHostToDevice);
-    TEST_ASSERT(cuda_err == cudaSuccess);
-    // Init stream
-    cudaStream_t stream;
-    cuda_err = cudaStreamCreate(&stream);
-    TEST_ASSERT(cuda_err == cudaSuccess);
-    // Launch low-level CUDA kernel
-    cuda<T>(stream, m, n, k, batch, alpha, dev_src, beta, dev_dst);
-    cuda_err = cudaStreamSynchronize(stream);
-    TEST_ASSERT(cuda_err == cudaSuccess);
-    // Copy result and deallocate device memory
-    cuda_err = cudaMemcpy(dst.data(), dev_dst, sizeof(T)*m*n*k*batch,
-            cudaMemcpyDeviceToHost);
-    TEST_ASSERT(cuda_err == cudaSuccess);
-    cuda_err = cudaFree(dev_src);
-    TEST_ASSERT(cuda_err == cudaSuccess);
-    cuda_err = cudaFree(dev_dst);
-    TEST_ASSERT(cuda_err == cudaSuccess);
-    cuda_err = cudaStreamDestroy(stream);
-    TEST_ASSERT(cuda_err == cudaSuccess);
-}
-#endif // NNTILE_USE_CUDA
 
-// Templated validation
+// Helper function to run CUDA test and verify results
+template<typename T, bool run_bench>
+void run_cuda_test(TestData<T>& data)
+{
+    T *dev_src, *dev_dst;
+    CUDA_CHECK(cudaMalloc(&dev_src, sizeof(T) * data.k * data.batch),
+               "cudaMalloc dev_src");
+    CUDA_CHECK(cudaMalloc(&dev_dst, sizeof(T) * data.m * data.n * data.k * data.batch),
+               "cudaMalloc dev_dst");
+
+    std::vector<T> dst_cuda(data.dst_init);
+
+    CUDA_CHECK(cudaMemcpy(dev_src, &data.src[0], sizeof(T) * data.k * data.batch,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_src");
+    CUDA_CHECK(cudaMemcpy(dev_dst, &dst_cuda[0], sizeof(T) * data.m * data.n * data.k * data.batch,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_dst");
+
+    cudaStream_t stream;
+    CUDA_CHECK(cudaStreamCreate(&stream), "cudaStreamCreate");
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][add_fiber_inplace][cuda][m=" +
+            std::to_string(data.m) + "][n=" + std::to_string(data.n) +
+            "][k=" + std::to_string(data.k) + "][batch=" + std::to_string(data.batch) +
+            "][alpha=" + std::to_string(data.alpha) + "][beta=" + std::to_string(data.beta) + "]"
+        )
+        {
+            cuda<T>(stream, data.m, data.n, data.k, data.batch, data.alpha, dev_src, data.beta, dev_dst);
+            cudaStreamSynchronize(stream);
+        };
+    }
+    else
+    {
+        cuda<T>(stream, data.m, data.n, data.k, data.batch, data.alpha, dev_src, data.beta, dev_dst);
+        CUDA_CHECK(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
+
+        CUDA_CHECK(cudaMemcpy(&dst_cuda[0], dev_dst, sizeof(T) * data.m * data.n * data.k * data.batch,
+                              cudaMemcpyDeviceToHost), "cudaMemcpy dst_cuda");
+
+        verify_results(data, dst_cuda);
+    }
+
+    CUDA_CHECK(cudaFree(dev_src), "cudaFree dev_src");
+    CUDA_CHECK(cudaFree(dev_dst), "cudaFree dev_dst");
+    CUDA_CHECK(cudaStreamDestroy(stream), "cudaStreamDestroy");
+}
+#endif
+
+// Type to acquire reference values
+using ref_t = double;
+
+// Struct to hold test data and reference results
 template<typename T>
-void validate(Index m, Index n, Index k, Index batch, int test_index_a,
-    int test_index_b)
+struct TestData
 {
     using Y = typename T::repr_t;
-    const Y eps = 2 * T::epsilon;
-    // Init test input
-    Scalar alpha = (1.0)/Scalar(test_index_a);
-    Scalar beta = (1.0)/Scalar(test_index_b);
-    std::vector<T> src(k*batch);
-    std::vector<T> dst(m*n*k*batch);
-    for(Index i = 0; i < k*batch; ++i)
+    Index m, n, k, batch; // Tensor dimensions
+    Scalar alpha, beta;   // Scalar factors
+
+    std::vector<T> src;
+    std::vector<T> dst_init;
+
+    std::vector<T> dst_ref;
+};
+
+// Reference implementation of the add fiber inplace operation
+template<typename T>
+void reference_add_fiber_inplace(TestData<T>& data)
+{
+    using Y = typename T::repr_t;
+
+    data.dst_ref = data.dst_init; // Copy initial destination
+
+    for(Index b = 0; b < data.batch; ++b)
     {
-        src[i] = Y(2*i+1-k*batch);
-    }
-    for(Index i = 0; i < m*n*k*batch; ++i)
-    {
-        dst[i] = Y(5*m*n*k*batch-2*i);
-    }
-    std::vector<T> dst_save(dst);
-    // Check CPU kernel
-    std::cout << "Run kernel::add_fiber_inplace::cpu<" << T::short_name << ">\n";
-    cpu<T>(m, n, k, batch, alpha, src.data(), beta, dst.data());
-    for(Index b = 0; b < batch; ++b)
-    {
-        for(Index i2 = 0; i2 < k; ++i2)
+        for(Index i2 = 0; i2 < data.k; ++i2)
         {
-            Y src_val = Y{src[i2+b*k]};
-            for(Index i1 = 0; i1 < n; ++i1)
+            const Y src_val = data.alpha * static_cast<Y>(data.src[i2 + b * data.k]);
+
+            for(Index i1 = 0; i1 < data.n; ++i1)
             {
-                for(Index i0 = 0; i0 < m; ++i0)
+                for(Index i0 = 0; i0 < data.m; ++i0)
                 {
-                    Index l = ((i1+b*n)*k+i2)*m+i0;
-                    Y val_ref = alpha*src_val + beta*Y{dst_save[l]};
-                    Y val = Y{dst[l]};
-                    Y abs_error = std::abs(val - val_ref);
-                    Y val_ref_abs = std::abs(val_ref);
-                    Y tol = eps * std::max(Y{1.0}, val_ref_abs);
-                    TEST_ASSERT(abs_error <= tol);
+                    Index dst_idx = ((i1 + b * data.n) * data.k + i2) * data.m + i0;
+                    Y& dst_val = reinterpret_cast<Y&>(data.dst_ref[dst_idx]);
+
+                    if(data.beta == 0.0)
+                    {
+                        dst_val = src_val;
+                    }
+                    else
+                    {
+                        dst_val = data.beta * dst_val + src_val;
+                    }
                 }
             }
         }
     }
-    std::cout << "OK: kernel::add_fiber_inplace::cpu<" << T::short_name << ">\n";
-#ifdef NNTILE_USE_CUDA
-    // Check CUDA kernel
-    dst = dst_save;
-    std::cout << "Run kernel::add_fiber_inplace::cuda<" << T::short_name << ">\n";
-    run_cuda<T>(m, n, k, batch, alpha, src, beta, dst);
-    for(Index b = 0; b < batch; ++b)
-    {
-        for(Index i2 = 0; i2 < k; ++i2)
-        {
-            Y src_val = Y{src[i2+b*k]};
-            for(Index i1 = 0; i1 < n; ++i1)
-            {
-                for(Index i0 = 0; i0 < m; ++i0)
-                {
-                    Index l = ((i1+b*n)*k+i2)*m+i0;
-                    Y val_ref = alpha*src_val + beta*Y{dst_save[l]};
-                    Y val = Y{dst[l]};
-                    Y abs_error = std::abs(val - val_ref);
-                    Y val_ref_abs = std::abs(val_ref);
-                    Y tol = eps * std::max(Y{1.0}, val_ref_abs);
-                    TEST_ASSERT(abs_error <= tol);
-                }
-            }
-        }
-    }
-    std::cout << "OK: kernel::add_fiber_inplace::cuda<" << T::short_name << ">\n";
-#endif // NNTILE_USE_CUDA
 }
 
-int main(int argc, char **argv)
+// Enum for data generation strategies
+enum class DataGen
 {
-    const Index test_m[] = {1, 5};
-    const Index test_n[] = {1, 3};
-    const Index test_k[] = {1, 10};
-    const Index test_batch[] = {1, 4};
-    int ti = 1;
-    for(Index m: test_m)
+    PRESET,
+    RANDOM
+};
+
+// Generates data with preset, deterministic values
+template<typename T>
+void generate_data(TestData<T>& data, DataGen strategy)
+{
+    using Y = typename T::repr_t;
+
+    data.src.resize(data.k * data.batch);
+    data.dst_init.resize(data.m * data.n * data.k * data.batch);
+    data.dst_ref.resize(data.m * data.n * data.k * data.batch);
+
+    switch(strategy)
     {
-        for(Index n: test_n)
-        {
-            for(Index k: test_k)
+        // Non-random input generation
+        case DataGen::PRESET:
+            for(Index i = 0; i < data.k * data.batch; ++i)
             {
-                for(Index batch: test_batch)
+                data.src[i] = Y(2 * i + 1 - data.k * data.batch);
+            }
+            for(Index i = 0; i < data.m * data.n * data.k * data.batch; ++i)
+            {
+                data.dst_init[i] = Y(5 * data.m * data.n * data.k * data.batch - 2 * i);
+            }
+            break;
+        // Specific random initialization
+        case DataGen::RANDOM:
+            std::mt19937 gen(42);
+            std::uniform_real_distribution<Y> dist(-2.0, 2.0);
+            for(Index i = 0; i < data.k * data.batch; ++i)
+            {
+                data.src[i] = dist(gen);
+            }
+            for(Index i = 0; i < data.m * data.n * data.k * data.batch; ++i)
+            {
+                data.dst_init[i] = dist(gen);
+            }
+            break;
+    }
+}
+
+// Get test data and reference results
+template<typename T>
+TestData<T> get_test_data(Index m, Index n, Index k, Index batch,
+                         Scalar alpha, Scalar beta, DataGen strategy)
+{
+    TestData<T> data;
+    data.m = m;
+    data.n = n;
+    data.k = k;
+    data.batch = batch;
+    data.alpha = alpha;
+    data.beta = beta;
+
+    // Generate data by a provided strategy
+    generate_data(data, strategy);
+
+    // Compute reference outputs
+    reference_add_fiber_inplace(data);
+    return data;
+}
+
+// Helper function to verify results
+template<typename T>
+void verify_results(const TestData<T>& data, const std::vector<T>& dst_out)
+{
+    using Y = typename T::repr_t;
+
+    // Set accuracy threshold for each precision
+    ref_t eps_check;
+    if (std::is_same_v<T, bf16_t>)
+    {
+        eps_check = 1e-1;
+    }
+    else if (std::is_same_v<T, fp16_t>)
+    {
+        eps_check = 1e-2;
+    }
+    else if (std::is_same_v<T, fp32_t>)
+    {
+        eps_check = 1e-6;
+    }
+    else if (std::is_same_v<T, fp64_t>)
+    {
+        eps_check = 1e-12;
+    }
+    else
+    {
+        throw std::runtime_error("Unsupported data type");
+    }
+
+    for(Index b = 0; b < data.batch; ++b)
+    {
+        for(Index i2 = 0; i2 < data.k; ++i2)
+        {
+            const Y src_val = data.alpha * static_cast<Y>(data.src[i2 + b * data.k]);
+
+            for(Index i1 = 0; i1 < data.n; ++i1)
+            {
+                for(Index i0 = 0; i0 < data.m; ++i0)
                 {
-                    validate<fp32_t>(m, n, k, batch, ti, ti+1);
-                    validate<fp64_t>(m, n, k, batch, ti, ti+1);
-                    validate<bf16_t>(m, n, k, batch, ti, ti+1);
-                    validate<fp16_t>(m, n, k, batch, ti, ti+1);
-                    ++ti;
+                    Index dst_idx = ((i1 + b * data.n) * data.k + i2) * data.m + i0;
+                    Y dst_ref = reinterpret_cast<const Y&>(data.dst_ref[dst_idx]);
+
+                    REQUIRE_THAT(
+                        static_cast<Y>(dst_out[dst_idx]),
+                        WithinAbs(dst_ref, eps_check) || WithinRel(dst_ref, eps_check)
+                    );
                 }
             }
         }
     }
+}
+
+// Helper function to run CPU test and verify results
+template<typename T, bool run_bench>
+void run_cpu_test(TestData<T>& data)
+{
+    std::vector<T> dst_cpu(data.dst_init);
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][add_fiber_inplace][cpu][m=" +
+            std::to_string(data.m) + "][n=" + std::to_string(data.n) +
+            "][k=" + std::to_string(data.k) + "][batch=" + std::to_string(data.batch) +
+            "][alpha=" + std::to_string(data.alpha) + "][beta=" + std::to_string(data.beta) + "]"
+        )
+        {
+            cpu<T>(data.m, data.n, data.k, data.batch, data.alpha, &data.src[0], data.beta, &dst_cpu[0]);
+        };
+    }
+    else
+    {
+        cpu<T>(data.m, data.n, data.k, data.batch, data.alpha, &data.src[0], data.beta, &dst_cpu[0]);
+        verify_results(data, dst_cpu);
+    }
+}
+
+// Catch2-based tests
+TEMPLATE_TEST_CASE(
+    "Add Fiber Inplace Kernel Verification",
+    "[add_fiber_inplace]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index m = GENERATE(1, 5);
+    const Index n = GENERATE(1, 3);
+    const Index k = GENERATE(1, 10);
+    const Index batch = GENERATE(1, 4);
+    const Scalar alpha = GENERATE(0.5, 1.0, 2.0);
+    const Scalar beta = GENERATE(0.0, 0.5, 1.0);
+    const DataGen strategy = GENERATE(DataGen::PRESET, DataGen::RANDOM);
+
+    auto data = get_test_data<T>(m, n, k, batch, alpha, beta, strategy);
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, false>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, false>(data);
+    }
+#endif
+}
+
+// Catch2-based benchmarks
+TEMPLATE_TEST_CASE(
+    "Add Fiber Inplace Kernel Benchmark",
+    "[add_fiber_inplace][!benchmark]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index m = GENERATE(64, 256);
+    const Index n = GENERATE(64, 256);
+    const Index k = GENERATE(32, 128);
+    const Index batch = GENERATE(4, 16);
+    const Scalar alpha = GENERATE(1.0);
+    const Scalar beta = GENERATE(1.0);
+    const DataGen strategy = GENERATE(DataGen::PRESET);
+
+    auto data = get_test_data<T>(m, n, k, batch, alpha, beta, strategy);
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, true>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, true>(data);
+    }
+#endif
 }

--- a/tests/kernel/add_inplace.cc
+++ b/tests/kernel/add_inplace.cc
@@ -12,21 +12,36 @@
  * @version 1.1.0
  * */
 
+// Corresponding header
 #include "nntile/kernel/add_inplace.hh"
-#include "../testing.hh"
+
+// Standard libraries
 #include <vector>
 #include <stdexcept>
 #include <limits>
 #include <iostream>
-#include "nntile/kernel/cpu.hh"
-#include "nntile/kernel/cuda.hh"
+#include <cmath>
+#include <random>
+#include <string>
 
-#ifdef NNTILE_USE_CUDA
-//#include <cuda_fp16.h>
-#endif // NNTILE_USE_CUDA
+// Third-party libraries
+#include <catch2/catch_all.hpp>
 
+// Other NNTile headers
+// CUDA_CHECK definition
+#include <nntile/kernel/cuda.hh>
+
+// Use namespaces for shorter code
+using namespace Catch;
+using namespace Catch::Matchers;
+
+// Use tested NNTile namespaces
 using namespace nntile;
 using namespace nntile::kernel;
+using namespace nntile::kernel::add_inplace;
+
+// Type to acquire reference values
+using ref_t = double;
 
 #ifdef NNTILE_USE_CUDA
 
@@ -105,15 +120,268 @@ void validate(Index nelems, int test_index_a, int test_index_b)
 #endif // NNTILE_USE_CUDA
 }
 
-int main(int argc, char **argv)
+// Struct to hold test data and reference results
+template<typename T>
+struct TestData
 {
-    const Index test_nelems[] = {0, 3, 999};
-    for(Index j = 0; j < 3; ++j)
+    using Y = typename T::repr_t;
+    Index nelems; // Number of elements
+    Scalar alpha, beta; // Scalar factors
+
+    std::vector<T> src;
+    std::vector<T> dst_init;
+
+    std::vector<T> dst_ref;
+};
+
+// Reference implementation of the add inplace operation
+template<typename T>
+void reference_add_inplace(TestData<T>& data)
+{
+    using Y = typename T::repr_t;
+
+    data.dst_ref = data.dst_init; // Copy initial destination
+
+    for(Index i = 0; i < data.nelems; ++i)
     {
-        Index nelems = test_nelems[j];
-        int i = int(j)+1;
-        validate<fp64_t>(nelems, i, i);
-        validate<fp32_t>(nelems, i, i);
-        validate<bf16_t>(nelems, i, i);
+        Y src_val = static_cast<Y>(data.src[i]);
+        Y dst_val = static_cast<Y>(data.dst_ref[i]);
+        data.dst_ref[i] = static_cast<T>(data.alpha * src_val + data.beta * dst_val);
     }
+}
+
+// Enum for data generation strategies
+enum class DataGen
+{
+    PRESET,
+    RANDOM
+};
+
+// Generates data with preset, deterministic values
+template<typename T>
+void generate_data(TestData<T>& data, DataGen strategy)
+{
+    using Y = typename T::repr_t;
+
+    data.src.resize(data.nelems);
+    data.dst_init.resize(data.nelems);
+    data.dst_ref.resize(data.nelems);
+
+    switch(strategy)
+    {
+        // Non-random input generation
+        case DataGen::PRESET:
+            for(Index i = 0; i < data.nelems; ++i)
+            {
+                data.src[i] = Y(2 * i + 1 - data.nelems);
+                data.dst_init[i] = Y(2 * data.nelems - i);
+            }
+            break;
+        // Specific random initialization
+        case DataGen::RANDOM:
+            std::mt19937 gen(42);
+            std::uniform_real_distribution<Y> dist(-2.0, 2.0);
+            for(Index i = 0; i < data.nelems; ++i)
+            {
+                data.src[i] = dist(gen);
+                data.dst_init[i] = dist(gen);
+            }
+            break;
+    }
+}
+
+// Get test data and reference results
+template<typename T>
+TestData<T> get_test_data(Index nelems, Scalar alpha, Scalar beta, DataGen strategy)
+{
+    TestData<T> data;
+    data.nelems = nelems;
+    data.alpha = alpha;
+    data.beta = beta;
+
+    // Generate data by a provided strategy
+    generate_data(data, strategy);
+
+    // Compute reference outputs
+    reference_add_inplace(data);
+    return data;
+}
+
+// Helper function to verify results
+template<typename T>
+void verify_results(const TestData<T>& data, const std::vector<T>& dst_out)
+{
+    using Y = typename T::repr_t;
+
+    // Set accuracy threshold for each precision
+    ref_t eps_check;
+    if (std::is_same_v<T, bf16_t>)
+    {
+        eps_check = 1e-1;
+    }
+    else if (std::is_same_v<T, fp16_t>)
+    {
+        eps_check = 1e-2;
+    }
+    else if (std::is_same_v<T, fp32_t>)
+    {
+        eps_check = 1e-6;
+    }
+    else if (std::is_same_v<T, fp64_t>)
+    {
+        eps_check = 1e-12;
+    }
+    else
+    {
+        throw std::runtime_error("Unsupported data type");
+    }
+
+    for(Index i = 0; i < data.nelems; ++i)
+    {
+        Y dst_ref = static_cast<Y>(data.dst_ref[i]);
+
+        REQUIRE_THAT(
+            static_cast<Y>(dst_out[i]),
+            WithinAbs(dst_ref, eps_check) || WithinRel(dst_ref, eps_check)
+        );
+    }
+}
+
+// Helper function to run CPU test and verify results
+template<typename T, bool run_bench>
+void run_cpu_test(TestData<T>& data)
+{
+    std::vector<T> dst_cpu(data.dst_init);
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][add_inplace][cpu][nelems=" +
+            std::to_string(data.nelems) +
+            "][alpha=" + std::to_string(data.alpha) +
+            "][beta=" + std::to_string(data.beta) + "]"
+        )
+        {
+            cpu<T>(data.nelems, data.alpha, &data.src[0], data.beta, &dst_cpu[0]);
+        };
+    }
+    else
+    {
+        cpu<T>(data.nelems, data.alpha, &data.src[0], data.beta, &dst_cpu[0]);
+        verify_results(data, dst_cpu);
+    }
+}
+
+#ifdef NNTILE_USE_CUDA
+
+// Helper function to run CUDA test and verify results
+template<typename T, bool run_bench>
+void run_cuda_test(TestData<T>& data)
+{
+    T *dev_src, *dev_dst;
+    CUDA_CHECK(cudaMalloc(&dev_src, sizeof(T) * data.nelems),
+               "cudaMalloc dev_src");
+    CUDA_CHECK(cudaMalloc(&dev_dst, sizeof(T) * data.nelems),
+               "cudaMalloc dev_dst");
+
+    std::vector<T> dst_cuda(data.dst_init);
+
+    CUDA_CHECK(cudaMemcpy(dev_src, &data.src[0], sizeof(T) * data.nelems,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_src");
+    CUDA_CHECK(cudaMemcpy(dev_dst, &dst_cuda[0], sizeof(T) * data.nelems,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_dst");
+
+    cudaStream_t stream;
+    CUDA_CHECK(cudaStreamCreate(&stream), "cudaStreamCreate");
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][add_inplace][cuda][nelems=" +
+            std::to_string(data.nelems) +
+            "][alpha=" + std::to_string(data.alpha) +
+            "][beta=" + std::to_string(data.beta) + "]"
+        )
+        {
+            cuda<T>(stream, data.nelems, data.alpha, dev_src, data.beta, dev_dst);
+            cudaStreamSynchronize(stream);
+        };
+    }
+    else
+    {
+        cuda<T>(stream, data.nelems, data.alpha, dev_src, data.beta, dev_dst);
+        CUDA_CHECK(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
+
+        CUDA_CHECK(cudaMemcpy(&dst_cuda[0], dev_dst, sizeof(T) * data.nelems,
+                              cudaMemcpyDeviceToHost), "cudaMemcpy dst_cuda");
+
+        verify_results(data, dst_cuda);
+    }
+
+    CUDA_CHECK(cudaFree(dev_src), "cudaFree dev_src");
+    CUDA_CHECK(cudaFree(dev_dst), "cudaFree dev_dst");
+    CUDA_CHECK(cudaStreamDestroy(stream), "cudaStreamDestroy");
+}
+#endif
+
+// Catch2-based tests
+TEMPLATE_TEST_CASE(
+    "Add Inplace Kernel Verification",
+    "[add_inplace]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index nelems = GENERATE(0, 3, 999);
+    const Scalar alpha = GENERATE(0.5, 1.0, 2.0);
+    const Scalar beta = GENERATE(0.0, 0.5, 1.0);
+    const DataGen strategy = GENERATE(DataGen::PRESET, DataGen::RANDOM);
+
+    auto data = get_test_data<T>(nelems, alpha, beta, strategy);
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, false>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, false>(data);
+    }
+#endif
+}
+
+// Catch2-based benchmarks
+TEMPLATE_TEST_CASE(
+    "Add Inplace Kernel Benchmark",
+    "[add_inplace][!benchmark]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index nelems = GENERATE(1000, 10000, 100000);
+    const Scalar alpha = GENERATE(1.0);
+    const Scalar beta = GENERATE(1.0);
+    const DataGen strategy = GENERATE(DataGen::PRESET);
+
+    auto data = get_test_data<T>(nelems, alpha, beta, strategy);
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, true>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, true>(data);
+    }
+#endif
 }

--- a/tests/kernel/add_slice_inplace.cc
+++ b/tests/kernel/add_slice_inplace.cc
@@ -12,15 +12,36 @@
  * @version 1.1.0
  * */
 
+// Corresponding header
 #include "nntile/kernel/add_slice_inplace.hh"
-#include "../testing.hh"
+
+// Standard libraries
 #include <vector>
 #include <stdexcept>
 #include <limits>
 #include <iostream>
+#include <cmath>
+#include <random>
+#include <string>
 
+// Third-party libraries
+#include <catch2/catch_all.hpp>
+
+// Other NNTile headers
+// CUDA_CHECK definition
+#include <nntile/kernel/cuda.hh>
+
+// Use namespaces for shorter code
+using namespace Catch;
+using namespace Catch::Matchers;
+
+// Use tested NNTile namespaces
 using namespace nntile;
+using namespace nntile::kernel;
 using namespace nntile::kernel::add_slice_inplace;
+
+// Type to acquire reference values
+using ref_t = double;
 
 #ifdef NNTILE_USE_CUDA
 template<typename T>
@@ -130,16 +151,327 @@ void validate(Index m, Index n, Index k)
 #endif // NNTILE_USE_CUDA
 }
 
-int main(int argc, char **argv)
+// Struct to hold test data and reference results
+template<typename T>
+struct TestData
 {
-    validate<fp32_t>(1, 9, 10);
-    validate<fp32_t>(8, 9, 1);
-    validate<fp32_t>(8, 1, 10);
-    validate<fp32_t>(4, 7, 8);
-    validate<fp64_t>(1, 9, 10);
-    validate<fp64_t>(8, 9, 1);
-    validate<fp64_t>(8, 1, 10);
-    validate<fp64_t>(4, 7, 8);
+    using Y = typename T::repr_t;
+    Index m, n, k; // Tensor dimensions
+    Scalar alpha, beta; // Scalar factors
 
-    return 0;
+    std::vector<T> src;
+    std::vector<T> dst_init;
+
+    std::vector<T> dst_ref;
+};
+
+// Reference implementation of the add slice inplace operation
+template<typename T>
+void reference_add_slice_inplace(TestData<T>& data)
+{
+    using Y = typename T::repr_t;
+
+    data.dst_ref = data.dst_init; // Copy initial destination
+
+    for(Index i0 = 0; i0 < data.m; ++i0)
+    {
+        for(Index i1 = 0; i1 < data.n; ++i1)
+        {
+            Y src_val = static_cast<Y>(data.src[i1 * data.m + i0]);
+
+            for(Index i2 = 0; i2 < data.k; ++i2)
+            {
+                Index dst_idx = (i1 * data.k + i2) * data.m + i0;
+                Y& dst_val = reinterpret_cast<Y&>(data.dst_ref[dst_idx]);
+
+                if(data.beta == 0.0)
+                {
+                    dst_val = data.alpha * src_val;
+                }
+                else
+                {
+                    dst_val = data.alpha * src_val + data.beta * dst_val;
+                }
+            }
+        }
+    }
+}
+
+// Enum for data generation strategies
+enum class DataGen
+{
+    PRESET,
+    RANDOM
+};
+
+// Generates data with preset, deterministic values
+template<typename T>
+void generate_data(TestData<T>& data, DataGen strategy)
+{
+    using Y = typename T::repr_t;
+
+    data.src.resize(data.m * data.n);
+    data.dst_init.resize(data.m * data.n * data.k);
+    data.dst_ref.resize(data.m * data.n * data.k);
+
+    switch(strategy)
+    {
+        // Non-random input generation
+        case DataGen::PRESET:
+            for(Index i0 = 0; i0 < data.m; ++i0)
+            {
+                for(Index i1 = 0; i1 < data.n; ++i1)
+                {
+                    data.src[i1 * data.m + i0] = Y(i0 + i1) / Y{20};
+                }
+            }
+            for(Index i0 = 0; i0 < data.m; ++i0)
+            {
+                for(Index i1 = 0; i1 < data.n; ++i1)
+                {
+                    for(Index i2 = 0; i2 < data.k; ++i2)
+                    {
+                        Index dst_idx = (i1 * data.k + i2) * data.m + i0;
+                        data.dst_init[dst_idx] = Y(i0 + i1 + i2) / Y{30};
+                    }
+                }
+            }
+            break;
+        // Specific random initialization
+        case DataGen::RANDOM:
+            std::mt19937 gen(42);
+            std::uniform_real_distribution<Y> dist(-2.0, 2.0);
+            for(Index i0 = 0; i0 < data.m; ++i0)
+            {
+                for(Index i1 = 0; i1 < data.n; ++i1)
+                {
+                    data.src[i1 * data.m + i0] = dist(gen);
+                }
+            }
+            for(Index i0 = 0; i0 < data.m; ++i0)
+            {
+                for(Index i1 = 0; i1 < data.n; ++i1)
+                {
+                    for(Index i2 = 0; i2 < data.k; ++i2)
+                    {
+                        Index dst_idx = (i1 * data.k + i2) * data.m + i0;
+                        data.dst_init[dst_idx] = dist(gen);
+                    }
+                }
+            }
+            break;
+    }
+}
+
+// Get test data and reference results
+template<typename T>
+TestData<T> get_test_data(Index m, Index n, Index k, Scalar alpha, Scalar beta, DataGen strategy)
+{
+    TestData<T> data;
+    data.m = m;
+    data.n = n;
+    data.k = k;
+    data.alpha = alpha;
+    data.beta = beta;
+
+    // Generate data by a provided strategy
+    generate_data(data, strategy);
+
+    // Compute reference outputs
+    reference_add_slice_inplace(data);
+    return data;
+}
+
+// Helper function to verify results
+template<typename T>
+void verify_results(const TestData<T>& data, const std::vector<T>& dst_out)
+{
+    using Y = typename T::repr_t;
+
+    // Set accuracy threshold for each precision
+    ref_t eps_check;
+    if (std::is_same_v<T, bf16_t>)
+    {
+        eps_check = 1e-1;
+    }
+    else if (std::is_same_v<T, fp16_t>)
+    {
+        eps_check = 1e-2;
+    }
+    else if (std::is_same_v<T, fp32_t>)
+    {
+        eps_check = 1e-5;
+    }
+    else if (std::is_same_v<T, fp64_t>)
+    {
+        eps_check = 1e-12;
+    }
+    else
+    {
+        throw std::runtime_error("Unsupported data type");
+    }
+
+    for(Index i0 = 0; i0 < data.m; ++i0)
+    {
+        for(Index i1 = 0; i1 < data.n; ++i1)
+        {
+            Y src_val = static_cast<Y>(data.src[i1 * data.m + i0]);
+
+            for(Index i2 = 0; i2 < data.k; ++i2)
+            {
+                Index dst_idx = (i1 * data.k + i2) * data.m + i0;
+                Y dst_ref = reinterpret_cast<const Y&>(data.dst_ref[dst_idx]);
+
+                REQUIRE_THAT(
+                    static_cast<Y>(dst_out[dst_idx]),
+                    WithinAbs(dst_ref, eps_check) || WithinRel(dst_ref, eps_check)
+                );
+            }
+        }
+    }
+}
+
+// Helper function to run CPU test and verify results
+template<typename T, bool run_bench>
+void run_cpu_test(TestData<T>& data)
+{
+    std::vector<T> dst_cpu(data.dst_init);
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][add_slice_inplace][cpu][m=" +
+            std::to_string(data.m) + "][n=" + std::to_string(data.n) +
+            "][k=" + std::to_string(data.k) +
+            "][alpha=" + std::to_string(data.alpha) +
+            "][beta=" + std::to_string(data.beta) + "]"
+        )
+        {
+            cpu<T>(data.m, data.n, data.k, data.alpha, &data.src[0], data.beta, &dst_cpu[0]);
+        };
+    }
+    else
+    {
+        cpu<T>(data.m, data.n, data.k, data.alpha, &data.src[0], data.beta, &dst_cpu[0]);
+        verify_results(data, dst_cpu);
+    }
+}
+
+#ifdef NNTILE_USE_CUDA
+
+// Helper function to run CUDA test and verify results
+template<typename T, bool run_bench>
+void run_cuda_test(TestData<T>& data)
+{
+    T *dev_src, *dev_dst;
+    CUDA_CHECK(cudaMalloc(&dev_src, sizeof(T) * data.m * data.n),
+               "cudaMalloc dev_src");
+    CUDA_CHECK(cudaMalloc(&dev_dst, sizeof(T) * data.m * data.n * data.k),
+               "cudaMalloc dev_dst");
+
+    std::vector<T> dst_cuda(data.dst_init);
+
+    CUDA_CHECK(cudaMemcpy(dev_src, &data.src[0], sizeof(T) * data.m * data.n,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_src");
+    CUDA_CHECK(cudaMemcpy(dev_dst, &dst_cuda[0], sizeof(T) * data.m * data.n * data.k,
+                          cudaMemcpyHostToDevice), "cudaMemcpy dev_dst");
+
+    cudaStream_t stream;
+    CUDA_CHECK(cudaStreamCreate(&stream), "cudaStreamCreate");
+
+    if constexpr (run_bench)
+    {
+        BENCHMARK(
+            "[kernel][add_slice_inplace][cuda][m=" +
+            std::to_string(data.m) + "][n=" + std::to_string(data.n) +
+            "][k=" + std::to_string(data.k) +
+            "][alpha=" + std::to_string(data.alpha) +
+            "][beta=" + std::to_string(data.beta) + "]"
+        )
+        {
+            cuda<T>(stream, data.m, data.n, data.k, data.alpha, dev_src, data.beta, dev_dst);
+            cudaStreamSynchronize(stream);
+        };
+    }
+    else
+    {
+        cuda<T>(stream, data.m, data.n, data.k, data.alpha, dev_src, data.beta, dev_dst);
+        CUDA_CHECK(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
+
+        CUDA_CHECK(cudaMemcpy(&dst_cuda[0], dev_dst, sizeof(T) * data.m * data.n * data.k,
+                              cudaMemcpyDeviceToHost), "cudaMemcpy dst_cuda");
+
+        verify_results(data, dst_cuda);
+    }
+
+    CUDA_CHECK(cudaFree(dev_src), "cudaFree dev_src");
+    CUDA_CHECK(cudaFree(dev_dst), "cudaFree dev_dst");
+    CUDA_CHECK(cudaStreamDestroy(stream), "cudaStreamDestroy");
+}
+#endif
+
+// Catch2-based tests
+TEMPLATE_TEST_CASE(
+    "Add Slice Inplace Kernel Verification",
+    "[add_slice_inplace]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index m = GENERATE(1, 8, 4);
+    const Index n = GENERATE(9, 9, 7);
+    const Index k = GENERATE(10, 1, 8);
+    const Scalar alpha = GENERATE(-2.0, 1.0);
+    const Scalar beta = GENERATE(3.0, 1.0);
+    const DataGen strategy = GENERATE(DataGen::PRESET, DataGen::RANDOM);
+
+    auto data = get_test_data<T>(m, n, k, alpha, beta, strategy);
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, false>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, false>(data);
+    }
+#endif
+}
+
+// Catch2-based benchmarks
+TEMPLATE_TEST_CASE(
+    "Add Slice Inplace Kernel Benchmark",
+    "[add_slice_inplace][!benchmark]",
+    fp64_t,
+    fp32_t,
+    fp16_t,
+    bf16_t
+)
+{
+    using T = TestType;
+    const Index m = GENERATE(64, 128);
+    const Index n = GENERATE(64, 128);
+    const Index k = GENERATE(32, 64);
+    const Scalar alpha = GENERATE(1.0);
+    const Scalar beta = GENERATE(1.0);
+    const DataGen strategy = GENERATE(DataGen::PRESET);
+
+    auto data = get_test_data<T>(m, n, k, alpha, beta, strategy);
+
+    SECTION("cpu")
+    {
+        run_cpu_test<T, true>(data);
+    }
+
+#ifdef NNTILE_USE_CUDA
+    SECTION("cuda")
+    {
+        run_cuda_test<T, true>(data);
+    }
+#endif
 }


### PR DESCRIPTION
Migrate `accumulate_maxsumexp`, `add_fiber`, `add_fiber_inplace`, `add_inplace`, and `add_slice_inplace` kernel tests to Catch2, and add `fp16_t` support to `accumulate_maxsumexp`, to modernize and standardize testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-76c08b2b-1cc3-4a83-9e10-40870bb5b07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-76c08b2b-1cc3-4a83-9e10-40870bb5b07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

