### PR TITLE
Add cpp-coding style skill for cursor and clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,30 @@
+# Canonical profile for this repository. Matches
+# .cursor/skills/cpp-coding-style/ — adjust here if team rules change.
+#
+# Optional east const (clang-format 14+; remove if unsupported):
+# QualifierAlignment: Custom
+# QualifierOrder: ['static', 'constexpr', 'type', 'const', 'volatile']
+
+BasedOnStyle: LLVM
+Language: Cpp
+ColumnLimit: 79
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+BreakBeforeBraces: Allman
+AllowShortBlocksOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+BinPackParameters: false
+ExperimentalAutoDetectBinPacking: false
+AlignAfterOpenBracket: DontAlign
+BreakConstructorInitializers: AfterColon
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ReflowComments: true
+SortIncludes: true
+IncludeBlocks: Regroup
+PointerAlignment: Right
+ReferenceAlignment: Pointer
+SpaceAfterCStyleCast: true
+SpacesInParentheses: false

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,0 @@
-{
-  "snapshot": "snapshot-20260224-aadd4d40-08b0-47f1-9123-678ecb258223",
-  "terminals": []
-}

--- a/.cursor/skills/cpp-coding-style/SKILL.md
+++ b/.cursor/skills/cpp-coding-style/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: cpp-coding-style
+description: >-
+  C++ style: 79 columns, Allman braces, 4-space indent, Black-like wrapping,
+  includes, class layout, east const, final newline. Use for C++ edits,
+  reviews, refactors.
+---
+
+# C++ coding style (Black-inspired)
+
+Apply these rules when writing, editing, or reviewing C++ in this project.
+The repo root **`.clang-format`** is the canonical formatter profile; keep it
+aligned with this skill when either changes. For **template** / **switch**
+detail and edge cases, see [reference.md](reference.md).
+
+## Hard limits
+
+- **Line length**: at most **79 characters** per line (including spaces and
+  punctuation). Prefer breaking earlier at a natural boundary when it reads
+  better.
+- **Final newline**: every source file must end with a **newline** (POSIX
+  end-of-line), not EOF immediately after the last character.
+
+## Indentation
+
+- **4 spaces** per indent level; **no tab characters** for indentation.
+- Wrapped expressions: indent **one level** past the start of the statement
+  unless the file already uses a consistent alternative—then **do not mix**
+  styles in one file.
+
+## Braces (curly brackets)
+
+Use **Allman** style: `{` and `}` each on their **own line** for `if`, `for`,
+`while`, `else`, `switch`, `try`/`catch`, `struct`, `class`, `enum class`,
+**named and anonymous `namespace`**, and function definitions.
+
+```cpp
+void foo()
+{
+    if (condition)
+    {
+        body();
+    }
+    else
+    {
+        other();
+    }
+}
+```
+
+Multi-line lambdas use Allman `{` / `}`; if the signature overflows 79
+columns, break parameters like a normal function (see
+[reference.md](reference.md)).
+
+## Namespaces
+
+Opening `{` on its own line after the namespace header; closing `}` on its own
+line. Do not add an extra file-wide indent level for a single outer namespace
+**unless** the rest of the tree already does—**match neighboring files**.
+
+## Classes and structs
+
+- **`class` / `struct`**: name on one line, `{` on the next, closing `};` with
+  `}` on its own line.
+- **Access**: order sections **`public` → `protected` → `private`**; omit
+  empty sections.
+- **Members** (within each section): nested types / `using`, then static
+  constants, then ctors / dtor / assignment, then methods (group overloads),
+  then static methods, then data members. See [reference.md](reference.md) for
+  `struct` / `= default` details.
+
+## Includes
+
+Order: **associated header** (in `.cpp`), blank line, **project** headers,
+blank line, **third-party**, blank line, **standard library** (`<…>`). Use
+`#pragma once` or guards **as the project already does**.
+
+## `const`, pointers, references
+
+- Prefer **east const** (`T const`, `T const&`, `T const*`).
+- **Spacing**: keep `*` and `&` styling **consistent in the file** (e.g.
+  `T *p`, `T const &r`).
+
+## Long comments
+
+If a comment would exceed 79 characters: split into **multiple** `//` lines
+(or wrapped `/* */` lines), respecting word boundaries when possible.
+
+## Long function calls (Black-like)
+
+1. **`(` stays** on the same line as the callee (including `->` / `.` chains).
+2. First argument on the **next** line, indented one level.
+3. If still too long: **one argument per line**, **trailing commas** between
+   arguments, **`)` on its own line**.
+
+```cpp
+result = some_very_long_function_name(
+    first_argument,
+    second_argument,
+    third_argument,
+);
+```
+
+Apply the same rules **recursively** inside arguments. **Templates**
+(`make_shared`, etc.): same—`(` after the full callee, then break (see
+[reference.md](reference.md) for multi-line `template<>`).
+
+## Long expressions (`if`, `while`, chains)
+
+Break **before** `&&` / `||` so the continuation line **starts with the
+operator**. Keep `(` on the `if` / `while` line; indent continuations
+consistently.
+
+## Constructor initializer lists
+
+If the list does not fit: put **`:`** after the closing `)` of the ctor
+parameter list (or at the end of a wrapped ctor line), then **one base/member
+init per line**, **comma at end of line**, then Allman `{` on the next line
+after the list.
+
+## “Black spirit” (general)
+
+- Prefer vertical layout over dense one-liners near the limit.
+- One logical statement per line; spaces around binary operators and after
+  commas in single-line lists.
+- Use **`nullptr`**, not `0` / `NULL`, for null pointers in new code unless
+  constrained by legacy APIs.
+
+## Checklist before finishing an edit
+
+- [ ] No line longer than 79 characters.
+- [ ] 4 spaces; no tabs for indent.
+- [ ] Long comments split; long calls, conditions, ctor inits wrapped as
+      above.
+- [ ] Allman `{` / `}` for control flow, classes, namespaces, functions.
+- [ ] Includes grouped and ordered; associated header first in `.cpp`.
+- [ ] Class access / member order follows this skill.
+- [ ] East const; consistent `*` / `&` spacing within the file.
+- [ ] File ends with a newline.

