### PR TITLE
update multiply_inplace API

### DIFF
--- a/include/nntile/kernel/multiply_inplace/cpu.hh
+++ b/include/nntile/kernel/multiply_inplace/cpu.hh
@@ -21,7 +21,7 @@ namespace nntile::kernel::multiply_inplace
 
 // Per-element product of two buffers
 template<typename T>
-void cpu(Index nelems, const T *src, T *dst)
+void cpu(Index nelems, Scalar alpha, const T *src, T *dst)
     noexcept;
 
 } // namespace nntile::kernel::multiply_inplace

--- a/include/nntile/kernel/multiply_inplace/cuda.hh
+++ b/include/nntile/kernel/multiply_inplace/cuda.hh
@@ -21,7 +21,7 @@ namespace nntile::kernel::multiply_inplace
 {
 
 template<typename T>
-void cuda(cudaStream_t stream, Index nelems, const T *src, T *dst)
+void cuda(cudaStream_t stream, Index nelems, Scalar alpha, const T *src, T *dst)
     noexcept;
 
 } // namespace nntile::kernel::multiply_inplace

--- a/include/nntile/starpu/multiply_inplace.hh
+++ b/include/nntile/starpu/multiply_inplace.hh
@@ -46,6 +46,7 @@ public:
     struct args_t
     {
         Index nelems;
+        Scalar alpha;
     };
 
     //! Footprint function for the current operation
@@ -77,6 +78,7 @@ public:
     //! Submit multiply_inplace task
     void submit(
         Index nelems,
+        Scalar alpha,
         Handle src,
         Handle dst
     );

--- a/include/nntile/tensor/multiply_inplace.hh
+++ b/include/nntile/tensor/multiply_inplace.hh
@@ -21,10 +21,10 @@ namespace nntile::tensor
 
 // Asynchronous tensor-wise multiply operation
 template<typename T>
-void multiply_inplace_async(const Tensor<T> &src, const Tensor<T> &dst);
+void multiply_inplace_async(Scalar alpha, const Tensor<T> &src, const Tensor<T> &dst);
 
 // Blocking version of tensor-wise multiply operation
 template<typename T>
-void multiply_inplace(const Tensor<T> &src, const Tensor<T> &dst);
+void multiply_inplace(Scalar alpha, const Tensor<T> &src, const Tensor<T> &dst);
 
 } // namespace nntile::tensor

--- a/include/nntile/tile/multiply_inplace.hh
+++ b/include/nntile/tile/multiply_inplace.hh
@@ -20,9 +20,9 @@ namespace nntile::tile
 {
 
 template<typename T>
-void multiply_inplace_async(const Tile<T> &src, const Tile<T> &dst);
+void multiply_inplace_async(Scalar alpha, const Tile<T> &src, const Tile<T> &dst);
 
 template<typename T>
-void multiply_inplace(const Tile<T> &src, const Tile<T> &dst);
+void multiply_inplace(Scalar alpha, const Tile<T> &src, const Tile<T> &dst);
 
 } // namespace nntile::tile

--- a/src/kernel/multiply_inplace/cpu.cc
+++ b/src/kernel/multiply_inplace/cpu.cc
@@ -19,12 +19,13 @@ namespace nntile::kernel::multiply_inplace
 {
 
 template<typename T>
-void cpu(Index nelems, const T *src, T *dst)
+void cpu(Index nelems, Scalar alpha, const T *src, T *dst)
     noexcept
 //! Per-element product of two buffers
 /*! One of the buffers serves as output
  *
  * @param[in] nelems: Number of elements in both buffers
+ * @param[in] alpha: Scalar multiplier
  * @param[in] src: Input buffer
  * @param[inout] dst: Input buffers that contains output in the end
  * */
@@ -33,30 +34,25 @@ void cpu(Index nelems, const T *src, T *dst)
     // Cycle over buffers
     for(Index i = 0; i < nelems; ++i)
     {
-        dst[i] = static_cast<T>(Y{dst[i]} * Y{src[i]});
+        dst[i] = static_cast<T>(alpha * Y{dst[i]} * Y{src[i]});
     }
 }
 
 // Explicit instantiation
 template
