### PR TITLE
Rename and update norm_fiber API

### DIFF
--- a/include/nntile/tile/norm_fiber_inplace.hh
+++ b/include/nntile/tile/norm_fiber_inplace.hh
@@ -21,12 +21,12 @@ namespace nntile::tile
 
 // Tile-wise norm_fiber_inplace
 template<typename T>
-void norm_fiber_inplace_async(Scalar alpha, const Tile<T> &src, Scalar beta, const Tile<T> &dst,
-        Index axis, Index batch_ndim, int redux=0);
+void norm_fiber_inplace_async(Scalar alpha, const Tile<T> &src, const Tile<T> &dst,
+        Index axis);
 
 // Tile-wise norm_fiber_inplace
 template<typename T>
-void norm_fiber_inplace(Scalar alpha, const Tile<T> &src, Scalar beta, const Tile<T> &dst,
-        Index axis, Index batch_ndim, int redux=0);
+void norm_fiber_inplace(Scalar alpha, const Tile<T> &src, const Tile<T> &dst,
+        Index axis);
 
 } // namespace nntile::tile

--- a/src/tile/norm_fiber_inplace.cc
+++ b/src/tile/norm_fiber_inplace.cc
@@ -19,9 +19,14 @@ namespace nntile::tile
 {
 
 template<typename T>
-void norm_fiber_inplace_async(Scalar alpha, const Tile<T> &src, Scalar beta,
-        const Tile<T> &dst, Index axis, Index batch_ndim, int redux)
+void norm_fiber_inplace_async(Scalar alpha, const Tile<T> &src,
+        const Tile<T> &dst, Index axis)
 {
+    // Default values for removed parameters
+    Scalar beta = 0.0;
+    Index batch_ndim = 0;
+    int redux = 0;
+
     // Check dimensions
     if(dst.ndim != batch_ndim+1)
     {
@@ -62,41 +67,41 @@ void norm_fiber_inplace_async(Scalar alpha, const Tile<T> &src, Scalar beta,
     n = src.matrix_shape[axis+1][1] / batch;
     k = src.shape[axis];
     // Insert task
-    starpu::norm_fiber_inplace.submit<std::tuple<T>>(m, n, k, batch, alpha, src, beta, dst);
+    starpu::norm_fiber_inplace.submit<std::tuple<T>>(m, n, k, batch, alpha, src, beta, dst, redux);
 }
 
 template<typename T>
-void norm_fiber_inplace(Scalar alpha, const Tile<T> &src, Scalar beta, const Tile<T> &dst,
-        Index axis, Index batch_ndim, int redux)
+void norm_fiber_inplace(Scalar alpha, const Tile<T> &src, const Tile<T> &dst,
+        Index axis)
 {
-    norm_fiber_inplace_async<T>(alpha, src, beta, dst, axis, batch_ndim, redux);
+    norm_fiber_inplace_async<T>(alpha, src, dst, axis);
     starpu_task_wait_for_all();
 }
 
 // Explicit instantiation
 template
 void norm_fiber_inplace_async<fp32_t>(Scalar alpha, const Tile<fp32_t> &src,
-        Scalar beta, const Tile<fp32_t> &dst, Index axis, Index batch_ndim, int redux=0);
+        const Tile<fp32_t> &dst, Index axis);
 
 template
 void norm_fiber_inplace_async<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src,
-        Scalar beta, const Tile<fp32_fast_tf32_t> &dst, Index axis, Index batch_ndim, int redux=0);
+        const Tile<fp32_fast_tf32_t> &dst, Index axis);
 
 template
 void norm_fiber_inplace_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src,
-        Scalar beta, const Tile<fp32_fast_fp16_t> &dst, Index axis, Index batch_ndim, int redux=0);
+        const Tile<fp32_fast_fp16_t> &dst, Index axis);
 
 template
 void norm_fiber_inplace_async<fp32_fast_bf16_t>(Scalar alpha, const Tile<fp32_fast_bf16_t> &src,
-        Scalar beta, const Tile<fp32_fast_bf16_t> &dst, Index axis, Index batch_ndim, int redux=0);
+        const Tile<fp32_fast_bf16_t> &dst, Index axis);
 
 template
 void norm_fiber_inplace_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &src,
-        Scalar beta, const Tile<fp64_t> &dst, Index axis, Index batch_ndim, int redux=0);
+        const Tile<fp64_t> &dst, Index axis);
 
 template
-void norm_fiber_inplace_async<bf16_t>(Scalar alpha, const Tile<bf16_t> &src, Scalar beta,
-        const Tile<bf16_t> &dst, Index axis, Index batch_ndim, int redux=0);
+void norm_fiber_inplace_async<bf16_t>(Scalar alpha, const Tile<bf16_t> &src,
+        const Tile<bf16_t> &dst, Index axis);
 
 // Explicit instantiation
 template


### PR DESCRIPTION
Refactor `norm_fiber_inplace` API to `(alpha, src, dst, axis)` by reordering parameters and internalizing `beta`, `batch_ndim`, and `redux` for simplification.

---
<a href="https://cursor.com/background-agent?bcId=bc-6caed90f-5242-4f5e-a5d0-2188f917a1f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6caed90f-5242-4f5e-a5d0-2188f917a1f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