--- a/.cursor/skills/cpp-coding-style/reference.md
+++ b/.cursor/skills/cpp-coding-style/reference.md
@@ -1,0 +1,250 @@
+# C++ style — reference
+
+Companion to [SKILL.md](SKILL.md). Read when applying rules to non-trivial
+constructs or setting up tooling.
+
+**Column width:** prose in this file uses at most **79 characters** per line.
+Indented `cpp` / `yaml` code blocks may exceed 79 where needed for valid
+syntax.
+
+## Indentation and tabs
+
+- **4 spaces** per indent level. **No tab characters** for indentation.
+- Continuation lines for wrapped calls, `if` conditions, and expressions:
+  indent **one level** (4 spaces) past the start of the statement, unless a
+  clearer local pattern already exists in the file—then stay consistent
+  **within that file**.
+
+## Namespaces
+
+Braces are **Allman** here too: `{` / `}` on their own lines.
+
+```cpp
+namespace project::detail
+{
+void helper();
+}
+
+namespace
+{
+void file_local();
+}
+```
+
+- **Do not** indent the entire file for an outer `namespace` wrapper unless the
+  codebase already does; if a file uses a single outer namespace, either no
+  extra indent inside it or one level—**match surrounding files**.
+- **Closing names** (e.g. `} // namespace detail`) are optional; if used, keep
+  the comment short and within 79 columns.
+
+## Classes and structs
+
+### Brace and semicolon
+
+```cpp
+class Widget
+{
+    // ...
+};
+
+struct Point
+{
+    int x;
+    int y;
+};
+```
+
+### Access order
+
+Default order (**top to bottom**): **`public`**, then **`protected`**, then
+**`private`**. Omit empty sections.
+
+### Member order (within each access section)
+
+1. Nested types / type aliases (`using`, `typedef`)
+2. Static constants (including `static constexpr`)
+3. Constructors, destructor, assignment operators
+4. Instance methods (group overloads together)
+5. Static methods
+6. Data members (static before instance, or match file convention—stay
+   consistent)
+
+`struct` defaults to public; still use explicit `public:` / `private:` when
+mixing.
+
+### `= default` / `= delete`
+
+Place on the **same line** as the declaration if it fits within 79 columns;
+otherwise break the signature first (parameters one per line), then keep
+`= default` on the last line of the declaration.
+
+## Includes
+
+1. **Associated header** (e.g. `foo.cpp` includes `foo.hpp` first).
+2. Blank line.
+3. **Project** headers.
+4. Blank line.
+5. **Third-party** headers.
+6. Blank line.
+7. **Standard library** headers (use `<cstdint>`-style C headers in C++).
+
+Use `#pragma once` or include guards—**match the project**. Guards, if used,
+wrap the whole file; the `#endif` comment must fit in 79 columns.
+
+## `const`, pointers, references
+
+- Prefer **east const**: use `T const`, `T const&`, and `T const*` so `const`
+  applies to what is on its left.
+- **References**: keep `*` / `&` consistent in the file. Pick either `T *p` /
+  `T &r` or `T* p` / `T& r`; default to `T *p` / `T &r` (space before `*` /
+  `&`) if undecided.
+
+## Control flow
+
+### `if` / `for` / `while`
+
+Space after keyword: `if (`, `for (`, `while (`.
+
+`else` / `catch` on a **new line**, with Allman braces:
+
+```cpp
+if (cond)
+{
+    ...
+}
+else
+{
+    ...
+}
+```
+
+### `switch`
+
+```cpp
+switch (tag)
+{
+case Kind::A:
+    handle_a();
+    break;
+case Kind::B:
+{
+    int scoped = 1;
+    handle_b(scoped);
+    break;
+}
+default:
+    break;
+}
+```
+
+Braces around a `case` body when it needs local variables or multi-line logic;
+`break` / `return` / `throw` explicit.
+
+### Long conditions
+
+Break **before** `&&` or `||` so the continuation line **starts** with the
+operator (Black-like readability):
+
+```cpp
+if (first_condition
+    && second_condition
+    && third_condition)
+{
+    ...
+}
+```
+
+Keep `(` on the line with `if`; indent continuation consistently (often 4
+spaces past `if`).
+
+## Constructor initializer lists
+
+Colon starts the list; if it does not fit in 79 columns, put the colon at the
+end of the constructor line and **one member per line**, **comma at end of
+line**:
+
+```cpp
+MyClass::MyClass(
+    Arg1 a1,
+    Arg2 a2,
+)
+    : base_(std::move(a1)),
+      member_(a2)
+{
+}
+```
+
+If the constructor name line is too long, wrap parameters using the same rules
+as function calls; then the `:` line as above.
+
+## Templates
+
+If `template<typename ...>` or the declaration exceeds 79 characters, break
+after `template<`, **one template parameter per line**, closing `>` on its own
+line if needed:
+
+```cpp
+template<
+    typename T,
+    typename Allocator,
+>
+class Vector
+{
+    ...
+};
+```
+
+Apply the same **call-wrapping** rules to function template arguments at call
+sites.
+
+## Lambdas
+
+- Prefer **named** lambdas or local structs when the body is large or reused.
+- For a multi-line lambda body, use **Allman** `{` / `}`.
+- If captures or parameters overflow 79 columns, break after `(` of the
+  parameter list (treat like a small function).
+
+## `using` and type aliases
+
+One primary name per alias statement; if the right-hand side is too long,
+break after `=` with continuation indented.
+
+## `clang-format` (canonical file)
+
+The **source of truth** is the repository root **`.clang-format`**. Run
+`clang-format` from the tree root (or ensure editors discover that file).
+
+`clang-format` cannot match Black exactly; that profile approximates **79
+columns**, **Allman**, and **fewer packed arguments**. Tune the repo root
+**`.clang-format`** if the team refines rules.
+
+**Key options** (see root file for full list):
+
+- `ColumnLimit: 79`, `BreakBeforeBraces: Allman`, `IndentWidth: 4`,
+  `UseTab: Never`
+- `BinPackArguments: false`, `BinPackParameters: false`,
+  `AlignAfterOpenBracket: DontAlign`
+- `BreakConstructorInitializers: AfterColon` (line-ending commas on inits;
+  switch to `BeforeComma` for leading-comma style)
+
+**Notes:**
+
+- `AllowShortBlocksOnASingleLine`, `AllowShortIfStatementsOnASingleLine`, and
+  `AllowShortLoopsOnASingleLine` use boolean `false` (not `Never`) so the YAML
+  parses across `clang-format` versions.
+- `AfterColon` tends to put **one initializer per line** with commas at **line
+  ends** (closer to Black-style trailing commas than `BeforeComma`, which uses
+  leading commas on the next line). Prefer `BeforeComma` if the team wants
+  leading commas.
+- Optional on newer `clang-format` for **east const** (verify with your
+  version): uncomment the `QualifierAlignment` / `QualifierOrder` lines at the
+  top of **`.clang-format`** — drop if unsupported or noisy.
+- Review diffs: some versions pack differently; **project consistency** beats
+  blind tooling.
+
+## Preprocessor
+
+- Prefer wrapping long `#define` bodies with backslash-newline; each
+  continuation line obeys 79 columns.
+- Indent code inside `#if 0` / feature macros consistently with the rest of
+  the file.

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@ build/
 __pycache__
 .venv/
 
+# Cursor: ignore machine-local state; track only shared skills under .cursor/skills/
+.cursor/*
+!.cursor/skills/
+!.cursor/skills/**
+
 # Binary test data (generated at test time via CTest fixture)
 *.safetensors

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.cursor/
 build/
 .vscode
 __pycache__


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds/adjusts formatting and editor guidance only, with no runtime or build logic changes beyond potential formatting churn.
> 
> **Overview**
> Introduces a repository-wide **C++ formatting standard** via a new root `.clang-format` (79-column limit, Allman braces, non-binpacked wrapping, include sorting/regrouping, etc.).
> 
> Adds a shared Cursor skill under `.cursor/skills/cpp-coding-style/` documenting the same conventions (plus a detailed `reference.md`), and updates `.gitignore` to ignore machine-local `.cursor` state while keeping shared skills tracked; removes `.cursor/environment.json` from version control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19087ec16d5f06f30714833a10ba71eb754f3db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->