### PR TITLE
Add C++ tests to the on-push and on-schedule workflows

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -119,7 +119,9 @@ jobs:
       - name: Build NNTile native libraries
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_CUDA=OFF
-          cmake --build build
+          cmake --build build -j
+      - name: Test CPU-only C++ tests
+        run: ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)"
       - name: Upload all shared objects (*.so)
         uses: actions/upload-artifact@v4.3.4
         with:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -107,29 +107,29 @@ jobs:
               --enable-blas-lib=none \
               --enable-maxcudadev=8 \
               --enable-maxbuffers=16 \
-              --with-fxt
+              --with-fxt \
+              --prefix=/usr/lib
           make -j 4 install
           rm -rf /usr/src/starpu /usr/src/starpu-$STARPU_LABEL
       - name: Upload StarPU libraries (*.so)
         uses: actions/upload-artifact@v4.3.4
         with:
           name: starpu-${{ matrix.python-version }}
-          path: /usr/local/lib/lib*.so*
+          path: /usr/lib/libstarpu*.so*
           retention-days: 7
       - name: Build NNTile native libraries
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_CUDA=OFF
           cmake --build build -j
-      - name: Test CPU-only C++ tests
-        run: |
-          cp /usr/local/lib/libstarpu-*.so* /usr/lib
-          ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)" --output-on-failure
       - name: Upload all shared objects (*.so)
         uses: actions/upload-artifact@v4.3.4
         with:
           name: shared-objects-${{ matrix.python-version }}
           path: build/**/*.so
           retention-days: 7
+      - name: Test CPU-only C++ tests
+        run: |
+          ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)" --output-on-failure
 
   test-python:
     name: Run CPU-only tests with Python ${{ matrix.python-version }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -108,7 +108,7 @@ jobs:
               --enable-maxcudadev=8 \
               --enable-maxbuffers=16 \
               --with-fxt \
-              --prefix=/usr/lib
+              --prefix=/usr
           make -j 4 install
           rm -rf /usr/src/starpu /usr/src/starpu-$STARPU_LABEL
       - name: Upload StarPU libraries (*.so)

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -121,7 +121,7 @@ jobs:
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_CUDA=OFF
           cmake --build build -j
       - name: Test CPU-only C++ tests
-        run: ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)"
+        run: ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)" --output-on-failure
       - name: Upload all shared objects (*.so)
         uses: actions/upload-artifact@v4.3.4
         with:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -121,7 +121,9 @@ jobs:
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_CUDA=OFF
           cmake --build build -j
       - name: Test CPU-only C++ tests
-        run: ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)" --output-on-failure
+        run: |
+          cp /usr/local/lib/libstarpu-*.so* /usr/lib
+          ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)" --output-on-failure
       - name: Upload all shared objects (*.so)
         uses: actions/upload-artifact@v4.3.4
         with:

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -82,29 +82,29 @@ jobs:
               --enable-blas-lib=none \
               --enable-maxcudadev=8 \
               --enable-maxbuffers=16 \
-              --with-fxt
+              --with-fxt \
+              --prefix=/usr
           make -j 4 install
           rm -rf /usr/src/starpu /usr/src/starpu-$STARPU_LABEL
       - name: Upload StarPU libraries (*.so)
         uses: actions/upload-artifact@v4.3.4
         with:
           name: starpu-${{ matrix.python-version }}
-          path: /usr/local/lib/lib*.so*
+          path: /usr/lib/libstarpu*.so*
           retention-days: 7
       - name: Build NNTile native libraries
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_CUDA=OFF
           cmake --build build -j
-      - name: Test CPU-only C++ tests
-        run: |
-          cp /usr/local/lib/libstarpu-*.so* /usr/lib
-          ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)" --output-on-failure
       - name: Upload all shared objects (*.so)
         uses: actions/upload-artifact@v4.3.4
         with:
           name: shared-objects-${{ matrix.python-version }}
           path: build/**/*.so
           retention-days: 7
+      - name: Test CPU-only C++ tests
+        run: |
+          ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)" --output-on-failure
 
   test-python:
     name: Run CPU-only tests with Python ${{ matrix.python-version }}

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -94,7 +94,9 @@ jobs:
       - name: Build NNTile native libraries
         run: |
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_CUDA=OFF
-          cmake --build build
+          cmake --build build -j
+      - name: Test CPU-only C++ tests
+        run: ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)"
       - name: Upload all shared objects (*.so)
         uses: actions/upload-artifact@v4.3.4
         with:

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -96,7 +96,9 @@ jobs:
           cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_CUDA=OFF
           cmake --build build -j
       - name: Test CPU-only C++ tests
-        run: ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)"
+        run: |
+          cp /usr/local/lib/libstarpu-*.so* /usr/lib
+          ctest --test-dir build -E wrappers -LE "(MPI|NotImplemented)" --output-on-failure
       - name: Upload all shared objects (*.so)
         uses: actions/upload-artifact@v4.3.4
         with:

--- a/include/nntile/base_types.hh
+++ b/include/nntile/base_types.hh
@@ -574,7 +574,7 @@ public:
         auto val = *reinterpret_cast<const __nv_bfloat16 *>(&value);
         return __bfloat162float(val);
 #else
-        std::uint32_t raw_uint32 = value;
+        std::uint32_t raw_uint32 = static_cast<std::uint32_t>(value) << 16;
         return *reinterpret_cast<repr_t *>(&raw_uint32);
 #endif
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add CPU-only C++ tests to CI, install StarPU to /usr with updated artifacts and faster builds, and fix bf16 CPU to_repr conversion.
> 
> - **CI**:
>   - **Workflows** (`.github/workflows/on-push.yml`, `.github/workflows/on-schedule.yml`):
>     - Install StarPU with `--prefix=/usr`; upload artifacts from `/usr/lib/libstarpu*.so*`.
>     - Speed up native build with `cmake --build ... -j`.
>     - Add CPU-only C++ tests step using `ctest` (exclude `wrappers`, labels `MPI|NotImplemented`).
> - **Core**:
>   - **`include/nntile/base_types.hh`**: Fix `bf16_t::to_repr` (non-CUDA) by left-shifting the raw value by 16 bits when reconstructing `float`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7870c8f1e31e9b2bde6c8d08e757fe1eb344f2b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->