### PR TITLE
Add ctest job for C++ tests

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -127,9 +127,61 @@ jobs:
           path: build/**/*.so
           retention-days: 7
 
+  test-cpp:
+    name: Run C++ tests
+    needs: 'build'
+    runs-on: 'ubuntu-24.04'
+    strategy:
+      matrix:
+        python-version: ['3.12']
+    container:
+      image: 'ubuntu:24.04'
+    steps:
+      - name: Cache system packages
+        uses: actions/cache@v4
+        id: cache-apt
+        env:
+          cache-name: cache-apt-packages
+        with:
+          path: /var/cache/apt
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+            ${{ runner.os }}-build-
+            ${{ runner.os }}
+      - name: Install Git in container
+        run: |
+          rm -rfv /etc/apt/apt.conf.d/docker*
+          apt update
+          apt install -y --no-install-recommends ca-certificates git
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: |
+          rm -rfv /etc/apt/apt.conf.d/docker*
+          apt update
+          apt install -y --no-install-recommends \
+              autoconf automake binutils build-essential ca-certificates \
+              clang cmake curl fxt-tools git lcov libfxt-dev libhwloc-dev \
+              libopenblas-dev libopenmpi-dev libopenmpi3 libtool-bin \
+              lsb-release ninja-build openmpi-bin pkg-config
+      - name: Download StarPU libraries (*.so)
+        uses: actions/download-artifact@v4
+        with:
+          name: starpu-${{ matrix.python-version }}
+          path: /usr/lib
+      - name: Download all shared objects (*.so)
+        uses: actions/download-artifact@v4
+        with:
+          name: shared-objects-${{ matrix.python-version }}
+          path: build
+      - name: Run C++ tests with ctest
+        run: |
+          cd build
+          ctest -LE "(MPI|NotImplemented)" -E wrappers
+
   test-python:
     name: Run CPU-only tests with Python ${{ matrix.python-version }}
-    needs: 'build'
+    needs: 'test-cpp'
     runs-on: 'ubuntu-24.04'
     strategy:
       matrix:

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -102,9 +102,56 @@ jobs:
           path: build/**/*.so
           retention-days: 7
 
+  test-cpp:
+    name: Run C++ tests
+    needs: 'build'
+    runs-on: 'ubuntu-24.04'
+    strategy:
+      matrix:
+        python-version: ['3.12']
+    container:
+      image: 'ubuntu:24.04'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache system packages
+        uses: actions/cache@v4
+        id: cache-apt
+        env:
+          cache-name: cache-apt-packages
+        with:
+          path: /var/cache/apt
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+            ${{ runner.os }}-build-
+            ${{ runner.os }}
+      - name: Install system dependencies
+        run: |
+          rm -rfv /etc/apt/apt.conf.d/docker*
+          apt update
+          apt install -y --no-install-recommends \
+              autoconf automake binutils build-essential ca-certificates \
+              clang cmake curl fxt-tools git lcov libfxt-dev libhwloc-dev \
+              libopenblas-dev libopenmpi-dev libopenmpi3 libtool-bin \
+              lsb-release ninja-build openmpi-bin pkg-config
+      - name: Download StarPU libraries (*.so)
+        uses: actions/download-artifact@v4
+        with:
+          name: starpu-${{ matrix.python-version }}
+          path: /usr/lib
+      - name: Download all shared objects (*.so)
+        uses: actions/download-artifact@v4
+        with:
+          name: shared-objects-${{ matrix.python-version }}
+          path: build
+      - name: Run C++ tests with ctest
+        run: |
+          cd build
+          ctest -LE "(MPI|NotImplemented)" -E wrappers
+
   test-python:
     name: Run CPU-only tests with Python ${{ matrix.python-version }}
-    needs: 'build'
+    needs: 'test-cpp'
     runs-on: 'ubuntu-24.04'
     strategy:
       matrix:


### PR DESCRIPTION
Add a C++ test job to GitHub workflows to run `ctest` after compilation and before Python tests, improving CI coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-faf2dd25-ebbe-4919-bafe-c7dc305efafa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-faf2dd25-ebbe-4919-bafe-c7dc305efafa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