-void cpu<fp32_t>(Index nelems, const fp32_t *src, fp32_t *dst)
+void cpu<fp32_t>(Index nelems, Scalar alpha, const fp32_t *src, fp32_t *dst)
     noexcept;
 
 template
-void cpu<fp32_fast_tf32_t>(Index nelems, const fp32_fast_tf32_t *src,
-        fp32_fast_tf32_t *dst)
+void cpu<fp64_t>(Index nelems, Scalar alpha, const fp64_t *src, fp64_t *dst)
     noexcept;
 
 template
-void cpu<fp64_t>(Index nelems, const fp64_t *src, fp64_t *dst)
+void cpu<bf16_t>(Index nelems, Scalar alpha, const bf16_t *src, bf16_t *dst)
     noexcept;
 
 template
-void cpu<bf16_t>(Index nelems, const bf16_t *src, bf16_t *dst)
-    noexcept;
-
-template
-void cpu<fp16_t>(Index nelems, const fp16_t *src, fp16_t *dst)
+void cpu<fp16_t>(Index nelems, Scalar alpha, const fp16_t *src, fp16_t *dst)
     noexcept;
 
 } // namespace nntile::kernel::multiply_inplace

--- a/src/tensor/multiply_inplace.cc
+++ b/src/tensor/multiply_inplace.cc
@@ -20,11 +20,12 @@ namespace nntile::tensor
 {
 
 //! Asynchronous tensor-wise prod operation
-/*! @param[in] src: Input tensor for the prod operation
+/*! @param[in] alpha: Scalar multiplier
+ * @param[in] src: Input tensor for the prod operation
  * @param[inout] dst: Input and output tensor for the prod operation
  * */
 template<typename T>
-void multiply_inplace_async(const Tensor<T> &src, const Tensor<T> &dst)
+void multiply_inplace_async(Scalar alpha, const Tensor<T> &src, const Tensor<T> &dst)
 {
     // Check shapes
     if(src.shape != dst.shape)
@@ -50,7 +51,7 @@ void multiply_inplace_async(const Tensor<T> &src, const Tensor<T> &dst)
         if(mpi_rank == dst_tile_rank)
         {
             auto traits = src.get_tile_traits(i);
-            starpu::multiply_inplace.submit<std::tuple<T>>(traits.nelems, src_tile_handle,
+            starpu::multiply_inplace.submit<std::tuple<T>>(traits.nelems, alpha, src_tile_handle,
                     dst_tile_handle);
         }
         // Flush cache for the output tile on every node
@@ -59,73 +60,74 @@ void multiply_inplace_async(const Tensor<T> &src, const Tensor<T> &dst)
 }
 
 //! Blocking version of tensor-wise prod operation
-/*! @param[in] src: Input tensor for the prod operation
+/*! @param[in] alpha: Scalar multiplier
+ * @param[in] src: Input tensor for the prod operation
  * @param[inout] dst: Input and output tensor for the prod operation
  * */
 template<typename T>
-void multiply_inplace(const Tensor<T> &src, const Tensor<T> &dst)
+void multiply_inplace(Scalar alpha, const Tensor<T> &src, const Tensor<T> &dst)
 {
-    multiply_inplace_async<T>(src, dst);
+    multiply_inplace_async<T>(alpha, src, dst);
     starpu_task_wait_for_all();
     starpu_mpi_wait_for_all(MPI_COMM_WORLD);
 }
 
 // Explicit instantiation
 template
-void multiply_inplace_async<fp32_t>(const Tensor<fp32_t> &src,
+void multiply_inplace_async<fp32_t>(Scalar alpha, const Tensor<fp32_t> &src,
         const Tensor<fp32_t> &dst);
 
 template
-void multiply_inplace_async<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
+void multiply_inplace_async<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src,
         const Tensor<fp32_fast_tf32_t> &dst);
 
 template
-void multiply_inplace_async<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+void multiply_inplace_async<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src,
         const Tensor<fp32_fast_fp16_t> &dst);
 
 template
-void multiply_inplace_async<fp32_fast_bf16_t>(const Tensor<fp32_fast_bf16_t> &src,
+void multiply_inplace_async<fp32_fast_bf16_t>(Scalar alpha, const Tensor<fp32_fast_bf16_t> &src,
         const Tensor<fp32_fast_bf16_t> &dst);
 
 template
-void multiply_inplace_async<fp64_t>(const Tensor<fp64_t> &src,
+void multiply_inplace_async<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src,
         const Tensor<fp64_t> &dst);
 
 template
-void multiply_inplace_async<bf16_t>(const Tensor<bf16_t> &src,
+void multiply_inplace_async<bf16_t>(Scalar alpha, const Tensor<bf16_t> &src,
         const Tensor<bf16_t> &dst);
 
 template
-void multiply_inplace_async<fp16_t>(const Tensor<fp16_t> &src,
+void multiply_inplace_async<fp16_t>(Scalar alpha, const Tensor<fp16_t> &src,
         const Tensor<fp16_t> &dst);
 
 // Explicit instantiation
 template
-void multiply_inplace<fp32_t>(const Tensor<fp32_t> &src,
+void multiply_inplace<fp32_t>(Scalar alpha, const Tensor<fp32_t> &src,
         const Tensor<fp32_t> &dst);
 
 template
-void multiply_inplace<fp32_fast_tf32_t>(const Tensor<fp32_fast_tf32_t> &src,
+void multiply_inplace<fp32_fast_tf32_t>(Scalar alpha, const Tensor<fp32_fast_tf32_t> &src,
         const Tensor<fp32_fast_tf32_t> &dst);
 
 template
-void multiply_inplace<fp32_fast_fp16_t>(const Tensor<fp32_fast_fp16_t> &src,
+void multiply_inplace<fp32_fast_fp16_t>(Scalar alpha, const Tensor<fp32_fast_fp16_t> &src,
         const Tensor<fp32_fast_fp16_t> &dst);
 
 template
-void multiply_inplace<fp32_fast_bf16_t>(const Tensor<fp32_fast_bf16_t> &src,
+void multiply_inplace<fp32_fast_bf16_t>(Scalar alpha, const Tensor<fp32_fast_bf16_t> &src,
         const Tensor<fp32_fast_bf16_t> &dst);
 
 template
-void multiply_inplace<fp64_t>(const Tensor<fp64_t> &src,
+void multiply_inplace<fp64_t>(Scalar alpha, const Tensor<fp64_t> &src,
         const Tensor<fp64_t> &dst);
 
 template
-void multiply_inplace<bf16_t>(const Tensor<bf16_t> &src,
+void multiply_inplace<bf16_t>(Scalar alpha, const Tensor<bf16_t> &src,
         const Tensor<bf16_t> &dst);
 
 template
-void multiply_inplace<fp16_t>(const Tensor<fp16_t> &src,
+void multiply_inplace<fp16_t>(Scalar alpha, const Tensor<fp16_t> &src,
         const Tensor<fp16_t> &dst);
 
 } // namespace nntile::tensor

--- a/src/tile/multiply_inplace.cc
+++ b/src/tile/multiply_inplace.cc
@@ -19,11 +19,12 @@ namespace nntile::tile
 {
 
 //! Asynchronous version of tile-wise multiply operation
-/*! @param[in] src: Input tile for element-wise multiply operation
+/*! @param[in] alpha: Scalar multiplier
+ * @param[in] src: Input tile for element-wise multiply operation
  * @param[inout] dst: Input and output tile for the multiply operation
  * */
 template<typename T>
-void multiply_inplace_async(const Tile<T> &src, const Tile<T> &dst)
+void multiply_inplace_async(Scalar alpha, const Tile<T> &src, const Tile<T> &dst)
 {
     // Check shapes
     if(src.shape != dst.shape)
@@ -31,71 +32,72 @@ void multiply_inplace_async(const Tile<T> &src, const Tile<T> &dst)
         throw std::runtime_error("src.shape != dst.shape");
     }
     // Submit task
-    starpu::multiply_inplace.submit<std::tuple<T>>(src.nelems, src, dst);
+    starpu::multiply_inplace.submit<std::tuple<T>>(src.nelems, alpha, src, dst);
 }
 
 //! Blocking version of tile-wise multiply operation
-/*! @param[in] src: Input tile for element-wise multiply operation
+/*! @param[in] alpha: Scalar multiplier
+ * @param[in] src: Input tile for element-wise multiply operation
  * @param[inout] dst: Input and output tile for the multiply operation
  * */
 template<typename T>
-void multiply_inplace(const Tile<T> &src, const Tile<T> &dst)
+void multiply_inplace(Scalar alpha, const Tile<T> &src, const Tile<T> &dst)
 {
-    multiply_inplace_async<T>(src, dst);
+    multiply_inplace_async<T>(alpha, src, dst);
     starpu_task_wait_for_all();
 }
 
 // Explicit instantiation
 template
-void multiply_inplace_async<fp32_t>(const Tile<fp32_t> &src,
+void multiply_inplace_async<fp32_t>(Scalar alpha, const Tile<fp32_t> &src,
         const Tile<fp32_t> &dst);
 
 template
-void multiply_inplace_async<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src,
+void multiply_inplace_async<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src,
         const Tile<fp32_fast_tf32_t> &dst);
 
 template
-void multiply_inplace_async<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src,
+void multiply_inplace_async<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src,
         const Tile<fp32_fast_fp16_t> &dst);
 
 template
-void multiply_inplace_async<fp32_fast_bf16_t>(const Tile<fp32_fast_bf16_t> &src,
+void multiply_inplace_async<fp32_fast_bf16_t>(Scalar alpha, const Tile<fp32_fast_bf16_t> &src,
         const Tile<fp32_fast_bf16_t> &dst);
 
 template
-void multiply_inplace_async<fp64_t>(const Tile<fp64_t> &src,
+void multiply_inplace_async<fp64_t>(Scalar alpha, const Tile<fp64_t> &src,
         const Tile<fp64_t> &dst);
 
 template
-void multiply_inplace_async<bf16_t>(const Tile<bf16_t> &src,
+void multiply_inplace_async<bf16_t>(Scalar alpha, const Tile<bf16_t> &src,
         const Tile<bf16_t> &dst);
 
 template
-void multiply_inplace_async<fp16_t>(const Tile<fp16_t> &src, const Tile<fp16_t> &dst);
+void multiply_inplace_async<fp16_t>(Scalar alpha, const Tile<fp16_t> &src, const Tile<fp16_t> &dst);
 
 // Explicit instantiation
 template
-void multiply_inplace<fp32_t>(const Tile<fp32_t> &src, const Tile<fp32_t> &dst);
+void multiply_inplace<fp32_t>(Scalar alpha, const Tile<fp32_t> &src, const Tile<fp32_t> &dst);
 
 template
-void multiply_inplace<fp32_fast_tf32_t>(const Tile<fp32_fast_tf32_t> &src,
+void multiply_inplace<fp32_fast_tf32_t>(Scalar alpha, const Tile<fp32_fast_tf32_t> &src,
         const Tile<fp32_fast_tf32_t> &dst);
 
 template
-void multiply_inplace<fp32_fast_fp16_t>(const Tile<fp32_fast_fp16_t> &src,
+void multiply_inplace<fp32_fast_fp16_t>(Scalar alpha, const Tile<fp32_fast_fp16_t> &src,
         const Tile<fp32_fast_fp16_t> &dst);
 
 template
-void multiply_inplace<fp32_fast_bf16_t>(const Tile<fp32_fast_bf16_t> &src,
+void multiply_inplace<fp32_fast_bf16_t>(Scalar alpha, const Tile<fp32_fast_bf16_t> &src,
         const Tile<fp32_fast_bf16_t> &dst);
 
 template
-void multiply_inplace<fp64_t>(const Tile<fp64_t> &src, const Tile<fp64_t> &dst);
+void multiply_inplace<fp64_t>(Scalar alpha, const Tile<fp64_t> &src, const Tile<fp64_t> &dst);
 
 template
-void multiply_inplace<bf16_t>(const Tile<bf16_t> &src, const Tile<bf16_t> &dst);
+void multiply_inplace<bf16_t>(Scalar alpha, const Tile<bf16_t> &src, const Tile<bf16_t> &dst);
 
 template
-void multiply_inplace<fp16_t>(const Tile<fp16_t> &src, const Tile<fp16_t> &dst);
+void multiply_inplace<fp16_t>(Scalar alpha, const Tile<fp16_t> &src, const Tile<fp16_t> &dst);
 
 } // namespace nntile::tile

--- a/tests/kernel/multiply_inplace.cc
+++ b/tests/kernel/multiply_inplace.cc
@@ -63,12 +63,13 @@ template<typename T>
 void reference_multiply_inplace(TestData<T>& data)
 {
     using Y = typename T::repr_t;
+    Scalar alpha = 1.0;
 
     for(Index i = 0; i < data.nelems; ++i)
     {
         ref_t src_val = static_cast<Y>(data.src_init[i]);
         ref_t dst_val = static_cast<Y>(data.dst_init[i]);
-        data.dst_ref[i] = static_cast<Y>(src_val * dst_val);
+        data.dst_ref[i] = static_cast<Y>(alpha * src_val * dst_val);
     }
 }
 
@@ -198,6 +199,7 @@ void run_cpu_test(TestData<T>& data)
         {
             cpu<T>(
                 data.nelems,
+                1.0,
                 &src_cpu[0],
                 &dst_cpu[0]
             );
@@ -207,6 +209,7 @@ void run_cpu_test(TestData<T>& data)
     {
         cpu<T>(
             data.nelems,
+            1.0,
             &src_cpu[0],
             &dst_cpu[0]
         );
@@ -266,6 +269,7 @@ void run_cuda_test(TestData<T>& data)
             cuda<T>(
                 stream,
                 data.nelems,
+                1.0,
                 dev_src,
                 dev_dst
             );
@@ -277,6 +281,7 @@ void run_cuda_test(TestData<T>& data)
         cuda<T>(
             stream,
             data.nelems,
+            1.0,
             dev_src,
             dev_dst
         );

--- a/tests/starpu/multiply_inplace.cc
+++ b/tests/starpu/multiply_inplace.cc
@@ -41,13 +41,13 @@ void validate_cpu(Index nelems)
     std::vector<T> dst2(dst);
     // Launch low-level kernel
     std::cout << "Run kernel::multiply_inplace::cpu<" << T::short_name << ">\n";
-    kernel::multiply_inplace::cpu<T>(nelems, &src[0], &dst[0]);
+    kernel::multiply_inplace::cpu<T>(nelems, 1.0, &src[0], &dst[0]);
     // Check by actually submitting a task
     VariableHandle src_handle(&src[0], sizeof(T)*nelems),
         dst2_handle(&dst2[0], sizeof(T)*nelems);
     multiply_inplace.restrict_where(STARPU_CPU);
     std::cout << "Run starpu::multiply_inplace::submit<" << T::short_name << "> restricted to CPU\n";
-    multiply_inplace.submit<std::tuple<T>>(nelems, src_handle, dst2_handle);
+    multiply_inplace.submit<std::tuple<T>>(nelems, 1.0, src_handle, dst2_handle);
     starpu_task_wait_for_all();
     src_handle.unregister();
     dst2_handle.unregister();
@@ -96,7 +96,7 @@ void validate_cuda(Index nelems)
             cudaMemcpyHostToDevice);
     TEST_ASSERT(cuda_err == cudaSuccess);
     std::cout << "Run kernel::multiply_inplace::cuda<" << T::short_name << ">\n";
-    kernel::multiply_inplace::cuda<T>(stream, nelems, dev_src, dev_dst);
+    kernel::multiply_inplace::cuda<T>(stream, nelems, 1.0, dev_src, dev_dst);
     // Wait for result and destroy stream
     cuda_err = cudaStreamSynchronize(stream);
     TEST_ASSERT(cuda_err == cudaSuccess);
@@ -116,7 +116,7 @@ void validate_cuda(Index nelems)
         dst2_handle(&dst2[0], sizeof(T)*nelems);
     multiply_inplace.restrict_where(STARPU_CUDA);
     std::cout << "Run starpu::multiply_inplace::submit<" << T::short_name << "> restricted to CUDA\n";
-    multiply_inplace.submit<std::tuple<T>>(nelems, src_handle, dst2_handle);
+    multiply_inplace.submit<std::tuple<T>>(nelems, 1.0, src_handle, dst2_handle);
     starpu_task_wait_for_all();
     src_handle.unregister();
     dst2_handle.unregister();

--- a/tests/tensor/multiply_inplace.cc
+++ b/tests/tensor/multiply_inplace.cc
@@ -72,9 +72,9 @@ void check(const std::vector<Index> &shape, const std::vector<Index> &basetile)
     {
         auto src_tile = src_single.get_tile(0);
         auto dst_tile = dst_single.get_tile(0);
-        tile::multiply_inplace<T>(src_tile, dst_tile);
+        tile::multiply_inplace<T>(1.0, src_tile, dst_tile);
     }
-    multiply_inplace<T>(src, dst);
+    multiply_inplace<T>(1.0, src, dst);
     // Compare results
     Tensor<T> dst2_single(single_traits, dist_root);
     gather<T>(dst, dst2_single);

--- a/tests/tile/multiply_inplace.cc
+++ b/tests/tile/multiply_inplace.cc
@@ -47,15 +47,15 @@ void validate()
     src2_local.release();
     dst2_local.release();
     dst2_copy_local.release();
-    starpu::multiply_inplace.submit<std::tuple<T>>(1, src1, dst1);
-    multiply_inplace<T>(src1, dst1_copy);
+    starpu::multiply_inplace.submit<std::tuple<T>>(1, 1.0, src1, dst1);
+    multiply_inplace<T>(1.0, src1, dst1_copy);
     dst1_local.acquire(STARPU_R);
     dst1_copy_local.acquire(STARPU_R);
     TEST_ASSERT(Y(dst1_local[0]) == Y(dst1_copy_local[0]));
     dst1_local.release();
     dst1_copy_local.release();
-    starpu::multiply_inplace.submit<std::tuple<T>>(src2.nelems, src2, dst2);
-    multiply_inplace<T>(src2, dst2_copy);
+    starpu::multiply_inplace.submit<std::tuple<T>>(src2.nelems, 1.0, src2, dst2);
+    multiply_inplace<T>(1.0, src2, dst2_copy);
     dst2_local.acquire(STARPU_R);
     dst2_copy_local.acquire(STARPU_R);
     for(Index i = 0; i < src2.nelems; ++i)

--- a/wrappers/python/nntile/functions.py
+++ b/wrappers/python/nntile/functions.py
@@ -703,26 +703,26 @@ def multiply_async(alpha: float, x: Tensor, y: Tensor, z: Tensor) -> None:
         raise TypeError
 
 
-def multiply_inplace_async(x: Tensor, y: Tensor) -> None:
+def multiply_inplace_async(alpha: float, x: Tensor, y: Tensor) -> None:
     """
     Wrapper for multiprecision multiply_inplace
     """
     if type(x) is not type(y):
         raise TypeError
     if type(x) is core_tensor.Tensor_fp32:
-        core_tensor.multiply_inplace_async_fp32(x, y)
+        core_tensor.multiply_inplace_async_fp32(alpha, x, y)
     elif type(x) is core_tensor.Tensor_fp32_fast_tf32:
-        core_tensor.multiply_inplace_async_fp32_fast_tf32(x, y)
+        core_tensor.multiply_inplace_async_fp32_fast_tf32(alpha, x, y)
     elif type(x) is core_tensor.Tensor_fp32_fast_fp16:
-        core_tensor.multiply_inplace_async_fp32_fast_fp16(x, y)
+        core_tensor.multiply_inplace_async_fp32_fast_fp16(alpha, x, y)
     elif type(x) is core_tensor.Tensor_fp32_fast_bf16:
-        core_tensor.multiply_inplace_async_fp32_fast_bf16(x, y)
+        core_tensor.multiply_inplace_async_fp32_fast_bf16(alpha, x, y)
     elif type(x) is core_tensor.Tensor_fp64:
-        core_tensor.multiply_inplace_async_fp64(x, y)
+        core_tensor.multiply_inplace_async_fp64(alpha, x, y)
     elif type(x) is core_tensor.Tensor_bf16:
-        core_tensor.multiply_inplace_async_bf16(x, y)
+        core_tensor.multiply_inplace_async_bf16(alpha, x, y)
     elif type(x) is core_tensor.Tensor_fp16:
-        core_tensor.multiply_inplace_async_fp16(x, y)
+        core_tensor.multiply_inplace_async_fp16(alpha, x, y)
     else:
         raise TypeError
 

--- a/wrappers/python/nntile/layer/attention.py
+++ b/wrappers/python/nntile/layer/attention.py
@@ -1039,7 +1039,7 @@ class Attention(BaseLayer):
             # self.a_sumprod_slice.wont_use()
             self.a_sumprod_slice.invalidate_submit()
             # dA *= A
-            multiply_inplace_async(self.a.value, self.a.grad)
+            multiply_inplace_async(1.0, self.a.value, self.a.grad)
         # A can be deleted
         # self.a.value.wont_use()
         self.a.value.invalidate_submit()

--- a/wrappers/python/nntile/layer/attention_single_head.py
+++ b/wrappers/python/nntile/layer/attention_single_head.py
@@ -609,7 +609,7 @@ class AttentionSingleHead(BaseLayer):
             # A_sumprod_slice can be deleted
             self.a_sumprod_slice.invalidate_submit()
             # dA *= A
-            multiply_inplace_async(self.a.value, self.a.grad)
+            multiply_inplace_async(1.0, self.a.value, self.a.grad)
         # A can be deleted
         self.a.value.invalidate_submit()
         # Backward for mask if needed

--- a/wrappers/python/nntile/layer/batch_norm.py
+++ b/wrappers/python/nntile/layer/batch_norm.py
@@ -160,7 +160,7 @@ class BatchNorm2d(BaseLayer):
         xvar_grad = x_var_eps_ref
 
         pow_async(-0.5, -2.0 * -1.5, xvar_grad)  # fuse two powers from above
-        multiply_inplace_async(inv_denom_grad, xvar_grad)
+        multiply_inplace_async(1.0, inv_denom_grad, xvar_grad)
 
         # Compute grad d(variance)/d(x)
         # empty(self.x.value.shape)

--- a/wrappers/python/nntile/layer/bert_selfattention.py
+++ b/wrappers/python/nntile/layer/bert_selfattention.py
@@ -680,7 +680,7 @@ class BertSelfAttention(BaseLayer):
             # self.a_sumprod_slice.wont_use()
             self.a_sumprod_slice.invalidate_submit()
             # dA *= A
-            multiply_inplace_async(self.a.value, self.a.grad)
+            multiply_inplace_async(1.0, self.a.value, self.a.grad)
         # A can be deleted
         # self.a.value.wont_use()
         self.a.value.invalidate_submit()

--- a/wrappers/python/nntile/layer/gpt2_attention.py
+++ b/wrappers/python/nntile/layer/gpt2_attention.py
@@ -713,7 +713,7 @@ class GPT2Attention(BaseLayer):
             # self.a_sumprod_slice.wont_use()
             self.a_sumprod_slice.invalidate_submit()
             # dA *= A
-            multiply_inplace_async(self.a.value, self.a.grad)
+            multiply_inplace_async(1.0, self.a.value, self.a.grad)
         # A can be deleted
         # self.a.value.wont_use()
         self.a.value.invalidate_submit()

--- a/wrappers/python/nntile/layer/gpt_neo_attention.py
+++ b/wrappers/python/nntile/layer/gpt_neo_attention.py
@@ -640,7 +640,7 @@ class GPTNeoAttention(BaseLayer):
             # self.a_sumprod_slice.wont_use()
             self.a_sumprod_slice.invalidate_submit()
             # dA *= A
-            multiply_inplace_async(self.a.value, self.a.grad)
+            multiply_inplace_async(1.0, self.a.value, self.a.grad)
         # A can be deleted
         # self.a.value.wont_use()
         self.a.value.invalidate_submit()

--- a/wrappers/python/nntile/layer/gpt_neox_attention.py
+++ b/wrappers/python/nntile/layer/gpt_neox_attention.py
@@ -1434,7 +1434,7 @@ class GPTNeoXAttention(BaseLayer):
             # A_sumprod_slice can be deleted
             self.a_sumprod_slice.invalidate_submit()
             # dA *= A
-            multiply_inplace_async(self.a.value, self.a.grad)
+            multiply_inplace_async(1.0, self.a.value, self.a.grad)
         # A can be deleted
         self.a.value.invalidate_submit()
         # Backward for mask if needed

--- a/wrappers/python/nntile/layer/llama_attention.py
+++ b/wrappers/python/nntile/layer/llama_attention.py
@@ -2039,7 +2039,7 @@ class LlamaAttention(BaseLayer):
             # A_sumprod_slice can be deleted
             self.a_sumprod_slice.invalidate_submit()
             # dA *= A
-            multiply_inplace_async(self.a.value, self.a.grad)
+            multiply_inplace_async(1.0, self.a.value, self.a.grad)
         # A can be deleted
         self.a.value.invalidate_submit()
         # Backward for mask if needed

--- a/wrappers/python/nntile/layer/t5_attention.py
+++ b/wrappers/python/nntile/layer/t5_attention.py
@@ -1311,7 +1311,7 @@ class T5Attention(BaseLayer):
             # self.a_sumprod_slice.wont_use()
             self.a_sumprod_slice.invalidate_submit()
             # dA *= A
-            multiply_inplace_async(self.a.value, self.a.grad)
+            multiply_inplace_async(1.0, self.a.value, self.a.grad)
 
             if self.has_relative_bias:
                 self._add_positional_bias_backward()

--- a/wrappers/python/nntile/loss/frob.py
+++ b/wrappers/python/nntile/loss/frob.py
@@ -75,5 +75,5 @@ class Frob:
         #    self.x.grad.invalidate_submit()
         # Compute loss as 0.5*||dX||^2
         copy_async(self.val_sqrt, self.val)
-        multiply_inplace_async(self.val_sqrt, self.val)
+        multiply_inplace_async(1.0, self.val_sqrt, self.val)
         scale_inplace_async(0.5, self.val)

--- a/wrappers/python/tests/nntile_core/test_tensor_multiply_inplace.py
+++ b/wrappers/python/tests/nntile_core/test_tensor_multiply_inplace.py
@@ -44,7 +44,7 @@ def test_multiply_inplace(context, dtype):
     rand_B = rng.standard_normal(shape)
     np_B = np.array(rand_B, dtype=dtype, order='F')
     B.from_array(np_B)
-    multiply_inplace[dtype](A, B)
+    multiply_inplace[dtype](1.0, A, B)
     np_C = np.zeros(shape, dtype=dtype, order='F')
     B.to_array(np_C)
     nntile.starpu.wait_for_all()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce an `alpha` scalar parameter to `multiply_inplace` and propagate it through CPU/CUDA kernels, StarPU codelets, tensor/tile APIs, Python wrappers, and all call sites/tests.
> 
> - **Core Kernels (CPU/CUDA)**:
>   - Add `Scalar alpha` to `kernel::multiply_inplace::cpu/cuda` signatures and apply `alpha * src * dst`.
>   - Update CUDA kernel launch and device kernel to use `alpha`.
> - **StarPU Integration**:
>   - Extend `MultiplyInplace::args_t` with `alpha`; include in `footprint` hash.
>   - Update CPU/CUDA wrappers and `submit` to pass `alpha`.
> - **Tensor/Tile C++ APIs**:
>   - Add `alpha` to `tensor::multiply_inplace[_async]` and `tile::multiply_inplace[_async]`; propagate to StarPU submit.
> - **Python API**:
>   - Change `multiply_inplace_async(alpha, x, y)`; forward `alpha` to core bindings; update usages to pass `1.0`.
> - **Call Sites & Layers**:
>   - Update attention, batch norm, GPT*, LLaMA, T5, loss (Frobenius) to call `multiply_inplace_async(1.0, ...)`.
> - **Tests**:
>   - Adjust kernel, StarPU, tensor, tile, and Python tests to include `alpha` (typically `1.0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28e6551bfa5a31c539a5ba14031aaa3f8670bbb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->