### PR TITLE
GPT-NeoX graph model, tests, and training example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -115,3 +115,8 @@ add_example(TARGET_NAME examples_gptneo_graph_training
     EXEC_NAME "gptneo_graph_training"
     SOURCES "gptneo_graph_training.cc"
     LINK_LIBRARIES nntile)
+
+add_example(TARGET_NAME examples_gpt_neox_generate
+    EXEC_NAME "gpt_neox_generate"
+    SOURCES "gpt_neox_generate.cc"
+    LINK_LIBRARIES nntile)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -120,3 +120,8 @@ add_example(TARGET_NAME examples_gpt_neox_generate
     EXEC_NAME "gpt_neox_generate"
     SOURCES "gpt_neox_generate.cc"
     LINK_LIBRARIES nntile)
+
+add_example(TARGET_NAME examples_gptneox_graph_training
+    EXEC_NAME "gptneox_graph_training"
+    SOURCES "gptneox_graph_training.cc"
+    LINK_LIBRARIES nntile)

--- a/examples/gpt_neox_generate.cc
+++ b/examples/gpt_neox_generate.cc
@@ -1,0 +1,389 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file examples/gpt_neox_generate.cc
+ * Autoregressive text generation with a GPT-NeoX causal LM.
+ *
+ * Workflow (two-step):
+ *
+ *   # Step 1 – Convert HF checkpoint and tokenize the prompt (Python):
+ *   python examples/gpt_neox_generate.py \
+ *       --model EleutherAI/gpt-neox-125m \
+ *       --output-dir /tmp/nntile_gptneox \
+ *       --prompt "The meaning of life is"
+ *
+ *   # Step 2 – Run autoregressive generation (this binary):
+ *   ./gpt_neox_generate \
+ *       --config /tmp/nntile_gptneox/config.json \
+ *       --weights /tmp/nntile_gptneox/weights.safetensors \
+ *       --prompt-ids "$(cat /tmp/nntile_gptneox/prompt_ids.txt)" \
+ *       --max-tokens 32
+ *
+ * Alternatively, let the binary call the Python script automatically:
+ *   ./gpt_neox_generate \
+ *       --model EleutherAI/gpt-neox-125m \
+ *       --prompt "The meaning of life is" \
+ *       --max-tokens 32
+ *
+ * @version 1.1.0
+ * */
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+#include <nntile.hh>
+#include <nntile/graph/io/safetensors.hh>
+#include <nntile/graph/model/gptneox/gptneox_causal.hh>
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+#include <nlohmann/json.hpp>
+
+using namespace nntile;
+using namespace nntile::graph;
+using namespace nntile::model::gptneox;
+using json = nlohmann::json;
+
+// ── CLI helpers ──────────────────────────────────────────────────────────
+
+struct Args
+{
+    std::string config_path;
+    std::string weights_path;
+    std::string prompt_ids_str;
+    std::string model;
+    std::string prompt;
+    std::string output_dir = "/tmp/nntile_gptneox";
+    int max_tokens = 32;
+};
+
+static Args parse_args(int argc, char** argv)
+{
+    Args a;
+    for(int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if(arg == "--config" && i + 1 < argc)
+            a.config_path = argv[++i];
+        else if(arg == "--weights" && i + 1 < argc)
+            a.weights_path = argv[++i];
+        else if(arg == "--prompt-ids" && i + 1 < argc)
+            a.prompt_ids_str = argv[++i];
+        else if((arg == "--model" || arg == "--model-dir") && i + 1 < argc)
+            a.model = argv[++i];
+        else if(arg == "--prompt" && i + 1 < argc)
+            a.prompt = argv[++i];
+        else if(arg == "--output-dir" && i + 1 < argc)
+            a.output_dir = argv[++i];
+        else if(arg == "--max-tokens" && i + 1 < argc)
+            a.max_tokens = std::stoi(argv[++i]);
+        else if(arg == "--help" || arg == "-h")
+        {
+            std::cout
+                << "Usage: " << argv[0] << " [options]\n\n"
+                << "Option A – provide pre-converted files:\n"
+                << "  --config <path>       config.json (from gpt_neox_generate.py)\n"
+                << "  --weights <path>      weights.safetensors\n"
+                << "  --prompt-ids <ids>    comma-separated token IDs\n\n"
+                << "Option B – let the binary call Python automatically:\n"
+                << "  --model <name|path>   HF model name or local path\n"
+                << "  --prompt <text>       text prompt\n"
+                << "  --output-dir <path>   scratch directory "
+                   "(default: /tmp/nntile_gptneox)\n\n"
+                << "Common:\n"
+                << "  --max-tokens <N>      tokens to generate (default: 32)\n";
+            std::exit(0);
+        }
+    }
+    return a;
+}
+
+static std::vector<std::int64_t> parse_ids(const std::string& s)
+{
+    std::string data = s;
+    {
+        std::ifstream f(s);
+        if(f.good())
+        {
+            std::string contents((std::istreambuf_iterator<char>(f)),
+                                  std::istreambuf_iterator<char>());
+            if(!contents.empty())
+                data = contents;
+        }
+    }
+
+    std::vector<std::int64_t> ids;
+    std::istringstream ss(data);
+    std::string tok;
+    while(std::getline(ss, tok, ','))
+    {
+        while(!tok.empty() && (tok.back() == '\n' || tok.back() == '\r'))
+            tok.pop_back();
+        if(!tok.empty())
+            ids.push_back(std::stoll(tok));
+    }
+    return ids;
+}
+
+// ── Config loader ────────────────────────────────────────────────────────
+
+static GptneoxConfig load_config(const std::string& path)
+{
+    std::ifstream f(path);
+    if(!f.good())
+    {
+        throw std::runtime_error("Cannot open config: " + path);
+    }
+    json j = json::parse(f);
+
+    GptneoxConfig cfg;
+    cfg.vocab_size           = j.value("vocab_size", 50280);
+    cfg.hidden_size          = j.value("hidden_size", 1024);
+    cfg.intermediate_size    = j.value("intermediate_size", 4096);
+    cfg.num_hidden_layers    = j.value("num_hidden_layers", 24);
+    cfg.num_attention_heads  = j.value("num_attention_heads", 16);
+    cfg.layer_norm_eps       = j.value("layer_norm_eps", 1e-5f);
+    cfg.rotary_pct           = j.value("rotary_pct", 0.25f);
+    cfg.rotary_emb_base      = j.value("rotary_emb_base", 10000.0f);
+    cfg.use_parallel_residual = j.value("use_parallel_residual", true);
+    cfg.eos_token_id         = j.value("eos_token_id", 50256);
+    cfg.bos_token_id         = j.value("bos_token_id", 50256);
+    cfg.compute_head_dim();
+    cfg.validate();
+    return cfg;
+}
+
+// ── Weight cache ─────────────────────────────────────────────────────────
+
+using WeightCache = std::map<std::string, std::vector<std::uint8_t>>;
+
+static WeightCache load_weights_to_memory(const std::string& path)
+{
+    io::SafeTensorsReader reader(path);
+    WeightCache cache;
+    for(const auto& name : reader.tensor_names())
+    {
+        cache[name] = reader.read_tensor(name);
+    }
+    return cache;
+}
+
+static void apply_weight_cache(
+    graph::module::Module& model,
+    const WeightCache& cache)
+{
+    for(const auto& [name, tensor] : model.named_parameters_recursive())
+    {
+        auto it = cache.find(name);
+        if(it != cache.end())
+        {
+            auto copy = it->second;
+            tensor->data()->set_bind_hint(std::move(copy));
+            tensor->mark_input(true);
+        }
+    }
+}
+
+// ── Python invocation ──────────────────────────────────────────────────────
+
+static bool run_python_conversion(const Args& args)
+{
+    std::vector<std::string> argv_strs = {
+        "python3",
+        "examples/gpt_neox_generate.py",
+        "--model",
+        args.model,
+        "--output-dir",
+        args.output_dir,
+    };
+    if(!args.prompt.empty())
+    {
+        argv_strs.push_back("--prompt");
+        argv_strs.push_back(args.prompt);
+    }
+
+    std::vector<char*> argv;
+    argv.reserve(argv_strs.size() + 1);
+    for(auto& s : argv_strs)
+        argv.push_back(s.data());
+    argv.push_back(nullptr);
+
+    std::cout << "Running: python3 examples/gpt_neox_generate.py --model "
+              << args.model << " --output-dir " << args.output_dir;
+    if(!args.prompt.empty())
+        std::cout << " --prompt " << args.prompt;
+    std::cout << "\n";
+
+    pid_t pid = fork();
+    if(pid < 0)
+    {
+        std::cerr << "fork() failed\n";
+        return false;
+    }
+    if(pid == 0)
+    {
+        execvp("python3", argv.data());
+        std::cerr << "execvp(python3) failed\n";
+        _exit(127);
+    }
+    int status;
+    if(waitpid(pid, &status, 0) != pid)
+    {
+        std::cerr << "waitpid() failed\n";
+        return false;
+    }
+    return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+static std::string read_file_trimmed(const std::string& path)
+{
+    std::ifstream f(path);
+    if(!f.good())
+        return {};
+    std::string s((std::istreambuf_iterator<char>(f)),
+                   std::istreambuf_iterator<char>());
+    while(!s.empty() && (s.back() == '\n' || s.back() == '\r'))
+        s.pop_back();
+    return s;
+}
+
+// ── Greedy argmax over last-position logits ──────────────────────────────
+
+static std::int64_t argmax_last_position(
+    const std::vector<float>& logits,
+    Index vocab_size,
+    Index seq_len)
+{
+    auto offset = static_cast<std::size_t>((seq_len - 1) * vocab_size);
+    auto begin = logits.begin()
+        + static_cast<std::ptrdiff_t>(offset);
+    auto end = begin + vocab_size;
+    return static_cast<std::int64_t>(std::distance(
+        begin, std::max_element(begin, end)));
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────
+
+int main(int argc, char** argv)
+{
+    Args args = parse_args(argc, argv);
+
+    if(!args.model.empty())
+    {
+        if(!run_python_conversion(args))
+        {
+            std::cerr << "Python conversion failed.\n";
+            return 1;
+        }
+        args.config_path  = args.output_dir + "/config.json";
+        args.weights_path = args.output_dir + "/weights.safetensors";
+
+        if(args.prompt_ids_str.empty())
+        {
+            std::string ids_file = args.output_dir + "/prompt_ids.txt";
+            args.prompt_ids_str = read_file_trimmed(ids_file);
+        }
+    }
+
+    if(args.config_path.empty() || args.weights_path.empty()
+       || args.prompt_ids_str.empty())
+    {
+        std::cerr
+            << "Error: provide either (--model + --prompt) or "
+               "(--config + --weights + --prompt-ids).\n"
+               "Run with --help for usage.\n";
+        return 1;
+    }
+
+    GptneoxConfig config = load_config(args.config_path);
+    std::cout << "Config: hidden=" << config.hidden_size
+              << "  layers=" << config.num_hidden_layers
+              << "  heads=" << config.num_attention_heads
+              << "  vocab=" << config.vocab_size << "\n";
+
+    std::vector<std::int64_t> tokens = parse_ids(args.prompt_ids_str);
+    if(tokens.empty())
+    {
+        std::cerr << "Error: prompt token list is empty.\n";
+        return 1;
+    }
+    std::cout << "Prompt: " << tokens.size() << " tokens\n";
+
+    std::cout << "Loading weights from " << args.weights_path << " ...\n";
+    WeightCache weights = load_weights_to_memory(args.weights_path);
+    std::cout << "Cached " << weights.size() << " parameter tensors\n";
+
+    Context context(1, 0, 0, "/tmp/nntile_ooc", 16777216, 0,
+                    "localhost", 5001, 0);
+
+    std::cout << "\n--- Generating (greedy, no KV-cache) ---\n";
+    for(int step = 0; step < args.max_tokens; ++step)
+    {
+        Index seq_len = static_cast<Index>(tokens.size());
+
+        NNGraph graph("gptneox_step");
+
+        auto* input_ids = graph.tensor(
+            {seq_len, 1}, "input_ids", DataType::INT64, false);
+        input_ids->mark_input(true);
+
+        GptneoxCausal model(&graph, "model", config);
+        auto* output = model.forward(input_ids);
+        output->mark_output(true);
+
+        apply_weight_cache(model, weights);
+
+        TensorGraph::Runtime runtime(graph.tensor_graph());
+        runtime.compile();
+        runtime.bind_data("input_ids", tokens);
+        runtime.execute();
+        runtime.wait();
+
+        auto logits = runtime.get_output<float>(output->name());
+
+        std::int64_t next_id = argmax_last_position(
+            logits, config.vocab_size, seq_len);
+        tokens.push_back(next_id);
+
+        std::cout << "step " << (step + 1) << "  token=" << next_id << "\n";
+
+        if(next_id == config.eos_token_id)
+        {
+            std::cout << "EOS reached.\n";
+            break;
+        }
+    }
+
+    std::cout << "\nGenerated token IDs:";
+    for(auto id : tokens)
+    {
+        std::cout << " " << id;
+    }
+    std::cout << "\n";
+
+    std::cout << "\nTo decode, run:\n"
+              << "  python3 -c \"from transformers import AutoTokenizer; "
+              << "t = AutoTokenizer.from_pretrained('<model-dir>'); "
+              << "print(t.decode([";
+    for(std::size_t i = 0; i < tokens.size(); ++i)
+    {
+        if(i > 0) std::cout << ",";
+        std::cout << tokens[i];
+    }
+    std::cout << "]))\"\n";
+
+    return 0;
+}

--- a/examples/gpt_neox_generate.cc
+++ b/examples/gpt_neox_generate.cc
@@ -50,6 +50,8 @@
 #include <nntile/graph/io/safetensors.hh>
 #include <nntile/graph/model/gptneox/gptneox_causal.hh>
 #include <nntile/graph/model/gptneox/gptneox_config.hh>
+#include <nntile/graph/model/gptneox/gptneox_rope.hh>
+#include <nntile/graph/nn/ops/sdpa_causal_mask.hh>
 #include <nlohmann/json.hpp>
 
 using namespace nntile;
@@ -262,6 +264,19 @@ static std::string read_file_trimmed(const std::string& path)
 
 // ── Greedy argmax over last-position logits ──────────────────────────────
 
+static void fill_arange_position_ids(
+    std::vector<std::int64_t>& pos, Index n_seq, Index n_batch)
+{
+    for(Index b = 0; b < n_batch; ++b)
+    {
+        for(Index s = 0; s < n_seq; ++s)
+        {
+            pos[static_cast<std::size_t>(s + n_seq * b)] =
+                static_cast<std::int64_t>(s);
+        }
+    }
+}
+
 static std::int64_t argmax_last_position(
     const std::vector<float>& logits,
     Index vocab_size,
@@ -330,29 +345,71 @@ int main(int argc, char** argv)
                     "localhost", 5001, 0);
 
     std::cout << "\n--- Generating (greedy, no KV-cache) ---\n";
+    const Index n_batch = 1;
+    const Index rope_half = gptneox_rope_dim(config) / 2;
+
     for(int step = 0; step < args.max_tokens; ++step)
     {
         Index seq_len = static_cast<Index>(tokens.size());
 
         NNGraph graph("gptneox_step");
 
-        auto* input_ids = graph.tensor(
-            {seq_len, 1}, "input_ids", DataType::INT64, false);
+        auto* input_ids = graph.tensor({seq_len, n_batch}, DataType::INT64, false)
+                              ->set_name("input_ids");
         input_ids->mark_input(true);
 
+        auto* rope_sin =
+            graph.tensor({rope_half, seq_len, n_batch}, DataType::FP32, false)
+                ->set_name("rope_sin");
+        auto* rope_cos =
+            graph.tensor({rope_half, seq_len, n_batch}, DataType::FP32, false)
+                ->set_name("rope_cos");
+        auto* attn_mask =
+            graph.tensor({seq_len, seq_len}, DataType::BOOL, false)
+                ->set_name("attn_mask");
+        rope_sin->mark_input(true);
+        rope_cos->mark_input(true);
+        attn_mask->mark_input(true);
+
         GptneoxCausal model(&graph, "model", config);
-        auto* output = model.forward(input_ids);
+        auto* output = model.forward(
+            input_ids, rope_sin, rope_cos, attn_mask);
         output->mark_output(true);
 
         apply_weight_cache(model, weights);
 
-        TensorGraph::Runtime runtime(graph.tensor_graph());
+        std::vector<std::int64_t> pos_data(
+            static_cast<std::size_t>(seq_len * n_batch));
+        fill_arange_position_ids(pos_data, seq_len, n_batch);
+
+        const std::size_t rope_n =
+            static_cast<std::size_t>(rope_half * seq_len * n_batch);
+        std::vector<float> sin_data(rope_n);
+        std::vector<float> cos_data(rope_n);
+        rope_sin_cos_from_position_ids(config,
+            pos_data.data(),
+            seq_len,
+            n_batch,
+            sin_data.data(),
+            cos_data.data());
+
+        const std::size_t mask_n =
+            static_cast<std::size_t>(seq_len * seq_len);
+        std::vector<std::uint8_t> mask_data(mask_n);
+        sdpa_causal_mask_bool_fortran_fill(seq_len, mask_data.data());
+
+        TileGraph tile_graph =
+            TileGraph::from_tensor_graph(graph.tensor_graph());
+        Runtime runtime(tile_graph);
         runtime.compile();
-        runtime.bind_data("input_ids", tokens);
+        runtime.bind_data(input_ids, tokens);
+        runtime.bind_data(rope_sin, sin_data);
+        runtime.bind_data(rope_cos, cos_data);
+        runtime.bind_data(attn_mask, mask_data);
         runtime.execute();
         runtime.wait();
 
-        auto logits = runtime.get_output<float>(output->name());
+        auto logits = runtime.get_output<float>(output);
 
         std::int64_t next_id = argmax_last_position(
             logits, config.vocab_size, seq_len);

--- a/examples/gpt_neox_generate.py
+++ b/examples/gpt_neox_generate.py
@@ -25,12 +25,12 @@
 #
 # @version 1.1.0
 
-"""Convert HuggingFace GPT-NeoX checkpoint to NNTile format and tokenize a prompt.
+"""Convert HF GPT-NeoX checkpoint to NNTile format and tokenize a prompt.
 
 Produces:
   - weights.safetensors  NNTile-layout weight file
   - config.json  Model configuration readable by the C++ example
-  - prompt_ids.txt  Comma-separated token IDs for the prompt (if --prompt supplied)
+  - prompt_ids.txt  Comma-separated token IDs (if --prompt supplied)
 """
 
 from __future__ import annotations
@@ -84,7 +84,8 @@ def _write_safetensors_streaming(
         for name, nbytes in entry_order:
             arr = get_data(name)
             raw = arr.tobytes()
-            assert len(raw) == nbytes, f"{name}: expected {nbytes} bytes, got {len(raw)}"
+            err = f"{name}: expected {nbytes} bytes, got {len(raw)}"
+            assert len(raw) == nbytes, err
             f.write(raw)
             del arr, raw
 
@@ -137,7 +138,11 @@ def _make_converter(
             return fortran_order(hf_get("gpt_neox.final_layer_norm.weight"))
 
         if name == "model.lm_head.weight":
-            key = "embed_out.weight" if has_lm_head else "gpt_neox.embed_in.weight"
+            key = (
+                "embed_out.weight"
+                if has_lm_head
+                else "gpt_neox.embed_in.weight"
+            )
             return fortran_order(hf_get(key).T)
 
         parts = name.split(".")
@@ -148,7 +153,8 @@ def _make_converter(
         if rest == "input_norm.gamma":
             return fortran_order(hf_get(f"{hp}.input_layernorm.weight"))
         if rest == "post_attn_norm.gamma":
-            return fortran_order(hf_get(f"{hp}.post_attention_layernorm.weight"))
+            w = hf_get(f"{hp}.post_attention_layernorm.weight")
+            return fortran_order(w)
 
         if rest == "attention.q_weight":
             qkv = hf_get(f"{hp}.attention.query_key_value.weight")
@@ -173,8 +179,8 @@ def _make_converter(
             return fortran_order(o.reshape(H, nh, hd))
 
         if rest == "mlp.fc1.weight":
-            # HF dense: (inter, H); NNTile fc1: (inter, H)
-            return fortran_order(hf_get(f"{hp}.mlp.dense.weight"))
+            # HF dense_h_to_4h: (inter, H); NNTile fc1: (inter, H)
+            return fortran_order(hf_get(f"{hp}.mlp.dense_h_to_4h.weight"))
         if rest == "mlp.fc2.weight":
             # HF dense_4h_to_h: (H, inter); NNTile fc2: (H, inter)
             return fortran_order(hf_get(f"{hp}.mlp.dense_4h_to_h.weight"))
@@ -203,7 +209,7 @@ def main() -> int:
     parser.add_argument(
         "--model",
         required=True,
-        help="HuggingFace model name (e.g. EleutherAI/gpt-neox-125m) or local path",
+        help="HF model name or path (e.g. EleutherAI/gpt-neox-125m)",
     )
     parser.add_argument(
         "--output-dir",
@@ -244,7 +250,8 @@ def main() -> int:
         "layer_norm_eps": getattr(config, "layer_norm_eps", 1e-5),
         "rotary_pct": getattr(config, "rotary_pct", 0.25),
         "rotary_emb_base": getattr(config, "rotary_emb_base", 10000),
-        "use_parallel_residual": getattr(config, "use_parallel_residual", True),
+        "use_parallel_residual": getattr(
+            config, "use_parallel_residual", True),
         "eos_token_id": getattr(config, "eos_token_id", 50256),
         "bos_token_id": getattr(config, "bos_token_id", 50256),
     }
@@ -254,7 +261,9 @@ def main() -> int:
 
     st_files = sorted(model_dir.glob("*.safetensors"))
     if not st_files:
-        print(f"ERROR: no *.safetensors files found in {model_dir}", file=sys.stderr)
+        print(
+            f"ERROR: no *.safetensors files found in {model_dir}",
+            file=sys.stderr)
         return 1
 
     handles: list = []
@@ -286,7 +295,7 @@ def main() -> int:
         tokenizer = _load_tokenizer(str(model_dir), model_id)
         if tokenizer is None:
             print(
-                "WARNING: could not load tokenizer; skipping prompt tokenization.",
+                "WARNING: tokenizer not loaded; skipping prompt tokenization.",
                 file=sys.stderr,
             )
         else:

--- a/examples/gpt_neox_generate.py
+++ b/examples/gpt_neox_generate.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+# @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#                2023-present Artificial Intelligence Research Institute
+#                              (AIRI), Russia. All rights reserved.
+#
+# NNTile is software framework for fast training of big neural networks on
+# distributed-memory heterogeneous systems based on StarPU runtime system.
+#
+# @file examples/gpt_neox_generate.py
+# Convert a HuggingFace GPT-NeoX checkpoint to NNTile format for C++ inference.
+#
+# Usage:
+#   python gpt_neox_generate.py \
+#       --model EleutherAI/gpt-neox-125m \
+#       --output-dir /tmp/nntile_gptneox \
+#       --prompt "The meaning of life is"
+#
+# Then run the C++ binary:
+#   ./gpt_neox_generate \
+#       --config /tmp/nntile_gptneox/config.json \
+#       --weights /tmp/nntile_gptneox/weights.safetensors \
+#       --prompt-ids "$(cat /tmp/nntile_gptneox/prompt_ids.txt)" \
+#       --max-tokens 32
+#
+# @version 1.1.0
+
+"""Convert HuggingFace GPT-NeoX checkpoint to NNTile format and tokenize a prompt.
+
+Produces:
+  - weights.safetensors  NNTile-layout weight file
+  - config.json  Model configuration readable by the C++ example
+  - prompt_ids.txt  Comma-separated token IDs for the prompt (if --prompt supplied)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+import sys
+from pathlib import Path
+from typing import Callable, Sequence
+
+import numpy as np
+import torch
+from huggingface_hub import snapshot_download
+from safetensors import safe_open
+from transformers import AutoConfig, AutoTokenizer
+
+
+def fortran_order(arr: np.ndarray) -> np.ndarray:
+    """Return C-contiguous array whose flat bytes equal NNTile column-major."""
+    a = np.asarray(arr, dtype=np.float32)
+    return a.ravel("F").reshape(a.shape)
+
+
+def _write_safetensors_streaming(
+    path: str | Path,
+    specs: Sequence[tuple[str, tuple[int, ...]]],
+    get_data: Callable[[str], np.ndarray],
+) -> None:
+    """Write a safetensors file one tensor at a time."""
+    header: dict[str, dict] = {}
+    offset = 0
+    entry_order: list[tuple[str, int]] = []
+    for name, shape in specs:
+        nbytes = int(np.prod(shape)) * 4
+        header[name] = {
+            "dtype": "F32",
+            "shape": list(shape),
+            "data_offsets": [offset, offset + nbytes],
+        }
+        entry_order.append((name, nbytes))
+        offset += nbytes
+
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    pad = (8 - len(header_bytes) % 8) % 8
+    header_bytes += b" " * pad
+
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header_bytes)))
+        f.write(header_bytes)
+        for name, nbytes in entry_order:
+            arr = get_data(name)
+            raw = arr.tobytes()
+            assert len(raw) == nbytes, f"{name}: expected {nbytes} bytes, got {len(raw)}"
+            f.write(raw)
+            del arr, raw
+
+
+def _output_specs(config) -> list[tuple[str, tuple[int, ...]]]:
+    """Return (nntile_name, shape) for every output tensor."""
+    H = config.hidden_size
+    V = config.vocab_size
+    inter = config.intermediate_size
+    nh = config.num_attention_heads
+    hd = H // nh
+
+    specs: list[tuple[str, tuple[int, ...]]] = []
+
+    specs.append(("model.model.embed_tokens.vocab", (H, V)))
+    specs.append(("model.model.norm.gamma", (H,)))
+    specs.append(("model.lm_head.weight", (H, V)))
+
+    for i in range(config.num_hidden_layers):
+        p = f"model.model.layers_{i}"
+        specs.append((f"{p}.input_norm.gamma", (H,)))
+        specs.append((f"{p}.post_attn_norm.gamma", (H,)))
+
+        specs.append((f"{p}.attention.q_weight", (nh, hd, H)))
+        specs.append((f"{p}.attention.k_weight", (nh, hd, H)))
+        specs.append((f"{p}.attention.v_weight", (nh, hd, H)))
+        specs.append((f"{p}.attention.o_weight", (H, nh, hd)))
+
+        specs.append((f"{p}.mlp.fc1.weight", (inter, H)))
+        specs.append((f"{p}.mlp.fc2.weight", (H, inter)))
+
+    return specs
+
+
+def _make_converter(
+    config,
+    hf_get: Callable[[str], np.ndarray],
+    has_lm_head: bool,
+) -> Callable[[str], np.ndarray]:
+    """Return a function that converts a single NNTile tensor on demand."""
+    H = config.hidden_size
+    nh = config.num_attention_heads
+    hd = H // nh
+
+    def convert(name: str) -> np.ndarray:
+        if name == "model.model.embed_tokens.vocab":
+            return fortran_order(hf_get("gpt_neox.embed_in.weight").T)
+
+        if name == "model.model.norm.gamma":
+            return fortran_order(hf_get("gpt_neox.final_layer_norm.weight"))
+
+        if name == "model.lm_head.weight":
+            key = "embed_out.weight" if has_lm_head else "gpt_neox.embed_in.weight"
+            return fortran_order(hf_get(key).T)
+
+        parts = name.split(".")
+        layer_idx = int(parts[2].split("_", 1)[1])
+        rest = ".".join(parts[3:])
+        hp = f"gpt_neox.layers.{layer_idx}"
+
+        if rest == "input_norm.gamma":
+            return fortran_order(hf_get(f"{hp}.input_layernorm.weight"))
+        if rest == "post_attn_norm.gamma":
+            return fortran_order(hf_get(f"{hp}.post_attention_layernorm.weight"))
+
+        if rest == "attention.q_weight":
+            qkv = hf_get(f"{hp}.attention.query_key_value.weight")
+            qkv = qkv.reshape(nh, 3 * hd, H)
+            q = qkv[:, :hd, :]
+            return fortran_order(q)
+
+        if rest == "attention.k_weight":
+            qkv = hf_get(f"{hp}.attention.query_key_value.weight")
+            qkv = qkv.reshape(nh, 3 * hd, H)
+            k = qkv[:, hd : 2 * hd, :]
+            return fortran_order(k)
+
+        if rest == "attention.v_weight":
+            qkv = hf_get(f"{hp}.attention.query_key_value.weight")
+            qkv = qkv.reshape(nh, 3 * hd, H)
+            v = qkv[:, 2 * hd : 3 * hd, :]
+            return fortran_order(v)
+
+        if rest == "attention.o_weight":
+            o = hf_get(f"{hp}.attention.dense.weight")
+            return fortran_order(o.reshape(H, nh, hd))
+
+        if rest == "mlp.fc1.weight":
+            # HF dense: (inter, H); NNTile fc1: (inter, H)
+            return fortran_order(hf_get(f"{hp}.mlp.dense.weight"))
+        if rest == "mlp.fc2.weight":
+            # HF dense_4h_to_h: (H, inter); NNTile fc2: (H, inter)
+            return fortran_order(hf_get(f"{hp}.mlp.dense_4h_to_h.weight"))
+
+        raise ValueError(f"Unknown NNTile tensor: {name}")
+
+    return convert
+
+
+def _load_tokenizer(*sources: str):
+    """Try to load a tokenizer from multiple sources."""
+    for src in sources:
+        if not src:
+            continue
+        try:
+            return AutoTokenizer.from_pretrained(src, use_fast=False)
+        except Exception:
+            pass
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Convert HF GPT-NeoX checkpoint → NNTile format",
+    )
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="HuggingFace model name (e.g. EleutherAI/gpt-neox-125m) or local path",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory where NNTile files will be written",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=None,
+        help="Optional text prompt to tokenize",
+    )
+    args = parser.parse_args()
+
+    model_id = args.model
+
+    if Path(model_id).is_dir():
+        model_dir = Path(model_id)
+    else:
+        print(f"Downloading {model_id} to HF cache ...")
+        model_dir = Path(snapshot_download(model_id))
+        print(f"Snapshot: {model_dir}")
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    config = AutoConfig.from_pretrained(str(model_dir))
+    print(
+        f"Model: {config.model_type}  hidden={config.hidden_size}  "
+        f"layers={config.num_hidden_layers}  vocab={config.vocab_size}"
+    )
+
+    nntile_config = {
+        "vocab_size": config.vocab_size,
+        "hidden_size": config.hidden_size,
+        "intermediate_size": config.intermediate_size,
+        "num_hidden_layers": config.num_hidden_layers,
+        "num_attention_heads": config.num_attention_heads,
+        "layer_norm_eps": getattr(config, "layer_norm_eps", 1e-5),
+        "rotary_pct": getattr(config, "rotary_pct", 0.25),
+        "rotary_emb_base": getattr(config, "rotary_emb_base", 10000),
+        "use_parallel_residual": getattr(config, "use_parallel_residual", True),
+        "eos_token_id": getattr(config, "eos_token_id", 50256),
+        "bos_token_id": getattr(config, "bos_token_id", 50256),
+    }
+    config_path = out_dir / "config.json"
+    config_path.write_text(json.dumps(nntile_config, indent=2) + "\n")
+    print(f"Wrote {config_path}")
+
+    st_files = sorted(model_dir.glob("*.safetensors"))
+    if not st_files:
+        print(f"ERROR: no *.safetensors files found in {model_dir}", file=sys.stderr)
+        return 1
+
+    handles: list = []
+    tensor_to_handle: dict[str, object] = {}
+    for sf in st_files:
+        h = safe_open(str(sf), framework="pt")
+        handles.append(h)
+        for key in h.keys():
+            tensor_to_handle[key] = h
+
+    n_hf = len(tensor_to_handle)
+    print(f"Indexed {n_hf} tensors from {len(st_files)} shard(s) (mmap)")
+
+    def hf_get(name: str, _m=tensor_to_handle) -> np.ndarray:
+        return _m[name].get_tensor(name).to(torch.float32).numpy()
+
+    specs = _output_specs(config)
+    has_lm_head = "embed_out.weight" in tensor_to_handle
+    converter = _make_converter(config, hf_get, has_lm_head)
+
+    weights_path = out_dir / "weights.safetensors"
+    print(f"Converting {len(specs)} tensors (streaming) ...")
+    _write_safetensors_streaming(weights_path, specs, converter)
+    print(f"Wrote {weights_path}")
+
+    del handles, tensor_to_handle
+
+    if args.prompt is not None:
+        tokenizer = _load_tokenizer(str(model_dir), model_id)
+        if tokenizer is None:
+            print(
+                "WARNING: could not load tokenizer; skipping prompt tokenization.",
+                file=sys.stderr,
+            )
+        else:
+            ids = tokenizer.encode(args.prompt, add_special_tokens=True)
+            ids_str = ",".join(str(i) for i in ids)
+            ids_path = out_dir / "prompt_ids.txt"
+            ids_path.write_text(ids_str + "\n")
+            print(f"Prompt ({len(ids)} tokens): {ids}")
+            print(f"Wrote {ids_path}")
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/gpt_neox_generate.py
+++ b/examples/gpt_neox_generate.py
@@ -102,20 +102,23 @@ def _output_specs(config) -> list[tuple[str, tuple[int, ...]]]:
 
     specs.append(("model.model.embed_tokens.vocab", (H, V)))
     specs.append(("model.model.norm.gamma", (H,)))
+    specs.append(("model.model.norm.beta", (H,)))
     specs.append(("model.lm_head.weight", (H, V)))
 
     for i in range(config.num_hidden_layers):
         p = f"model.model.layers_{i}"
         specs.append((f"{p}.input_norm.gamma", (H,)))
+        specs.append((f"{p}.input_norm.beta", (H,)))
         specs.append((f"{p}.post_attn_norm.gamma", (H,)))
+        specs.append((f"{p}.post_attn_norm.beta", (H,)))
 
         specs.append((f"{p}.attention.q_weight", (nh, hd, H)))
         specs.append((f"{p}.attention.k_weight", (nh, hd, H)))
         specs.append((f"{p}.attention.v_weight", (nh, hd, H)))
         specs.append((f"{p}.attention.o_weight", (H, nh, hd)))
 
-        specs.append((f"{p}.mlp.fc1.weight", (inter, H)))
-        specs.append((f"{p}.mlp.fc2.weight", (H, inter)))
+        specs.append((f"{p}.mlp.fc1.weight", (H, inter)))
+        specs.append((f"{p}.mlp.fc2.weight", (inter, H)))
 
     return specs
 
@@ -136,6 +139,8 @@ def _make_converter(
 
         if name == "model.model.norm.gamma":
             return fortran_order(hf_get("gpt_neox.final_layer_norm.weight"))
+        if name == "model.model.norm.beta":
+            return fortran_order(hf_get("gpt_neox.final_layer_norm.bias"))
 
         if name == "model.lm_head.weight":
             key = (
@@ -152,9 +157,14 @@ def _make_converter(
 
         if rest == "input_norm.gamma":
             return fortran_order(hf_get(f"{hp}.input_layernorm.weight"))
+        if rest == "input_norm.beta":
+            return fortran_order(hf_get(f"{hp}.input_layernorm.bias"))
         if rest == "post_attn_norm.gamma":
-            w = hf_get(f"{hp}.post_attention_layernorm.weight")
-            return fortran_order(w)
+            return fortran_order(
+                hf_get(f"{hp}.post_attention_layernorm.weight"))
+        if rest == "post_attn_norm.beta":
+            return fortran_order(
+                hf_get(f"{hp}.post_attention_layernorm.bias"))
 
         if rest == "attention.q_weight":
             qkv = hf_get(f"{hp}.attention.query_key_value.weight")
@@ -179,11 +189,13 @@ def _make_converter(
             return fortran_order(o.reshape(H, nh, hd))
 
         if rest == "mlp.fc1.weight":
-            # HF dense_h_to_4h: (inter, H); NNTile fc1: (inter, H)
-            return fortran_order(hf_get(f"{hp}.mlp.dense_h_to_4h.weight"))
+            # HF dense_h_to_4h: (inter, H); NNTile fc1 Linear(H, inter)
+            w = hf_get(f"{hp}.mlp.dense_h_to_4h.weight")
+            return fortran_order(w.T)
         if rest == "mlp.fc2.weight":
-            # HF dense_4h_to_h: (H, inter); NNTile fc2: (H, inter)
-            return fortran_order(hf_get(f"{hp}.mlp.dense_4h_to_h.weight"))
+            # HF dense_4h_to_h: (H, inter); NNTile fc2 Linear(inter, H)
+            w = hf_get(f"{hp}.mlp.dense_4h_to_h.weight")
+            return fortran_order(w.T)
 
         raise ValueError(f"Unknown NNTile tensor: {name}")
 

--- a/examples/gpt_neox_generate.py
+++ b/examples/gpt_neox_generate.py
@@ -118,7 +118,9 @@ def _output_specs(config) -> list[tuple[str, tuple[int, ...]]]:
         specs.append((f"{p}.attention.o_weight", (H, nh, hd)))
 
         specs.append((f"{p}.mlp.fc1.weight", (H, inter)))
+        specs.append((f"{p}.mlp.fc1.bias", (inter,)))
         specs.append((f"{p}.mlp.fc2.weight", (inter, H)))
+        specs.append((f"{p}.mlp.fc2.bias", (H,)))
 
     return specs
 
@@ -192,10 +194,14 @@ def _make_converter(
             # HF dense_h_to_4h: (inter, H); NNTile fc1 Linear(H, inter)
             w = hf_get(f"{hp}.mlp.dense_h_to_4h.weight")
             return fortran_order(w.T)
+        if rest == "mlp.fc1.bias":
+            return fortran_order(hf_get(f"{hp}.mlp.dense_h_to_4h.bias"))
         if rest == "mlp.fc2.weight":
             # HF dense_4h_to_h: (H, inter); NNTile fc2 Linear(inter, H)
             w = hf_get(f"{hp}.mlp.dense_4h_to_h.weight")
             return fortran_order(w.T)
+        if rest == "mlp.fc2.bias":
+            return fortran_order(hf_get(f"{hp}.mlp.dense_4h_to_h.bias"))
 
         raise ValueError(f"Unknown NNTile tensor: {name}")
 

--- a/examples/gptneox_config_json.hh
+++ b/examples/gptneox_config_json.hh
@@ -1,0 +1,97 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file examples/gptneox_config_json.hh
+ * Load/save GptneoxConfig JSON for C++ examples.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include "json_config_helpers.hh"
+
+#include <nlohmann/json.hpp>
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+namespace nntile::examples
+{
+
+inline model::gptneox::GptneoxConfig load_gptneox_config_json(
+    std::string const &path)
+{
+    std::ifstream f(path);
+    if(!f.good())
+    {
+        throw std::runtime_error("Cannot open config: " + path);
+    }
+    nlohmann::json j = nlohmann::json::parse(f);
+
+    model::gptneox::GptneoxConfig cfg;
+    cfg.vocab_size = config_get_int(j, "vocab_size", 50280);
+    cfg.hidden_size = config_get_int(
+        j, "hidden_size", config_get_int(j, "n_embd", 1024));
+    cfg.num_hidden_layers = config_get_int(
+        j, "num_hidden_layers", config_get_int(j, "n_layer", 24));
+    cfg.num_attention_heads = config_get_int(
+        j, "num_attention_heads", config_get_int(j, "n_head", 16));
+    cfg.max_position_embeddings = config_get_int(
+        j, "max_position_embeddings", config_get_int(j, "n_positions", 2048));
+    cfg.layer_norm_eps = config_get_float(j, "layer_norm_eps", 1e-5f);
+    cfg.intermediate_size = config_get_int(
+        j, "intermediate_size", config_get_int(j, "n_inner", 0));
+    if(cfg.intermediate_size <= 0)
+    {
+        cfg.intermediate_size = 4 * cfg.hidden_size;
+    }
+    cfg.rotary_pct = config_get_float(j, "rotary_pct", 0.25f);
+    cfg.rotary_emb_base = config_get_float(j, "rotary_emb_base", 10000.0f);
+    cfg.use_parallel_residual =
+        config_get_bool(j, "use_parallel_residual", true);
+    cfg.attention_bias = config_get_bool(j, "attention_bias", false);
+    cfg.eos_token_id = config_get_int(j, "eos_token_id", 50256);
+    cfg.bos_token_id = config_get_int(j, "bos_token_id", 50256);
+    if(j.contains("name") && j["name"].is_string())
+    {
+        cfg.name = j["name"].get<std::string>();
+    }
+    cfg.compute_head_dim();
+    cfg.validate();
+    return cfg;
+}
+
+inline void save_gptneox_config_json(
+    model::gptneox::GptneoxConfig const &cfg,
+    std::string const &path)
+{
+    nlohmann::json j;
+    j["vocab_size"] = cfg.vocab_size;
+    j["hidden_size"] = cfg.hidden_size;
+    j["intermediate_size"] = cfg.intermediate_size;
+    j["num_hidden_layers"] = cfg.num_hidden_layers;
+    j["num_attention_heads"] = cfg.num_attention_heads;
+    j["max_position_embeddings"] = cfg.max_position_embeddings;
+    j["head_dim"] = cfg.head_dim;
+    j["layer_norm_eps"] = cfg.layer_norm_eps;
+    j["rotary_pct"] = cfg.rotary_pct;
+    j["rotary_emb_base"] = cfg.rotary_emb_base;
+    j["use_parallel_residual"] = cfg.use_parallel_residual;
+    j["attention_bias"] = cfg.attention_bias;
+    j["eos_token_id"] = cfg.eos_token_id;
+    j["bos_token_id"] = cfg.bos_token_id;
+    j["name"] = cfg.name;
+    std::ofstream f(path);
+    if(!f.good())
+    {
+        throw std::runtime_error("Cannot write config: " + path);
+    }
+    f << j.dump(2) << "\n";
+}
+
+} // namespace nntile::examples

--- a/examples/gptneox_graph_training.cc
+++ b/examples/gptneox_graph_training.cc
@@ -1,0 +1,667 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file examples/gptneox_graph_training.cc
+ * GPT-NeoX causal LM training on the graph API.
+ *
+ * Data path: ``--train-bin`` is a flat ``uint16`` token stream read via mmap
+ * (``TokenMemoryMap`` / ``CausalLmBatchIterator``). Each batch needs at least
+ * ``(seq_len + 1) * batch`` ids; labels are the next-token targets for the
+ * same windows. Optional ``--shuffle`` permutes sequence starts (``--seed``).
+ *
+ * Train.bin generation: use ``wrappers/python/examples/causal_lm_data_preparation.py``
+ * with a GPT-NeoX tokenizer (e.g. ``--hf-tokenizer gptneox``). Point
+ * ``--train-bin`` at the resulting ``train.bin``; ``GptneoxConfig.vocab_size``
+ * must cover token ids (``--tiny`` uses a 256-id toy vocab).
+ *
+ * Model path: ``GptneoxCausal`` forward takes ``input_ids``, RoPE ``sin``/``cos``,
+ * and a boolean causal attention mask; logits feed a scaled scalar cross-entropy
+ * vs ``labels``. ``--tiny`` selects a built-in small config; ``--config`` loads
+ * JSON ``GptneoxConfig``; otherwise the tiny default applies.
+ * ``--load-weights`` uses ``Module::load`` (SafeTensors).
+ *
+ * Training loop matches ``llama_graph_training``: clear grads, forward, loss,
+ * ``backward(true)``, ``optimizer->step(scheduled_lr)``, ``finish_phase()``,
+ * ``lower_and_compile()``, bind batch tensors, ``runtime.execute()``.
+ *
+ * Usage:
+ *   ./gptneox_graph_training --train-bin /path/train.bin --seq 8 --batch 2
+ *   ./gptneox_graph_training --train-bin data.bin --tiny --output-dir /tmp/out
+ *
+ * @version 1.1.0
+ * */
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <nlohmann/json.hpp>
+
+#include "gptneox_config_json.hh"
+#include <nntile.hh>
+#include <nntile/graph/dataset/causal_lm_mmap.hh>
+#include <nntile/graph/model/gptneox/gptneox_causal.hh>
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+#include <nntile/graph/model/gptneox/gptneox_rope.hh>
+#include <nntile/graph/nn/ops/sdpa_causal_mask.hh>
+#include <nntile/graph/tensor/ops/clear.hh>
+#include <random>
+#include <stdexcept>
+#include <string>
+
+using json = nlohmann::json;
+
+using namespace nntile;
+using namespace nntile::graph;
+using namespace nntile::model::gptneox;
+using namespace nntile::graph::dataset;
+using namespace nntile::graph::optim;
+
+namespace
+{
+
+constexpr int EXIT_OK = 0;
+constexpr int EXIT_ERROR = 1;
+
+constexpr int CONTEXT_NUM_CPU = 1;
+constexpr int CONTEXT_NUM_CUDA = 0;
+constexpr int CONTEXT_OOC = 0;
+constexpr int CONTEXT_OOC_SIZE = 16777216;
+constexpr int CONTEXT_LOGGER = 0;
+constexpr int CONTEXT_VERBOSE = 0;
+constexpr int CONTEXT_LOGGER_PORT = 5001;
+
+struct Args
+{
+    std::string config_path;
+    std::string load_weights;
+    std::string output_dir;
+    std::string train_bin;
+    Index seq_len = 8;
+    Index batch = 2;
+    unsigned seed = 42;
+    bool use_tiny = false;
+    bool shuffle = false;
+    std::size_t max_batches = 0;
+    std::size_t epochs = 1;
+    float learning_rate = 0.001f;
+    float weight_decay = 0.0f;
+    float beta1 = 0.9f;
+    float beta2 = 0.999f;
+    int warmup_steps = 0;
+};
+
+
+
+using nntile::examples::load_gptneox_config_json;
+using nntile::examples::save_gptneox_config_json;
+
+static GptneoxConfig make_tiny_config()
+{
+    GptneoxConfig c;
+    c.vocab_size = 256;
+    c.hidden_size = 64;
+    c.intermediate_size = 128;
+    c.num_hidden_layers = 2;
+    c.num_attention_heads = 4;
+    c.max_position_embeddings = 512;
+    c.layer_norm_eps = 1e-5f;
+    c.rotary_pct = 1.0f;
+    c.rotary_emb_base = 10000.0f;
+    c.use_parallel_residual = true;
+    c.compute_head_dim();
+    c.validate();
+    return c;
+}
+
+static bool take_string_opt(
+    int argc, char **argv, int &i, char const *name, std::string &out)
+{
+    std::string const arg = argv[i];
+    std::string const prefix = std::string(name) + "=";
+    if (arg == name)
+    {
+        if (i + 1 >= argc)
+        {
+            return false;
+        }
+        out = argv[++i];
+        return true;
+    }
+    if (arg.compare(0, prefix.size(), prefix) == 0)
+    {
+        out = arg.substr(prefix.size());
+        return true;
+    }
+    return false;
+}
+
+static Args parse_args(int argc, char **argv)
+{
+    Args a;
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        std::string s;
+        if (take_string_opt(argc, argv, i, "--config", a.config_path))
+        {
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--load-weights", a.load_weights))
+        {
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--output-dir", a.output_dir))
+        {
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--train-bin", a.train_bin))
+        {
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--max-batches", s))
+        {
+            a.max_batches = static_cast<std::size_t>(std::stoull(s));
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--epochs", s))
+        {
+            a.epochs = static_cast<std::size_t>(std::stoull(s));
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--lr", s))
+        {
+            a.learning_rate = std::stof(s);
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--weight-decay", s))
+        {
+            a.weight_decay = std::stof(s);
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--beta1", s))
+        {
+            a.beta1 = std::stof(s);
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--beta2", s))
+        {
+            a.beta2 = std::stof(s);
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--warmup-steps", s))
+        {
+            a.warmup_steps = std::stoi(s);
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--seq", s))
+        {
+            a.seq_len = static_cast<Index>(std::stoll(s));
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--batch", s))
+        {
+            a.batch = static_cast<Index>(std::stoll(s));
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--seed", s))
+        {
+            a.seed = static_cast<unsigned>(std::stoul(s));
+            continue;
+        }
+        if (arg == "--tiny")
+        {
+            a.use_tiny = true;
+            continue;
+        }
+        if (arg == "--shuffle")
+        {
+            a.shuffle = true;
+            continue;
+        }
+        if (arg == "--help" || arg == "-h")
+        {
+            std::cout
+                << "Usage: " << argv[0] << " [options]\n"
+                << "  --config <path>       GPT-NeoX JSON (optional if --tiny)\n"
+                << "  --tiny                use built-in tiny architecture\n"
+                << "  --load-weights <path> SafeTensors checkpoint\n"
+                << "  --output-dir <path>   write config.json + "
+                   "model.safetensors\n"
+                << "  --train-bin <path>    required: uint16 token file\n"
+                << "  --shuffle             shuffle sequence starts\n"
+                << "  --max-batches <N>     cap batches (0 = all)\n"
+                << "  --epochs <N>          repeat mmap data (default 1)\n"
+                << "  --lr <rate>           AdamW learning rate\n"
+                << "  --weight-decay <v>    AdamW weight decay\n"
+                << "  --beta1 / --beta2     AdamW betas\n"
+                << "  --warmup-steps <N>    linear LR warmup\n"
+                << "  --seq <N>             sequence length (default 8)\n"
+                << "  --batch <N>           batch size (default 2)\n"
+                << "  --seed <N>            RNG seed (default 42)\n"
+                << "\n"
+                << "Options may use --opt=value or --opt value.\n";
+            std::exit(EXIT_OK);
+        }
+        if (arg == "--config" || arg == "--load-weights" ||
+            arg == "--output-dir" || arg == "--train-bin" || arg == "--seq" ||
+            arg == "--batch" || arg == "--seed" || arg == "--max-batches" ||
+            arg == "--lr" || arg == "--weight-decay" || arg == "--beta1" ||
+            arg == "--beta2" || arg == "--warmup-steps" || arg == "--epochs")
+        {
+            std::cerr << "gptneox_graph_training: " << arg
+                      << " requires a value\n";
+            std::exit(EXIT_ERROR);
+        }
+        if (!arg.empty() && arg[0] == '-')
+        {
+            std::cerr << "gptneox_graph_training: unknown option " << arg
+                      << "\n";
+            std::exit(EXIT_ERROR);
+        }
+        std::cerr << "gptneox_graph_training: unexpected argument " << arg
+                  << "\n";
+        std::exit(EXIT_ERROR);
+    }
+    return a;
+}
+
+static Scalar scheduled_lr(Index train_step, Args const &args)
+{
+    Scalar const peak = static_cast<Scalar>(args.learning_rate);
+    if (args.warmup_steps <= 0)
+    {
+        return peak;
+    }
+    Index const w = static_cast<Index>(args.warmup_steps);
+    if (train_step + 1 <= w)
+    {
+        return peak * static_cast<Scalar>(train_step + 1) /
+               static_cast<Scalar>(w);
+    }
+    return peak;
+}
+
+static void fill_arange_position_ids(
+    std::vector<std::int64_t> &pos, Index n_seq, Index n_batch)
+{
+    for (Index b = 0; b < n_batch; ++b)
+    {
+        for (Index s = 0; s < n_seq; ++s)
+        {
+            pos[s + n_seq * b] = static_cast<std::int64_t>(s);
+        }
+    }
+}
+
+static void init_random_parameter_hints(GptneoxCausal &model, std::mt19937 &gen)
+{
+    for (NNGraph::TensorNode *tensor : model.parameters_recursive())
+    {
+        const auto &shape = tensor->shape();
+        Index nelems = 1;
+        for (auto d : shape)
+        {
+            nelems *= d;
+        }
+        float fan_in = static_cast<float>(shape[0]);
+        if (fan_in < 1.f)
+        {
+            fan_in = 1.f;
+        }
+        float limit = std::sqrt(1.0f / fan_in);
+        std::uniform_real_distribution<float> wdist(-limit, limit);
+
+        std::vector<float> data(static_cast<std::size_t>(nelems));
+        for (auto &v : data)
+        {
+            v = wdist(gen);
+        }
+        std::vector<std::uint8_t> bytes(data.size() * sizeof(float));
+        std::memcpy(bytes.data(), data.data(), bytes.size());
+        tensor->data()->set_bind_hint(std::move(bytes));
+    }
+    model.mark_parameters_input_recursive();
+}
+
+static void sync_param_hint_from_runtime(
+    Runtime &runtime, NNGraph::TensorNode *t)
+{
+    std::vector<std::uint8_t> bytes;
+    switch (t->dtype())
+    {
+    case DataType::FP64:
+    {
+        auto d = runtime.get_output<double>(t);
+        bytes.resize(d.size() * sizeof(double));
+        std::memcpy(bytes.data(), d.data(), bytes.size());
+        break;
+    }
+    case DataType::INT64:
+    {
+        auto d = runtime.get_output<std::int64_t>(t);
+        bytes.resize(d.size() * sizeof(std::int64_t));
+        std::memcpy(bytes.data(), d.data(), bytes.size());
+        break;
+    }
+    default:
+    {
+        auto d = runtime.get_output<float>(t);
+        bytes.resize(d.size() * sizeof(float));
+        std::memcpy(bytes.data(), d.data(), bytes.size());
+        break;
+    }
+    }
+    t->data()->set_bind_hint(std::move(bytes));
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    Args args = parse_args(argc, argv);
+
+    if (args.train_bin.empty())
+    {
+        std::cerr << "gptneox_graph_training: --train-bin <path> is required\n";
+        return EXIT_ERROR;
+    }
+
+    GptneoxConfig config;
+    if (args.use_tiny)
+    {
+        config = make_tiny_config();
+    }
+    else if (!args.config_path.empty())
+    {
+        config = load_gptneox_config_json(args.config_path);
+    }
+    else
+    {
+        config = make_tiny_config();
+    }
+
+    if (args.seq_len > config.max_position_embeddings)
+    {
+        std::cerr << "Warning: seq_len > max_position_embeddings.\n";
+    }
+
+    if (args.warmup_steps < 0)
+    {
+        std::cerr << "gptneox_graph_training: --warmup-steps must be >= 0\n";
+        return EXIT_ERROR;
+    }
+    if (args.epochs == 0)
+    {
+        std::cerr << "gptneox_graph_training: --epochs must be >= 1\n";
+        return EXIT_ERROR;
+    }
+
+    const Index n_seq = args.seq_len;
+    const Index n_batch = args.batch;
+    const Index rope_half = gptneox_rope_dim(config) / 2;
+
+    std::cout << "=== GPT-NeoX graph training (setup) ===\n"
+              << "hidden=" << config.hidden_size
+              << "  layers=" << config.num_hidden_layers
+              << "  heads=" << config.num_attention_heads
+              << "  seq=" << n_seq << "  batch=" << n_batch
+              << "  epochs=" << args.epochs << "\n";
+
+    Context context(CONTEXT_NUM_CPU,
+        CONTEXT_NUM_CUDA,
+        CONTEXT_OOC,
+        "/tmp/nntile_ooc",
+        CONTEXT_OOC_SIZE,
+        CONTEXT_LOGGER,
+        "localhost",
+        CONTEXT_LOGGER_PORT,
+        CONTEXT_VERBOSE);
+
+    NNGraph graph("gptneox_graph_training");
+    GptneoxCausal model(&graph, "model", config);
+
+    auto *input_ids = graph.tensor({n_seq, n_batch}, DataType::INT64, false)
+                          ->set_name("input_ids");
+    auto *rope_sin =
+        graph.tensor({rope_half, n_seq, n_batch}, DataType::FP32, false)
+            ->set_name("rope_sin");
+    auto *rope_cos =
+        graph.tensor({rope_half, n_seq, n_batch}, DataType::FP32, false)
+            ->set_name("rope_cos");
+    auto *attn_mask = graph.tensor({n_seq, n_seq}, DataType::BOOL, false)
+                          ->set_name("attn_mask");
+    input_ids->mark_input(true);
+    rope_sin->mark_input(true);
+    rope_cos->mark_input(true);
+    attn_mask->mark_input(true);
+
+    auto *labels = graph.tensor({n_seq, n_batch}, DataType::INT64, false)
+                       ->set_name("labels");
+    labels->mark_input(true);
+
+    if (!args.load_weights.empty())
+    {
+        model.load(args.load_weights);
+    }
+    else
+    {
+        std::mt19937 gen(args.seed);
+        init_random_parameter_hints(model, gen);
+    }
+
+    auto optimizer = std::make_unique<AdamW>(&graph,
+        &model,
+        static_cast<Scalar>(args.learning_rate),
+        static_cast<Scalar>(args.beta1),
+        static_cast<Scalar>(args.beta2),
+        1e-8,
+        static_cast<Scalar>(args.weight_decay));
+
+    std::cout << "Optimizer: " << optimizer->repr() << "\n";
+    if (args.warmup_steps > 0)
+    {
+        std::cout << "LR schedule: linear warmup " << args.warmup_steps
+                  << " steps to lr=" << args.learning_rate << "\n";
+    }
+
+    std::vector<std::int64_t> pos_data(
+        static_cast<std::size_t>(n_seq * n_batch));
+    fill_arange_position_ids(pos_data, n_seq, n_batch);
+
+    const std::size_t rope_n =
+        static_cast<std::size_t>(rope_half * n_seq * n_batch);
+    std::vector<float> sin_data(rope_n);
+    std::vector<float> cos_data(rope_n);
+    rope_sin_cos_from_position_ids(config,
+        pos_data.data(),
+        n_seq,
+        n_batch,
+        sin_data.data(),
+        cos_data.data());
+
+    const std::size_t mask_n = static_cast<std::size_t>(n_seq * n_seq);
+    std::vector<std::uint8_t> mask_data(mask_n);
+    sdpa_causal_mask_bool_fortran_fill(n_seq, mask_data.data());
+
+    graph.enable_auto_tensor_name_phase_suffix(true);
+
+    const Scalar ce_scale = 1.0f / static_cast<Scalar>(n_seq * n_batch);
+
+    bool bound_optimizer_state = false;
+
+    TokenMemoryMap train_mmap(args.train_bin);
+    CausalLmBatchConfig lcfg;
+    lcfg.n_seq = n_seq;
+    lcfg.n_batch = n_batch;
+    lcfg.shuffle = args.shuffle;
+    lcfg.seed = args.seed;
+    CausalLmBatch mmap_batch;
+    Index train_step = 0;
+
+    for (std::size_t epoch = 0; epoch < args.epochs; ++epoch)
+    {
+        if (args.max_batches > 0 &&
+            train_step >= static_cast<Index>(args.max_batches))
+        {
+            break;
+        }
+        CausalLmBatchIterator train_it(train_mmap, lcfg, config.vocab_size);
+        for (;;)
+        {
+            if (!train_it.next(mmap_batch))
+            {
+                break;
+            }
+            if (args.max_batches > 0 &&
+                train_step >= static_cast<Index>(args.max_batches))
+            {
+                break;
+            }
+
+            if (train_step > 0)
+            {
+                graph.reset_incremental_tile_state();
+            }
+
+            for (NNGraph::TensorNode *p : graph.parameters())
+            {
+                if (p->grad() != nullptr)
+                {
+                    graph::tensor::clear(p->grad()->data());
+                }
+            }
+
+            NNGraph::TensorNode *logits =
+                model.forward(input_ids, rope_sin, rope_cos, attn_mask);
+            if (logits == nullptr)
+            {
+                throw std::runtime_error(
+                    "gptneox_graph_training: model.forward returned null");
+            }
+
+            std::string const loss_name =
+                std::string("loss_s") + std::to_string(train_step);
+            auto *loss = cross_entropy(logits, labels, 0, ce_scale, -100)
+                             ->set_name(loss_name);
+            loss->mark_output(true);
+
+            std::string const loss_grad_name = loss_name + "_grad";
+            auto [loss_grad, loss_grad_first] =
+                graph.get_or_create_grad(loss, loss_grad_name);
+            (void) loss_grad_first;
+            graph::tensor::fill(Scalar(1.0), loss_grad->data());
+            loss->backward(true);
+
+            Scalar const step_lr = scheduled_lr(train_step, args);
+            optimizer->step(step_lr);
+
+            graph.finish_phase();
+            graph.lower_and_compile();
+            Runtime &runtime = graph.runtime();
+
+            if (!bound_optimizer_state)
+            {
+                auto state_tensors = optimizer->named_state_tensors();
+                for (const auto &[sname, stensor] : state_tensors)
+                {
+                    (void) sname;
+                    Index n = 1;
+                    for (auto d : stensor->shape())
+                    {
+                        n *= d;
+                    }
+                    std::vector<float> zeros(static_cast<std::size_t>(n), 0.0f);
+                    runtime.bind_data(stensor, zeros);
+                }
+                bound_optimizer_state = true;
+            }
+
+            runtime.bind_data(input_ids, mmap_batch.input_ids);
+            runtime.bind_data(labels, mmap_batch.target_ids);
+            runtime.bind_data(rope_sin, sin_data);
+            runtime.bind_data(rope_cos, cos_data);
+            runtime.bind_data(attn_mask, mask_data);
+
+            auto t0 = std::chrono::high_resolution_clock::now();
+            runtime.execute();
+            runtime.wait();
+            auto t1 = std::chrono::high_resolution_clock::now();
+            auto us =
+                std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0)
+                    .count();
+
+            float loss_val = runtime.get_output<float>(loss)[0];
+            if (args.warmup_steps > 0)
+            {
+                std::cout << "Batch " << static_cast<long long>(train_step)
+                          << "  lr=" << static_cast<float>(step_lr)
+                          << "  loss=" << loss_val << "  (" << us << " us)\n";
+            }
+            else
+            {
+                std::cout << "Batch " << static_cast<long long>(train_step)
+                          << "  loss=" << loss_val << "  (" << us << " us)\n";
+            }
+
+            for (NNGraph::TensorNode *ptensor : graph.parameters())
+            {
+                sync_param_hint_from_runtime(runtime, ptensor);
+            }
+            for (const auto &[sname, stensor] :
+                optimizer->named_state_tensors())
+            {
+                (void) sname;
+                sync_param_hint_from_runtime(runtime, stensor);
+            }
+
+            ++train_step;
+        }
+        if (args.max_batches > 0 &&
+            train_step >= static_cast<Index>(args.max_batches))
+        {
+            break;
+        }
+    }
+
+    if (train_step == 0)
+    {
+        std::cerr
+            << "Warning: no full batches from --train-bin (need at least "
+            << "((seq+1)*batch) uint16 tokens).\n";
+    }
+    else
+    {
+        std::cout << "Processed " << static_cast<long long>(train_step)
+                  << " batch(es) from " << args.train_bin << "\n";
+    }
+
+    if (!args.output_dir.empty())
+    {
+        std::filesystem::create_directories(args.output_dir);
+        const std::string cfg_path = args.output_dir + "/config.json";
+        const std::string w_path = args.output_dir + "/model.safetensors";
+        save_gptneox_config_json(config, cfg_path);
+        if (graph.has_runtime())
+        {
+            for (NNGraph::TensorNode *ptensor : graph.parameters())
+            {
+                sync_param_hint_from_runtime(graph.runtime(), ptensor);
+            }
+        }
+        model.save(w_path);
+        std::cout << "Wrote " << cfg_path << "\n"
+                  << "Wrote " << w_path << "\n";
+    }
+
+    return EXIT_OK;
+}

--- a/examples/run_gptneox_graph_training_demo.sh
+++ b/examples/run_gptneox_graph_training_demo.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#                2023-present Artificial Intelligence Research Institute
+#                              (AIRI), Russia. All rights reserved.
+#
+# @file examples/run_gptneox_graph_training_demo.sh
+# Prepare tiny train.bin and run gptneox_graph_training for a few epochs.
+#
+# Usage (from repo root, after building gptneox_graph_training):
+#   ./examples/run_gptneox_graph_training_demo.sh
+#
+# Optional environment variables:
+#   BUILD_DIR  CMake build directory (default: <repo>/build)
+#   DATA_DIR   Where to write train.bin (default: <build>/examples/demo_data/gptneox)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=demo_common.sh
+source "${SCRIPT_DIR}/demo_common.sh"
+
+if [[ -d /opt/starpu/lib ]]; then
+    export LD_LIBRARY_PATH="/opt/starpu/lib:${LD_LIBRARY_PATH:-}"
+fi
+
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="$(demo_resolve_build_dir "${REPO_ROOT}")"
+DATA_DIR="${DATA_DIR:-${BUILD_DIR}/examples/demo_data/gptneox}"
+TRAIN_BIN="${DATA_DIR}/train.bin"
+LOG_FILE="${DATA_DIR}/training.log"
+BIN="${BUILD_DIR}/examples/gptneox_graph_training"
+
+SEQ_LEN="${SEQ_LEN:-8}"
+BATCH_SIZE="${BATCH_SIZE:-2}"
+NUM_BATCHES="${NUM_BATCHES:-8}"
+EPOCHS="${EPOCHS:-4}"
+MAX_BATCHES="${MAX_BATCHES:-32}"
+LR="${LR:-0.003}"
+
+demo_require_executable "${BIN}" "gptneox_graph_training"
+
+echo "=== GPT-NeoX graph training demo ==="
+echo "Build dir:  ${BUILD_DIR}"
+echo "Data dir:   ${DATA_DIR}"
+echo ""
+
+echo "--- Preparing tiny train.bin ---"
+python3 "${SCRIPT_DIR}/prepare_tiny_train_bin.py" \
+    --output "${TRAIN_BIN}" \
+    --seq-len "${SEQ_LEN}" \
+    --batch-size "${BATCH_SIZE}" \
+    --num-batches "${NUM_BATCHES}" \
+    --vocab-size 256 \
+    --seed 42
+echo ""
+
+echo "--- Training (tiny model, repeated epochs on same data) ---"
+mkdir -p "${DATA_DIR}"
+"${BIN}" \
+    --train-bin "${TRAIN_BIN}" \
+    --tiny \
+    --seq "${SEQ_LEN}" \
+    --batch "${BATCH_SIZE}" \
+    --epochs "${EPOCHS}" \
+    --max-batches "${MAX_BATCHES}" \
+    --lr "${LR}" \
+    --seed 42 \
+    2>&1 | tee "${LOG_FILE}"
+
+echo ""
+echo "--- Loss summary ---"
+demo_summarize_loss "${LOG_FILE}"

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -705,6 +705,14 @@ set(GRAPH_MODEL_HDR
     "nntile/graph/model/gpt2/gpt2_block.hh"
     "nntile/graph/model/gpt2/gpt2_model.hh"
     "nntile/graph/model/gpt2/gpt2_causal.hh"
+    "nntile/graph/model/gptneox.hh"
+    "nntile/graph/model/gptneox/gptneox_config.hh"
+    "nntile/graph/model/gptneox/gptneox_mlp.hh"
+    "nntile/graph/model/gptneox/gptneox_attention.hh"
+    "nntile/graph/model/gptneox/gptneox_decoder.hh"
+    "nntile/graph/model/gptneox/gptneox_model.hh"
+    "nntile/graph/model/gptneox/gptneox.hh"
+    "nntile/graph/model/gptneox/gptneox_causal.hh"
     )
 
 set(GRAPH_OPTIM_HDR

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -707,11 +707,13 @@ set(GRAPH_MODEL_HDR
     "nntile/graph/model/gpt2/gpt2_causal.hh"
     "nntile/graph/model/gptneox.hh"
     "nntile/graph/model/gptneox/gptneox_config.hh"
+    "nntile/graph/model/gptneox/gptneox_config_json.hh"
     "nntile/graph/model/gptneox/gptneox_mlp.hh"
     "nntile/graph/model/gptneox/gptneox_attention.hh"
     "nntile/graph/model/gptneox/gptneox_decoder.hh"
     "nntile/graph/model/gptneox/gptneox_model.hh"
     "nntile/graph/model/gptneox/gptneox.hh"
+    "nntile/graph/model/gptneox/gptneox_rope.hh"
     "nntile/graph/model/gptneox/gptneox_causal.hh"
     )
 

--- a/include/nntile/graph/model/gptneox.hh
+++ b/include/nntile/graph/model/gptneox.hh
@@ -1,0 +1,23 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file include/nntile/graph/model/gptneox.hh
+ * Convenience header for GPT-NeoX model components.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+#include <nntile/graph/model/gptneox/gptneox_mlp.hh>
+#include <nntile/graph/model/gptneox/gptneox_attention.hh>
+#include <nntile/graph/model/gptneox/gptneox_decoder.hh>
+#include <nntile/graph/model/gptneox/gptneox_model.hh>
+#include <nntile/graph/model/gptneox/gptneox.hh>
+#include <nntile/graph/model/gptneox/gptneox_causal.hh>

--- a/include/nntile/graph/model/gptneox/gptneox.hh
+++ b/include/nntile/graph/model/gptneox/gptneox.hh
@@ -1,0 +1,25 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file include/nntile/graph/model/gptneox/gptneox.hh
+ * Alias for GptneoxModel (base model without LM head).
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include <nntile/graph/model/gptneox/gptneox_model.hh>
+
+namespace nntile::model::gptneox
+{
+
+//! Gptneox - same as GptneoxModel (embedding + decoder layers + final norm)
+using Gptneox = GptneoxModel;
+
+} // namespace nntile::model::gptneox

--- a/include/nntile/graph/model/gptneox/gptneox_attention.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_attention.hh
@@ -1,0 +1,66 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file include/nntile/graph/model/gptneox/gptneox_attention.hh
+ * GPT-NeoX attention - self-attention with RoPE and SDPA.
+ *
+ * Input layout: (hidden_size, seq, batch) in Fortran order.
+ * GPT-NeoX uses full attention heads (no GQA).
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+// Include standard headers
+#include <string>
+
+// NNTile headers
+#include <nntile/graph.hh>
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+#include <nntile/graph/module/module.hh>
+
+namespace nntile::model::gptneox
+{
+
+//! GPT-NeoXAttention - Q/K/V projections via gemm, RoPE, SDPA, output projection
+class GptneoxAttention : public graph::module::Module
+{
+private:
+    graph::NNGraph::TensorNode* w_q_ = nullptr;  // (n_heads, head_size, n_emb)
+    graph::NNGraph::TensorNode* w_k_ = nullptr;  // (n_heads, head_size, n_emb)
+    graph::NNGraph::TensorNode* w_v_ = nullptr;  // (n_heads, head_size, n_emb)
+    graph::NNGraph::TensorNode* w_o_ = nullptr;  // (n_emb, n_heads, head_size)
+
+    GptneoxConfig config_;
+    graph::DataType dtype_;
+
+    Index head_size_;
+    Index n_heads_;
+
+public:
+    //! Constructor
+    GptneoxAttention(graph::NNGraph* graph,
+                     const std::string& name,
+                     const GptneoxConfig& config,
+                     graph::DataType dtype = graph::DataType::FP32);
+
+    //! Forward pass
+    graph::NNGraph::TensorNode* forward(
+        graph::NNGraph::TensorNode* x,
+        graph::NNGraph::TensorNode* sin = nullptr,
+        graph::NNGraph::TensorNode* cos = nullptr,
+        graph::NNGraph::TensorNode* mask = nullptr);
+
+    std::string repr() const override;
+
+    Index head_size() const { return head_size_; }
+    Index num_heads() const { return n_heads_; }
+};
+
+} // namespace nntile::model::gptneox

--- a/include/nntile/graph/model/gptneox/gptneox_causal.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_causal.hh
@@ -1,0 +1,60 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file include/nntile/graph/model/gptneox/gptneox_causal.hh
+ * GptneoxCausal - GptneoxModel + lm_head for causal language modeling.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+// Include standard headers
+#include <memory>
+#include <string>
+
+// NNTile headers
+#include <nntile/graph.hh>
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+#include <nntile/graph/model/gptneox/gptneox_model.hh>
+#include <nntile/graph/module/linear.hh>
+#include <nntile/graph/module/module.hh>
+
+namespace nntile::model::gptneox
+{
+
+//! GptneoxCausal - GptneoxModel + lm_head for next-token prediction
+class GptneoxCausal : public graph::module::Module
+{
+private:
+    std::unique_ptr<GptneoxModel> model_;
+    graph::module::Linear lm_head_;
+
+    GptneoxConfig config_;
+    graph::DataType dtype_;
+
+public:
+    //! Constructor
+    GptneoxCausal(graph::NNGraph* graph,
+                  const std::string& name,
+                  const GptneoxConfig& config,
+                  graph::DataType dtype = graph::DataType::FP32);
+
+    //! Forward pass
+    graph::NNGraph::TensorNode* forward(
+        graph::NNGraph::TensorNode* input_ids,
+        graph::NNGraph::TensorNode* sin = nullptr,
+        graph::NNGraph::TensorNode* cos = nullptr,
+        graph::NNGraph::TensorNode* mask = nullptr);
+
+    std::string repr() const override;
+
+    GptneoxModel* model() { return model_.get(); }
+};
+
+} // namespace nntile::model::gptneox

--- a/include/nntile/graph/model/gptneox/gptneox_config.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_config.hh
@@ -1,0 +1,78 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file include/nntile/graph/model/gptneox/gptneox_config.hh
+ * GPT-NeoX model configuration (mirrors HuggingFace GPTNeoXConfig).
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+// Standard library headers
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+// NNTile headers
+#include <nntile/base_types.hh>
+
+namespace nntile::model::gptneox
+{
+
+//! GPT-NeoX model configuration (mirrors HuggingFace GPTNeoXConfig)
+struct GptneoxConfig
+{
+    Index vocab_size = 50280;
+    Index hidden_size = 1024;
+    Index intermediate_size = 4096;
+    Index num_hidden_layers = 24;
+    Index num_attention_heads = 16;
+    Index max_position_embeddings = 2048;
+    Index head_dim = 64;  // hidden_size / num_attention_heads
+
+    float layer_norm_eps = 1e-5f;
+    float rotary_pct = 0.25f;
+    float rotary_emb_base = 10000.0f;
+
+    bool use_parallel_residual = true;
+    bool attention_bias = false;
+
+    int eos_token_id = 50256;
+    int bos_token_id = 50256;
+
+    std::string name = "gpt-neox";
+
+    //! Compute head_dim from hidden_size and num_attention_heads
+    void compute_head_dim()
+    {
+        if(num_attention_heads > 0 && hidden_size % num_attention_heads == 0)
+        {
+            head_dim = hidden_size / num_attention_heads;
+        }
+    }
+
+    //! Validate configuration
+    void validate() const
+    {
+        if(hidden_size % num_attention_heads != 0)
+        {
+            throw std::invalid_argument(
+                "GptneoxConfig: hidden_size must be divisible by "
+                "num_attention_heads");
+        }
+        if(hidden_size / num_attention_heads != head_dim)
+        {
+            throw std::invalid_argument(
+                "GptneoxConfig: head_dim must equal hidden_size / "
+                "num_attention_heads");
+        }
+    }
+};
+
+} // namespace nntile::model::gptneox

--- a/include/nntile/graph/model/gptneox/gptneox_config.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_config.hh
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 // NNTile headers
 #include <nntile/base_types.hh>
@@ -48,6 +49,9 @@ struct GptneoxConfig
 
     std::string name = "gpt-neox";
 
+    //! Per-layer attention: "global" or "local". Empty -> HF default.
+    std::vector<std::string> attention_layers;
+
     //! Compute head_dim from hidden_size and num_attention_heads
     void compute_head_dim()
     {
@@ -56,6 +60,12 @@ struct GptneoxConfig
             head_dim = hidden_size / num_attention_heads;
         }
     }
+
+    //! Fill ``attention_layers`` when empty (odd layers local).
+    void build_attention_layers();
+
+    //! True when layer uses sliding-window (local) attention.
+    bool is_local_attention_layer(Index layer_id) const;
 
     //! Validate configuration
     void validate() const
@@ -71,6 +81,13 @@ struct GptneoxConfig
             throw std::invalid_argument(
                 "GptneoxConfig: head_dim must equal hidden_size / "
                 "num_attention_heads");
+        }
+        if(!attention_layers.empty() &&
+            static_cast<Index>(attention_layers.size()) != num_hidden_layers)
+        {
+            throw std::invalid_argument(
+                "GptneoxConfig: attention_layers size must match "
+                "num_hidden_layers");
         }
     }
 };

--- a/include/nntile/graph/model/gptneox/gptneox_config_json.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_config_json.hh
@@ -1,0 +1,90 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file include/nntile/graph/model/gptneox/gptneox_config_json.hh
+ * Parse ``attention_layers`` / HF ``attention_types`` into ``GptneoxConfig``.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace nntile::model::gptneox
+{
+
+//! Expand HF ``attention_types`` like ``GPTNeoXConfig.expand_attention_types``.
+inline void parse_gptneox_attention_layers(
+    nlohmann::json const &j,
+    GptneoxConfig &cfg)
+{
+    if (j.contains("attention_layers") && j["attention_layers"].is_array())
+    {
+        cfg.attention_layers.clear();
+        for (auto const &entry : j["attention_layers"])
+        {
+            if (!entry.is_string())
+            {
+                throw std::runtime_error(
+                    "GptneoxConfig JSON: attention_layers entries must be "
+                    "strings");
+            }
+            cfg.attention_layers.push_back(entry.get<std::string>());
+        }
+        return;
+    }
+    if (!j.contains("attention_types") || !j["attention_types"].is_array())
+    {
+        return;
+    }
+    cfg.attention_layers.clear();
+    for (auto const &group : j["attention_types"])
+    {
+        if (!group.is_array() || group.size() != 2)
+        {
+            throw std::runtime_error(
+                "GptneoxConfig JSON: attention_types must be [[types], count], "
+                "...");
+        }
+        auto const &types_json = group[0];
+        int count = group.at(1).get<int>();
+        if (!types_json.is_array() || count <= 0)
+        {
+            throw std::runtime_error(
+                "GptneoxConfig JSON: invalid attention_types group");
+        }
+        std::vector<std::string> types;
+        types.reserve(types_json.size());
+        for (auto const &entry : types_json)
+        {
+            if (!entry.is_string())
+            {
+                throw std::runtime_error(
+                    "GptneoxConfig JSON: attention_types type must be string");
+            }
+            types.push_back(entry.get<std::string>());
+        }
+        if (types.empty())
+        {
+            throw std::runtime_error(
+                "GptneoxConfig JSON: attention_types type list is empty");
+        }
+        for (int rep = 0; rep < count; ++rep)
+        {
+            for (auto const &layer_type : types)
+            {
+                cfg.attention_layers.push_back(layer_type);
+            }
+        }
+    }
+}
+
+} // namespace nntile::model::gptneox

--- a/include/nntile/graph/model/gptneox/gptneox_decoder.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_decoder.hh
@@ -1,0 +1,66 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file include/nntile/graph/model/gptneox/gptneox_decoder.hh
+ * GPT-NeoXDecoder - one transformer block with parallel residual.
+ *
+ * When use_parallel_residual: attention and MLP run in parallel from same
+ * normalized input, then outputs are summed.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+// Include standard headers
+#include <string>
+
+// NNTile headers
+#include <nntile/graph.hh>
+#include <nntile/graph/model/gptneox/gptneox_attention.hh>
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+#include <nntile/graph/model/gptneox/gptneox_mlp.hh>
+#include <nntile/graph/module/module.hh>
+#include <nntile/graph/module/rms_norm.hh>
+
+namespace nntile::model::gptneox
+{
+
+//! GPT-NeoXDecoder - input_norm -> [attention, post_attn_norm->mlp] with parallel residual
+class GptneoxDecoder : public graph::module::Module
+{
+private:
+    graph::module::RMSNorm input_norm_;
+    GptneoxAttention attention_;
+    graph::module::RMSNorm post_attn_norm_;
+    GptneoxMlp mlp_;
+
+    GptneoxConfig config_;
+    graph::DataType dtype_;
+
+public:
+    //! Constructor
+    GptneoxDecoder(graph::NNGraph* graph,
+                   const std::string& name,
+                   const GptneoxConfig& config,
+                   graph::DataType dtype = graph::DataType::FP32);
+
+    //! Forward pass
+    graph::NNGraph::TensorNode* forward(
+        graph::NNGraph::TensorNode* x,
+        graph::NNGraph::TensorNode* sin = nullptr,
+        graph::NNGraph::TensorNode* cos = nullptr,
+        graph::NNGraph::TensorNode* mask = nullptr);
+
+    std::string repr() const override;
+
+    GptneoxAttention& attention() { return attention_; }
+    GptneoxMlp& mlp() { return mlp_; }
+};
+
+} // namespace nntile::model::gptneox

--- a/include/nntile/graph/model/gptneox/gptneox_decoder.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_decoder.hh
@@ -26,7 +26,7 @@
 #include <nntile/graph/model/gptneox/gptneox_config.hh>
 #include <nntile/graph/model/gptneox/gptneox_mlp.hh>
 #include <nntile/graph/module/module.hh>
-#include <nntile/graph/module/rms_norm.hh>
+#include <nntile/graph/module/layer_norm.hh>
 
 namespace nntile::model::gptneox
 {
@@ -35,9 +35,9 @@ namespace nntile::model::gptneox
 class GptneoxDecoder : public graph::module::Module
 {
 private:
-    graph::module::RMSNorm input_norm_;
+    graph::module::LayerNorm input_norm_;
     GptneoxAttention attention_;
-    graph::module::RMSNorm post_attn_norm_;
+    graph::module::LayerNorm post_attn_norm_;
     GptneoxMlp mlp_;
 
     GptneoxConfig config_;

--- a/include/nntile/graph/model/gptneox/gptneox_decoder.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_decoder.hh
@@ -59,6 +59,8 @@ public:
 
     std::string repr() const override;
 
+    graph::module::LayerNorm& input_norm() { return input_norm_; }
+    graph::module::LayerNorm& post_attn_norm() { return post_attn_norm_; }
     GptneoxAttention& attention() { return attention_; }
     GptneoxMlp& mlp() { return mlp_; }
 };

--- a/include/nntile/graph/model/gptneox/gptneox_mlp.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_mlp.hh
@@ -1,0 +1,51 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file include/nntile/graph/model/gptneox/gptneox_mlp.hh
+ * GPT-NeoX MLP module - up_proj -> GELU -> down_proj.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+// Include standard headers
+#include <string>
+
+// NNTile headers
+#include <nntile/graph.hh>
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+#include <nntile/graph/module/activation.hh>
+#include <nntile/graph/module/mlp.hh>
+
+namespace nntile::model::gptneox
+{
+
+//! GPT-NeoXMLP - GPT-NeoX-style MLP using GELU activation
+//! Architecture: down_proj(GELU(up_proj(x)))
+class GptneoxMlp : public graph::module::Mlp
+{
+public:
+    //! Constructor
+    //! @param graph Pointer to the neural network graph
+    //! @param name Module name
+    //! @param config GPT-NeoX configuration
+    GptneoxMlp(graph::NNGraph* graph,
+               const std::string& name,
+               const GptneoxConfig& config,
+               graph::DataType dtype = graph::DataType::FP32);
+
+    //! Forward pass
+    graph::NNGraph::TensorNode* forward(
+        graph::NNGraph::TensorNode* input);
+
+    //! Get string representation
+    std::string repr() const override;
+};
+
+} // namespace nntile::model::gptneox

--- a/include/nntile/graph/model/gptneox/gptneox_mlp.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_mlp.hh
@@ -26,25 +26,22 @@
 namespace nntile::model::gptneox
 {
 
-//! GPT-NeoXMLP - GPT-NeoX-style MLP using GELU activation
-//! Architecture: down_proj(GELU(up_proj(x)))
+//! GPT-NeoXMLP - MLP with GELU and HF ``dense_*`` biases (like ``Gpt2MLP``).
 class GptneoxMlp : public graph::module::Mlp
 {
+private:
+    graph::NNGraph::TensorNode* fc1_bias_ = nullptr;
+    graph::NNGraph::TensorNode* fc2_bias_ = nullptr;
+
 public:
-    //! Constructor
-    //! @param graph Pointer to the neural network graph
-    //! @param name Module name
-    //! @param config GPT-NeoX configuration
     GptneoxMlp(graph::NNGraph* graph,
                const std::string& name,
                const GptneoxConfig& config,
                graph::DataType dtype = graph::DataType::FP32);
 
-    //! Forward pass
     graph::NNGraph::TensorNode* forward(
         graph::NNGraph::TensorNode* input);
 
-    //! Get string representation
     std::string repr() const override;
 };
 

--- a/include/nntile/graph/model/gptneox/gptneox_model.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_model.hh
@@ -1,0 +1,63 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file include/nntile/graph/model/gptneox/gptneox_model.hh
+ * GptneoxModel - embedding + decoder layers + final norm.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+// Include standard headers
+#include <memory>
+#include <string>
+#include <vector>
+
+// NNTile headers
+#include <nntile/graph.hh>
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+#include <nntile/graph/model/gptneox/gptneox_decoder.hh>
+#include <nntile/graph/module/embedding.hh>
+#include <nntile/graph/module/module.hh>
+#include <nntile/graph/module/rms_norm.hh>
+
+namespace nntile::model::gptneox
+{
+
+//! GptneoxModel - embed_tokens + num_hidden_layers x GptneoxDecoder + norm
+class GptneoxModel : public graph::module::Module
+{
+private:
+    graph::module::Embedding embed_tokens_;
+    std::vector<std::unique_ptr<GptneoxDecoder>> layers_;
+    graph::module::RMSNorm norm_;
+
+    GptneoxConfig config_;
+    graph::DataType dtype_;
+
+public:
+    //! Constructor
+    GptneoxModel(graph::NNGraph* graph,
+                 const std::string& name,
+                 const GptneoxConfig& config,
+                 graph::DataType dtype = graph::DataType::FP32);
+
+    //! Forward pass
+    graph::NNGraph::TensorNode* forward(
+        graph::NNGraph::TensorNode* input_ids,
+        graph::NNGraph::TensorNode* sin = nullptr,
+        graph::NNGraph::TensorNode* cos = nullptr,
+        graph::NNGraph::TensorNode* mask = nullptr);
+
+    std::string repr() const override;
+
+    Index num_layers() const { return config_.num_hidden_layers; }
+};
+
+} // namespace nntile::model::gptneox

--- a/include/nntile/graph/model/gptneox/gptneox_model.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_model.hh
@@ -58,6 +58,11 @@ public:
     std::string repr() const override;
 
     Index num_layers() const { return config_.num_hidden_layers; }
+
+    graph::NNGraph::TensorNode* embed_vocab_tensor() const
+    {
+        return embed_tokens_.vocab_tensor();
+    }
 };
 
 } // namespace nntile::model::gptneox

--- a/include/nntile/graph/model/gptneox/gptneox_model.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_model.hh
@@ -25,7 +25,7 @@
 #include <nntile/graph/model/gptneox/gptneox_decoder.hh>
 #include <nntile/graph/module/embedding.hh>
 #include <nntile/graph/module/module.hh>
-#include <nntile/graph/module/rms_norm.hh>
+#include <nntile/graph/module/layer_norm.hh>
 
 namespace nntile::model::gptneox
 {
@@ -36,7 +36,7 @@ class GptneoxModel : public graph::module::Module
 private:
     graph::module::Embedding embed_tokens_;
     std::vector<std::unique_ptr<GptneoxDecoder>> layers_;
-    graph::module::RMSNorm norm_;
+    graph::module::LayerNorm norm_;
 
     GptneoxConfig config_;
     graph::DataType dtype_;

--- a/include/nntile/graph/model/gptneox/gptneox_rope.hh
+++ b/include/nntile/graph/model/gptneox/gptneox_rope.hh
@@ -1,0 +1,42 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file include/nntile/graph/model/gptneox/gptneox_rope.hh
+ * RoPE sin/cos from position ids (HuggingFace GPTNeoXRotaryEmbedding).
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include <cstdint>
+
+#include <nntile/base_types.hh>
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+
+namespace nntile::model::gptneox
+{
+
+//! Number of head dimensions that receive RoPE (even, from ``rotary_pct``).
+Index gptneox_rope_dim(GptneoxConfig const& config);
+
+//! Inverse frequencies for GPT-NeoX RoPE. ``out`` must hold ``rope_dim/2``
+//! values.
+void rope_inv_freq_gptneox(GptneoxConfig const& config, float* out);
+
+//! Fill ``sin`` and ``cos`` for ``graph::rope`` in layout
+//! ``(rope_dim/2, n_seq, n_batch)`` (Fortran order).
+void rope_sin_cos_from_position_ids(
+    GptneoxConfig const& config,
+    std::int64_t const* position_ids,
+    Index n_seq,
+    Index n_batch,
+    float* out_sin,
+    float* out_cos);
+
+} // namespace nntile::model::gptneox

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -574,6 +574,11 @@ set(GRAPH_MODEL_SRC
     "graph/model/gpt2/gpt2_block.cc"
     "graph/model/gpt2/gpt2_model.cc"
     "graph/model/gpt2/gpt2_causal.cc"
+    "graph/model/gptneox/gptneox_mlp.cc"
+    "graph/model/gptneox/gptneox_attention.cc"
+    "graph/model/gptneox/gptneox_decoder.cc"
+    "graph/model/gptneox/gptneox_model.cc"
+    "graph/model/gptneox/gptneox_causal.cc"
     )
 
 set(GRAPH_OPTIM_SRC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -574,6 +574,8 @@ set(GRAPH_MODEL_SRC
     "graph/model/gpt2/gpt2_block.cc"
     "graph/model/gpt2/gpt2_model.cc"
     "graph/model/gpt2/gpt2_causal.cc"
+    "graph/model/gptneox/gptneox_config.cc"
+    "graph/model/gptneox/gptneox_rope.cc"
     "graph/model/gptneox/gptneox_mlp.cc"
     "graph/model/gptneox/gptneox_attention.cc"
     "graph/model/gptneox/gptneox_decoder.cc"

--- a/src/graph/model/gptneox/gptneox_attention.cc
+++ b/src/graph/model/gptneox/gptneox_attention.cc
@@ -1,0 +1,138 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file src/graph/model/gptneox/gptneox_attention.cc
+ * GPT-NeoXAttention implementation.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_attention.hh"
+#include "nntile/graph/nn/gemm.hh"
+#include "nntile/graph/nn/rope.hh"
+#include "nntile/graph/nn/sdpa_eager.hh"
+#include "nntile/graph/nn/transpose.hh"
+
+#include <stdexcept>
+
+namespace nntile::model::gptneox
+{
+
+GptneoxAttention::GptneoxAttention(graph::NNGraph* graph,
+                                   const std::string& name,
+                                   const GptneoxConfig& config,
+                                   graph::DataType dtype)
+    : graph::module::Module(graph, name)
+    , config_(config)
+    , dtype_(dtype)
+    , head_size_(config.head_dim)
+    , n_heads_(config.num_attention_heads)
+{
+    Index n_emb = config.hidden_size;
+
+    // w_q, w_k, w_v: (n_heads, head_size, n_emb) - 3D
+    w_q_ = graph_->tensor(
+        {n_heads_, head_size_, n_emb},
+        tensor_name("q_weight"),
+        dtype_,
+        true);
+    register_parameter("q_weight", w_q_);
+
+    w_k_ = graph_->tensor(
+        {n_heads_, head_size_, n_emb},
+        tensor_name("k_weight"),
+        dtype_,
+        true);
+    register_parameter("k_weight", w_k_);
+
+    w_v_ = graph_->tensor(
+        {n_heads_, head_size_, n_emb},
+        tensor_name("v_weight"),
+        dtype_,
+        true);
+    register_parameter("v_weight", w_v_);
+
+    // w_o: (n_emb, n_heads, head_size) - 3D
+    w_o_ = graph_->tensor(
+        {n_emb, n_heads_, head_size_},
+        tensor_name("o_weight"),
+        dtype_,
+        true);
+    register_parameter("o_weight", w_o_);
+}
+
+graph::NNGraph::TensorNode* GptneoxAttention::forward(
+    graph::NNGraph::TensorNode* x,
+    graph::NNGraph::TensorNode* sin,
+    graph::NNGraph::TensorNode* cos,
+    graph::NNGraph::TensorNode* mask)
+{
+    if(x == nullptr)
+    {
+        throw std::invalid_argument(
+            "GptneoxAttention::forward: input tensor must be non-null");
+    }
+
+    // Q = gemm(w_q, x)
+    graph::NNGraph::TensorNode* q_proj = graph::gemm(
+        w_q_, x, tensor_name("q_proj"),
+        1.0, false, false, 1, 0);
+    graph::NNGraph::TensorNode* q =
+        graph::transpose(q_proj, tensor_name("q"), 1);
+
+    // K = gemm(w_k, x)
+    graph::NNGraph::TensorNode* k_proj = graph::gemm(
+        w_k_, x, tensor_name("k_proj"),
+        1.0, false, false, 1, 0);
+    graph::NNGraph::TensorNode* k =
+        graph::transpose(k_proj, tensor_name("k"), 1);
+
+    // V = gemm(w_v, x)
+    graph::NNGraph::TensorNode* v_proj = graph::gemm(
+        w_v_, x, tensor_name("v_proj"),
+        1.0, false, false, 1, 0);
+    graph::NNGraph::TensorNode* v =
+        graph::transpose(v_proj, tensor_name("v"), 1);
+
+    // RoPE on Q and K (if sin/cos provided)
+    graph::NNGraph::TensorNode* q_rope = q;
+    graph::NNGraph::TensorNode* k_rope = k;
+    if(sin != nullptr && cos != nullptr)
+    {
+        q_rope = graph::rope(sin, cos, q, tensor_name("q_rope"));
+        k_rope = graph::rope(sin, cos, k, tensor_name("k_rope"));
+    }
+
+    // SDPA: q, k, v layout (head_size, seq, batch, n_heads)
+    graph::NNGraph::TensorNode* attn_out = graph::sdpa_eager(
+        q_rope, k_rope, v,
+        tensor_name("sdpa_out"),
+        mask,
+        2,  // batch_ndim
+        0);
+
+    // Transpose to (n_heads, head_size, seq, batch) for output projection
+    graph::NNGraph::TensorNode* attn_t =
+        graph::transpose(attn_out, tensor_name("attn_t"), 3);
+
+    // Output projection: gemm(w_o, attn_t)
+    graph::NNGraph::TensorNode* out = graph::gemm(
+        w_o_, attn_t, tensor_name("out_proj"),
+        1.0, false, false, 2, 0);
+
+    return out;
+}
+
+std::string GptneoxAttention::repr() const
+{
+    return "GptneoxAttention(hidden=" + std::to_string(config_.hidden_size) +
+           ", n_heads=" + std::to_string(n_heads_) +
+           ", head_size=" + std::to_string(head_size_) + ")";
+}
+
+} // namespace nntile::model::gptneox

--- a/src/graph/model/gptneox/gptneox_attention.cc
+++ b/src/graph/model/gptneox/gptneox_attention.cc
@@ -13,10 +13,10 @@
  * */
 
 #include "nntile/graph/model/gptneox/gptneox_attention.hh"
-#include "nntile/graph/nn/gemm.hh"
-#include "nntile/graph/nn/rope.hh"
-#include "nntile/graph/nn/sdpa_eager.hh"
-#include "nntile/graph/nn/transpose.hh"
+#include "nntile/graph/nn/ops/gemm.hh"
+#include "nntile/graph/nn/ops/rope.hh"
+#include "nntile/graph/nn/ops/sdpa_eager.hh"
+#include "nntile/graph/nn/ops/transpose.hh"
 
 #include <stdexcept>
 
@@ -33,36 +33,23 @@ GptneoxAttention::GptneoxAttention(graph::NNGraph* graph,
     , head_size_(config.head_dim)
     , n_heads_(config.num_attention_heads)
 {
+    config_.validate();
     Index n_emb = config.hidden_size;
 
-    // w_q, w_k, w_v: (n_heads, head_size, n_emb) - 3D
-    w_q_ = graph_->tensor(
-        {n_heads_, head_size_, n_emb},
-        tensor_name("q_weight"),
-        dtype_,
-        true);
+    w_q_ = graph_->tensor({n_heads_, head_size_, n_emb}, dtype_, true);
+    w_q_->set_name(tensor_name("q_weight"));
     register_parameter("q_weight", w_q_);
 
-    w_k_ = graph_->tensor(
-        {n_heads_, head_size_, n_emb},
-        tensor_name("k_weight"),
-        dtype_,
-        true);
+    w_k_ = graph_->tensor({n_heads_, head_size_, n_emb}, dtype_, true);
+    w_k_->set_name(tensor_name("k_weight"));
     register_parameter("k_weight", w_k_);
 
-    w_v_ = graph_->tensor(
-        {n_heads_, head_size_, n_emb},
-        tensor_name("v_weight"),
-        dtype_,
-        true);
+    w_v_ = graph_->tensor({n_heads_, head_size_, n_emb}, dtype_, true);
+    w_v_->set_name(tensor_name("v_weight"));
     register_parameter("v_weight", w_v_);
 
-    // w_o: (n_emb, n_heads, head_size) - 3D
-    w_o_ = graph_->tensor(
-        {n_emb, n_heads_, head_size_},
-        tensor_name("o_weight"),
-        dtype_,
-        true);
+    w_o_ = graph_->tensor({n_emb, n_heads_, head_size_}, dtype_, true);
+    w_o_->set_name(tensor_name("o_weight"));
     register_parameter("o_weight", w_o_);
 }
 
@@ -78,53 +65,44 @@ graph::NNGraph::TensorNode* GptneoxAttention::forward(
             "GptneoxAttention::forward: input tensor must be non-null");
     }
 
-    // Q = gemm(w_q, x)
-    graph::NNGraph::TensorNode* q_proj = graph::gemm(
-        w_q_, x, tensor_name("q_proj"),
-        1.0, false, false, 1, 0);
-    graph::NNGraph::TensorNode* q =
-        graph::transpose(q_proj, tensor_name("q"), 1);
+    graph::NNGraph::TensorNode* q_proj =
+        graph::gemm(w_q_, x, 1.0, false, false, 1, 0);
+    q_proj->set_name(tensor_name("q_proj"));
+    graph::NNGraph::TensorNode* q = graph::transpose(q_proj, 1);
+    q->set_name(tensor_name("q"));
 
-    // K = gemm(w_k, x)
-    graph::NNGraph::TensorNode* k_proj = graph::gemm(
-        w_k_, x, tensor_name("k_proj"),
-        1.0, false, false, 1, 0);
-    graph::NNGraph::TensorNode* k =
-        graph::transpose(k_proj, tensor_name("k"), 1);
+    graph::NNGraph::TensorNode* k_proj =
+        graph::gemm(w_k_, x, 1.0, false, false, 1, 0);
+    k_proj->set_name(tensor_name("k_proj"));
+    graph::NNGraph::TensorNode* k = graph::transpose(k_proj, 1);
+    k->set_name(tensor_name("k"));
 
-    // V = gemm(w_v, x)
-    graph::NNGraph::TensorNode* v_proj = graph::gemm(
-        w_v_, x, tensor_name("v_proj"),
-        1.0, false, false, 1, 0);
-    graph::NNGraph::TensorNode* v =
-        graph::transpose(v_proj, tensor_name("v"), 1);
+    graph::NNGraph::TensorNode* v_proj =
+        graph::gemm(w_v_, x, 1.0, false, false, 1, 0);
+    v_proj->set_name(tensor_name("v_proj"));
+    graph::NNGraph::TensorNode* v = graph::transpose(v_proj, 1);
+    v->set_name(tensor_name("v"));
 
-    // RoPE on Q and K (if sin/cos provided)
     graph::NNGraph::TensorNode* q_rope = q;
     graph::NNGraph::TensorNode* k_rope = k;
     if(sin != nullptr && cos != nullptr)
     {
-        q_rope = graph::rope(sin, cos, q, tensor_name("q_rope"));
-        k_rope = graph::rope(sin, cos, k, tensor_name("k_rope"));
+        q_rope = graph::rope(sin, cos, q);
+        q_rope->set_name(tensor_name("q_rope"));
+        k_rope = graph::rope(sin, cos, k);
+        k_rope->set_name(tensor_name("k_rope"));
     }
 
-    // SDPA: q, k, v layout (head_size, seq, batch, n_heads)
-    graph::NNGraph::TensorNode* attn_out = graph::sdpa_eager(
-        q_rope, k_rope, v,
-        tensor_name("sdpa_out"),
-        mask,
-        2,  // batch_ndim
-        0);
+    graph::NNGraph::TensorNode* attn_out =
+        graph::sdpa_eager(q_rope, k_rope, v, mask, 2, 0);
+    attn_out->set_name(tensor_name("sdpa_out"));
 
-    // Transpose to (n_heads, head_size, seq, batch) for output projection
-    graph::NNGraph::TensorNode* attn_t =
-        graph::transpose(attn_out, tensor_name("attn_t"), 3);
+    graph::NNGraph::TensorNode* attn_t = graph::transpose(attn_out, 3);
+    attn_t->set_name(tensor_name("attn_t"));
 
-    // Output projection: gemm(w_o, attn_t)
-    graph::NNGraph::TensorNode* out = graph::gemm(
-        w_o_, attn_t, tensor_name("out_proj"),
-        1.0, false, false, 2, 0);
-
+    graph::NNGraph::TensorNode* out =
+        graph::gemm(w_o_, attn_t, 1.0, false, false, 2, 0);
+    out->set_name(tensor_name("out_proj"));
     return out;
 }
 

--- a/src/graph/model/gptneox/gptneox_causal.cc
+++ b/src/graph/model/gptneox/gptneox_causal.cc
@@ -1,0 +1,61 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file src/graph/model/gptneox/gptneox_causal.cc
+ * GptneoxCausal implementation.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_causal.hh"
+#include "nntile/graph/nn/transpose.hh"
+
+#include <stdexcept>
+
+namespace nntile::model::gptneox
+{
+
+GptneoxCausal::GptneoxCausal(graph::NNGraph* graph,
+                             const std::string& name,
+                             const GptneoxConfig& config,
+                             graph::DataType dtype)
+    : graph::module::Module(graph, name)
+    , model_(std::make_unique<GptneoxModel>(graph, name + "_model", config, dtype))
+    , lm_head_(graph, name + "_lm_head",
+               config.hidden_size, config.vocab_size, false, dtype)
+    , config_(config)
+    , dtype_(dtype)
+{
+    register_module("model", model_.get());
+    register_module("lm_head", &lm_head_);
+}
+
+graph::NNGraph::TensorNode* GptneoxCausal::forward(
+    graph::NNGraph::TensorNode* input_ids,
+    graph::NNGraph::TensorNode* sin,
+    graph::NNGraph::TensorNode* cos,
+    graph::NNGraph::TensorNode* mask)
+{
+    // Model output: (hidden, seq, batch)
+    graph::NNGraph::TensorNode* hidden =
+        model_->forward(input_ids, sin, cos, mask);
+    // Transpose (hidden, seq, batch) -> (seq, batch, hidden) for lm_head
+    graph::NNGraph::TensorNode* hidden_t =
+        graph::transpose(hidden, tensor_name("hidden_t"), 1);
+    graph::NNGraph::TensorNode* logits_sbv = lm_head_.forward(hidden_t);
+    // Transpose to (vocab, seq, batch) for output
+    return graph::transpose(logits_sbv, tensor_name("logits"), 2);
+}
+
+std::string GptneoxCausal::repr() const
+{
+    return "GptneoxCausal(" + model_->repr() + ", vocab=" +
+           std::to_string(config_.vocab_size) + ")";
+}
+
+} // namespace nntile::model::gptneox

--- a/src/graph/model/gptneox/gptneox_causal.cc
+++ b/src/graph/model/gptneox/gptneox_causal.cc
@@ -13,7 +13,7 @@
  * */
 
 #include "nntile/graph/model/gptneox/gptneox_causal.hh"
-#include "nntile/graph/nn/transpose.hh"
+#include "nntile/graph/nn/ops/transpose.hh"
 
 #include <stdexcept>
 
@@ -41,15 +41,14 @@ graph::NNGraph::TensorNode* GptneoxCausal::forward(
     graph::NNGraph::TensorNode* cos,
     graph::NNGraph::TensorNode* mask)
 {
-    // Model output: (hidden, seq, batch)
     graph::NNGraph::TensorNode* hidden =
         model_->forward(input_ids, sin, cos, mask);
-    // Transpose (hidden, seq, batch) -> (seq, batch, hidden) for lm_head
-    graph::NNGraph::TensorNode* hidden_t =
-        graph::transpose(hidden, tensor_name("hidden_t"), 1);
+    graph::NNGraph::TensorNode* hidden_t = graph::transpose(hidden, 1);
+    hidden_t->set_name(tensor_name("hidden_t"));
     graph::NNGraph::TensorNode* logits_sbv = lm_head_.forward(hidden_t);
-    // Transpose to (vocab, seq, batch) for output
-    return graph::transpose(logits_sbv, tensor_name("logits"), 2);
+    graph::NNGraph::TensorNode* logits = graph::transpose(logits_sbv, 2);
+    logits->set_name(tensor_name("logits"));
+    return logits;
 }
 
 std::string GptneoxCausal::repr() const

--- a/src/graph/model/gptneox/gptneox_config.cc
+++ b/src/graph/model/gptneox/gptneox_config.cc
@@ -1,0 +1,47 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file src/graph/model/gptneox/gptneox_config.cc
+ * GPT-NeoX configuration helpers.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_config.hh"
+
+#include <stdexcept>
+
+namespace nntile::model::gptneox
+{
+
+void GptneoxConfig::build_attention_layers()
+{
+    if(!attention_layers.empty())
+    {
+        return;
+    }
+    attention_layers.resize(static_cast<std::size_t>(num_hidden_layers));
+    for(Index i = 0; i < num_hidden_layers; ++i)
+    {
+        attention_layers[static_cast<std::size_t>(i)] =
+            (i % 2 == 1) ? "local" : "global";
+    }
+}
+
+bool GptneoxConfig::is_local_attention_layer(Index layer_id) const
+{
+    if(layer_id < 0 || layer_id >= num_hidden_layers)
+    {
+        throw std::out_of_range(
+            "GptneoxConfig::is_local_attention_layer: layer_id out of range");
+    }
+    if(attention_layers.empty())
+    {
+        return layer_id % 2 == 1;
+    }
+    return attention_layers[static_cast<std::size_t>(layer_id)] == "local";
+}
+
+} // namespace nntile::model::gptneox

--- a/src/graph/model/gptneox/gptneox_decoder.cc
+++ b/src/graph/model/gptneox/gptneox_decoder.cc
@@ -1,0 +1,87 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file src/graph/model/gptneox/gptneox_decoder.cc
+ * GPT-NeoXDecoder implementation.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_decoder.hh"
+#include "nntile/graph/nn/add.hh"
+
+#include <stdexcept>
+
+namespace nntile::model::gptneox
+{
+
+GptneoxDecoder::GptneoxDecoder(graph::NNGraph* graph,
+                               const std::string& name,
+                               const GptneoxConfig& config,
+                               graph::DataType dtype)
+    : graph::module::Module(graph, name)
+    , input_norm_(graph, name + "_input_norm",
+                  config.hidden_size, 0, config.layer_norm_eps, 0, dtype)
+    , attention_(graph, name + "_attention", config, dtype)
+    , post_attn_norm_(graph, name + "_post_attn_norm",
+                      config.hidden_size, 0, config.layer_norm_eps, 0, dtype)
+    , mlp_(graph, name + "_mlp", config, dtype)
+    , config_(config)
+    , dtype_(dtype)
+{
+    register_module("input_norm", &input_norm_);
+    register_module("attention", &attention_);
+    register_module("post_attn_norm", &post_attn_norm_);
+    register_module("mlp", &mlp_);
+}
+
+graph::NNGraph::TensorNode* GptneoxDecoder::forward(
+    graph::NNGraph::TensorNode* x,
+    graph::NNGraph::TensorNode* sin,
+    graph::NNGraph::TensorNode* cos,
+    graph::NNGraph::TensorNode* mask)
+{
+    if(x == nullptr)
+    {
+        throw std::invalid_argument(
+            "GptneoxDecoder::forward: input tensor must be non-null");
+    }
+
+    // input_norm -> attention
+    graph::NNGraph::TensorNode* x_norm = input_norm_.forward(x);
+    graph::NNGraph::TensorNode* attn_out =
+        attention_.forward(x_norm, sin, cos, mask);
+
+    // residual: x + attn_out
+    graph::NNGraph::TensorNode* post_attn =
+        graph::add(1.0, x, 1.0, attn_out, tensor_name("post_attn"));
+
+    if(config_.use_parallel_residual)
+    {
+        // Parallel residual: ln_2 normalizes x (not post_attn)
+        graph::NNGraph::TensorNode* ln2_in = post_attn_norm_.forward(x);
+        graph::NNGraph::TensorNode* mlp_out = mlp_.forward(ln2_in);
+        // post_mlp_add: mlp_out + post_attn
+        return graph::add(1.0, post_attn, 1.0, mlp_out, tensor_name("decoder_out"));
+    }
+    else
+    {
+        // Sequential: post_attn_norm -> mlp
+        graph::NNGraph::TensorNode* mlp_in = post_attn_norm_.forward(post_attn);
+        graph::NNGraph::TensorNode* mlp_out = mlp_.forward(mlp_in);
+        return graph::add(1.0, post_attn, 1.0, mlp_out, tensor_name("decoder_out"));
+    }
+}
+
+std::string GptneoxDecoder::repr() const
+{
+    return "GptneoxDecoder(hidden=" + std::to_string(config_.hidden_size) +
+           ", parallel_residual=" + (config_.use_parallel_residual ? "true" : "false") + ")";
+}
+
+} // namespace nntile::model::gptneox

--- a/src/graph/model/gptneox/gptneox_decoder.cc
+++ b/src/graph/model/gptneox/gptneox_decoder.cc
@@ -63,6 +63,7 @@ graph::NNGraph::TensorNode* GptneoxDecoder::forward(
 
     if(config_.use_parallel_residual)
     {
+        // HF: mlp(post_attention_layernorm(x)) + attn + x (not ln2(post_attn)).
         graph::NNGraph::TensorNode* ln2_in = post_attn_norm_.forward(x);
         graph::NNGraph::TensorNode* mlp_out = mlp_.forward(ln2_in);
         graph::NNGraph::TensorNode* out =
@@ -71,6 +72,7 @@ graph::NNGraph::TensorNode* GptneoxDecoder::forward(
         return out;
     }
 
+    // Sequential: ln2(post_attn) -> mlp, like GPT-Neo decoder block.
     graph::NNGraph::TensorNode* mlp_in = post_attn_norm_.forward(post_attn);
     graph::NNGraph::TensorNode* mlp_out = mlp_.forward(mlp_in);
     graph::NNGraph::TensorNode* out =

--- a/src/graph/model/gptneox/gptneox_decoder.cc
+++ b/src/graph/model/gptneox/gptneox_decoder.cc
@@ -57,22 +57,25 @@ graph::NNGraph::TensorNode* GptneoxDecoder::forward(
     graph::NNGraph::TensorNode* attn_out =
         attention_.forward(x_norm, sin, cos, mask);
 
-    graph::NNGraph::TensorNode* post_attn =
-        graph::add(1.0, x, 1.0, attn_out);
-    post_attn->set_name(tensor_name("post_attn"));
-
     if(config_.use_parallel_residual)
     {
-        // HF: mlp(post_attention_layernorm(x)) + attn + x (not ln2(post_attn)).
+        // HF: x + attn + mlp(ln2(x)); skip post_attn = x + attn intermediate.
         graph::NNGraph::TensorNode* ln2_in = post_attn_norm_.forward(x);
         graph::NNGraph::TensorNode* mlp_out = mlp_.forward(ln2_in);
+        graph::NNGraph::TensorNode* attn_plus_mlp =
+            graph::add(1.0, attn_out, 1.0, mlp_out);
+        attn_plus_mlp->set_name(tensor_name("attn_plus_mlp"));
         graph::NNGraph::TensorNode* out =
-            graph::add(1.0, post_attn, 1.0, mlp_out);
+            graph::add(1.0, x, 1.0, attn_plus_mlp);
         out->set_name(tensor_name("decoder_out"));
         return out;
     }
 
-    // Sequential: ln2(post_attn) -> mlp, like GPT-Neo decoder block.
+    // Sequential: ln2(x + attn) -> mlp, like GPT-Neo decoder block.
+    graph::NNGraph::TensorNode* post_attn =
+        graph::add(1.0, x, 1.0, attn_out);
+    post_attn->set_name(tensor_name("post_attn"));
+
     graph::NNGraph::TensorNode* mlp_in = post_attn_norm_.forward(post_attn);
     graph::NNGraph::TensorNode* mlp_out = mlp_.forward(mlp_in);
     graph::NNGraph::TensorNode* out =

--- a/src/graph/model/gptneox/gptneox_decoder.cc
+++ b/src/graph/model/gptneox/gptneox_decoder.cc
@@ -13,7 +13,7 @@
  * */
 
 #include "nntile/graph/model/gptneox/gptneox_decoder.hh"
-#include "nntile/graph/nn/add.hh"
+#include "nntile/graph/nn/ops/add.hh"
 
 #include <stdexcept>
 
@@ -34,6 +34,7 @@ GptneoxDecoder::GptneoxDecoder(graph::NNGraph* graph,
     , config_(config)
     , dtype_(dtype)
 {
+    config_.validate();
     register_module("input_norm", &input_norm_);
     register_module("attention", &attention_);
     register_module("post_attn_norm", &post_attn_norm_);
@@ -52,36 +53,37 @@ graph::NNGraph::TensorNode* GptneoxDecoder::forward(
             "GptneoxDecoder::forward: input tensor must be non-null");
     }
 
-    // input_norm -> attention
     graph::NNGraph::TensorNode* x_norm = input_norm_.forward(x);
     graph::NNGraph::TensorNode* attn_out =
         attention_.forward(x_norm, sin, cos, mask);
 
-    // residual: x + attn_out
     graph::NNGraph::TensorNode* post_attn =
-        graph::add(1.0, x, 1.0, attn_out, tensor_name("post_attn"));
+        graph::add(1.0, x, 1.0, attn_out);
+    post_attn->set_name(tensor_name("post_attn"));
 
     if(config_.use_parallel_residual)
     {
-        // Parallel residual: ln_2 normalizes x (not post_attn)
         graph::NNGraph::TensorNode* ln2_in = post_attn_norm_.forward(x);
         graph::NNGraph::TensorNode* mlp_out = mlp_.forward(ln2_in);
-        // post_mlp_add: mlp_out + post_attn
-        return graph::add(1.0, post_attn, 1.0, mlp_out, tensor_name("decoder_out"));
+        graph::NNGraph::TensorNode* out =
+            graph::add(1.0, post_attn, 1.0, mlp_out);
+        out->set_name(tensor_name("decoder_out"));
+        return out;
     }
-    else
-    {
-        // Sequential: post_attn_norm -> mlp
-        graph::NNGraph::TensorNode* mlp_in = post_attn_norm_.forward(post_attn);
-        graph::NNGraph::TensorNode* mlp_out = mlp_.forward(mlp_in);
-        return graph::add(1.0, post_attn, 1.0, mlp_out, tensor_name("decoder_out"));
-    }
+
+    graph::NNGraph::TensorNode* mlp_in = post_attn_norm_.forward(post_attn);
+    graph::NNGraph::TensorNode* mlp_out = mlp_.forward(mlp_in);
+    graph::NNGraph::TensorNode* out =
+        graph::add(1.0, post_attn, 1.0, mlp_out);
+    out->set_name(tensor_name("decoder_out"));
+    return out;
 }
 
 std::string GptneoxDecoder::repr() const
 {
     return "GptneoxDecoder(hidden=" + std::to_string(config_.hidden_size) +
-           ", parallel_residual=" + (config_.use_parallel_residual ? "true" : "false") + ")";
+           ", parallel_residual=" +
+           (config_.use_parallel_residual ? "true" : "false") + ")";
 }
 
 } // namespace nntile::model::gptneox

--- a/src/graph/model/gptneox/gptneox_mlp.cc
+++ b/src/graph/model/gptneox/gptneox_mlp.cc
@@ -1,0 +1,52 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file src/graph/model/gptneox/gptneox_mlp.cc
+ * GPT-NeoXMLP implementation.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_mlp.hh"
+#include "nntile/graph/nn/transpose.hh"
+
+#include <stdexcept>
+
+namespace nntile::model::gptneox
+{
+
+GptneoxMlp::GptneoxMlp(graph::NNGraph* graph,
+                       const std::string& name,
+                       const GptneoxConfig& config,
+                       graph::DataType dtype)
+    : graph::module::Mlp(graph, name,
+                         config.hidden_size,
+                         config.intermediate_size,
+                         config.hidden_size,
+                         graph::module::ActivationType::GELU,
+                         dtype)
+{
+}
+
+graph::NNGraph::TensorNode* GptneoxMlp::forward(
+    graph::NNGraph::TensorNode* input)
+{
+    // Transpose (hidden, seq, batch) -> (seq, batch, hidden) for Mlp (ndim=1)
+    graph::NNGraph::TensorNode* x =
+        graph::transpose(input, tensor_name("x"), 1);
+    graph::NNGraph::TensorNode* out = graph::module::Mlp::forward(x);
+    // Transpose back to (hidden, seq, batch) (ndim=2)
+    return graph::transpose(out, tensor_name("mlp_out"), 2);
+}
+
+std::string GptneoxMlp::repr() const
+{
+    return "GptneoxMlp(" + graph::module::Mlp::repr() + ")";
+}
+
+} // namespace nntile::model::gptneox

--- a/src/graph/model/gptneox/gptneox_mlp.cc
+++ b/src/graph/model/gptneox/gptneox_mlp.cc
@@ -13,6 +13,7 @@
  * */
 
 #include "nntile/graph/model/gptneox/gptneox_mlp.hh"
+#include "nntile/graph/nn/ops/add_fiber.hh"
 #include "nntile/graph/nn/ops/gemm.hh"
 
 namespace nntile::model::gptneox
@@ -29,6 +30,15 @@ GptneoxMlp::GptneoxMlp(graph::NNGraph* graph,
                          graph::module::ActivationType::GELU,
                          dtype)
 {
+    config.validate();
+
+    fc1_bias_ = graph_->tensor({config.intermediate_size}, dtype, true);
+    fc1_bias_->set_name(tensor_name("fc1.bias"));
+    register_parameter("fc1.bias", fc1_bias_);
+
+    fc2_bias_ = graph_->tensor({config.hidden_size}, dtype, true);
+    fc2_bias_->set_name(tensor_name("fc2.bias"));
+    register_parameter("fc2.bias", fc2_bias_);
 }
 
 graph::NNGraph::TensorNode* GptneoxMlp::forward(
@@ -38,10 +48,12 @@ graph::NNGraph::TensorNode* GptneoxMlp::forward(
     graph::NNGraph::TensorNode* hidden =
         graph::gemm(w1, input, 1.0, true, false, 1, 0);
     hidden->set_name(tensor_name("fc1_out"));
+    hidden = graph::add_fiber(1.0, fc1_bias_, 1.0, hidden, 0, 0);
     hidden = activation().forward(hidden);
     graph::NNGraph::TensorNode* w2 = fc2().weight_tensor();
     graph::NNGraph::TensorNode* out =
         graph::gemm(w2, hidden, 1.0, true, false, 1, 0);
+    out = graph::add_fiber(1.0, fc2_bias_, 1.0, out, 0, 0);
     out->set_name(tensor_name("mlp_out"));
     return out;
 }

--- a/src/graph/model/gptneox/gptneox_mlp.cc
+++ b/src/graph/model/gptneox/gptneox_mlp.cc
@@ -13,9 +13,7 @@
  * */
 
 #include "nntile/graph/model/gptneox/gptneox_mlp.hh"
-#include "nntile/graph/nn/transpose.hh"
-
-#include <stdexcept>
+#include "nntile/graph/nn/ops/gemm.hh"
 
 namespace nntile::model::gptneox
 {
@@ -36,12 +34,16 @@ GptneoxMlp::GptneoxMlp(graph::NNGraph* graph,
 graph::NNGraph::TensorNode* GptneoxMlp::forward(
     graph::NNGraph::TensorNode* input)
 {
-    // Transpose (hidden, seq, batch) -> (seq, batch, hidden) for Mlp (ndim=1)
-    graph::NNGraph::TensorNode* x =
-        graph::transpose(input, tensor_name("x"), 1);
-    graph::NNGraph::TensorNode* out = graph::module::Mlp::forward(x);
-    // Transpose back to (hidden, seq, batch) (ndim=2)
-    return graph::transpose(out, tensor_name("mlp_out"), 2);
+    graph::NNGraph::TensorNode* w1 = fc1().weight_tensor();
+    graph::NNGraph::TensorNode* hidden =
+        graph::gemm(w1, input, 1.0, true, false, 1, 0);
+    hidden->set_name(tensor_name("fc1_out"));
+    hidden = activation().forward(hidden);
+    graph::NNGraph::TensorNode* w2 = fc2().weight_tensor();
+    graph::NNGraph::TensorNode* out =
+        graph::gemm(w2, hidden, 1.0, true, false, 1, 0);
+    out->set_name(tensor_name("mlp_out"));
+    return out;
 }
 
 std::string GptneoxMlp::repr() const

--- a/src/graph/model/gptneox/gptneox_model.cc
+++ b/src/graph/model/gptneox/gptneox_model.cc
@@ -1,0 +1,80 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file src/graph/model/gptneox/gptneox_model.cc
+ * GptneoxModel implementation.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_model.hh"
+#include "nntile/graph/nn/transpose.hh"
+
+#include <stdexcept>
+
+namespace nntile::model::gptneox
+{
+
+GptneoxModel::GptneoxModel(graph::NNGraph* graph,
+                           const std::string& name,
+                           const GptneoxConfig& config,
+                           graph::DataType dtype)
+    : graph::module::Module(graph, name)
+    , embed_tokens_(graph, name + "_embed_tokens",
+                    config.vocab_size, config.hidden_size,
+                    2, 0, dtype)
+    , norm_(graph, name + "_norm",
+            config.hidden_size, 0, config.layer_norm_eps, 0, dtype)
+    , config_(config)
+    , dtype_(dtype)
+{
+    register_module("embed_tokens", &embed_tokens_);
+    register_module("norm", &norm_);
+
+    for(Index i = 0; i < config.num_hidden_layers; ++i)
+    {
+        auto layer = std::make_unique<GptneoxDecoder>(
+            graph, name + "_layers_" + std::to_string(i), config, dtype);
+        register_module("layers_" + std::to_string(i), layer.get());
+        layers_.push_back(std::move(layer));
+    }
+}
+
+graph::NNGraph::TensorNode* GptneoxModel::forward(
+    graph::NNGraph::TensorNode* input_ids,
+    graph::NNGraph::TensorNode* sin,
+    graph::NNGraph::TensorNode* cos,
+    graph::NNGraph::TensorNode* mask)
+{
+    if(input_ids == nullptr)
+    {
+        throw std::invalid_argument(
+            "GptneoxModel::forward: input_ids must be non-null");
+    }
+
+    // Embedding: (seq, batch) -> (seq, batch, hidden)
+    graph::NNGraph::TensorNode* embed = embed_tokens_.forward(input_ids);
+    // Transpose to (hidden, seq, batch) for decoder layers
+    graph::NNGraph::TensorNode* x =
+        graph::transpose(embed, tensor_name("embed_out"), 2);
+
+    for(auto& layer : layers_)
+    {
+        x = layer->forward(x, sin, cos, mask);
+    }
+
+    return norm_.forward(x);
+}
+
+std::string GptneoxModel::repr() const
+{
+    return "GptneoxModel(hidden=" + std::to_string(config_.hidden_size) +
+           ", layers=" + std::to_string(config_.num_hidden_layers) + ")";
+}
+
+} // namespace nntile::model::gptneox

--- a/src/graph/model/gptneox/gptneox_model.cc
+++ b/src/graph/model/gptneox/gptneox_model.cc
@@ -13,7 +13,7 @@
  * */
 
 #include "nntile/graph/model/gptneox/gptneox_model.hh"
-#include "nntile/graph/nn/transpose.hh"
+#include "nntile/graph/nn/ops/transpose.hh"
 
 #include <stdexcept>
 
@@ -33,6 +33,7 @@ GptneoxModel::GptneoxModel(graph::NNGraph* graph,
     , config_(config)
     , dtype_(dtype)
 {
+    config_.validate();
     register_module("embed_tokens", &embed_tokens_);
     register_module("norm", &norm_);
 
@@ -57,11 +58,9 @@ graph::NNGraph::TensorNode* GptneoxModel::forward(
             "GptneoxModel::forward: input_ids must be non-null");
     }
 
-    // Embedding: (seq, batch) -> (seq, batch, hidden)
     graph::NNGraph::TensorNode* embed = embed_tokens_.forward(input_ids);
-    // Transpose to (hidden, seq, batch) for decoder layers
-    graph::NNGraph::TensorNode* x =
-        graph::transpose(embed, tensor_name("embed_out"), 2);
+    graph::NNGraph::TensorNode* x = graph::transpose(embed, 2);
+    x->set_name(tensor_name("embed_out"));
 
     for(auto& layer : layers_)
     {

--- a/src/graph/model/gptneox/gptneox_rope.cc
+++ b/src/graph/model/gptneox/gptneox_rope.cc
@@ -1,0 +1,107 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file src/graph/model/gptneox/gptneox_rope.cc
+ * RoPE sin/cos from position ids (HF GPTNeoXRotaryEmbedding).
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_rope.hh"
+
+#include <cmath>
+#include <stdexcept>
+#include <vector>
+
+namespace nntile::model::gptneox
+{
+
+Index gptneox_rope_dim(GptneoxConfig const& config)
+{
+    config.validate();
+    double const pct = static_cast<double>(config.rotary_pct);
+    Index dim = static_cast<Index>(
+        std::lround(static_cast<double>(config.head_dim) * pct));
+    if(dim < 2)
+    {
+        dim = 2;
+    }
+    if(dim % 2 != 0)
+    {
+        --dim;
+    }
+    if(dim > config.head_dim)
+    {
+        dim = config.head_dim;
+        if(dim % 2 != 0)
+        {
+            --dim;
+        }
+    }
+    return dim;
+}
+
+void rope_inv_freq_gptneox(GptneoxConfig const& config, float* out)
+{
+    config.validate();
+    const Index rope_dim = gptneox_rope_dim(config);
+    const Index half = rope_dim / 2;
+    if(out == nullptr || half <= 0)
+    {
+        throw std::invalid_argument("rope_inv_freq_gptneox: bad out or rope_dim");
+    }
+    const double base = static_cast<double>(config.rotary_emb_base);
+    const double dim = static_cast<double>(rope_dim);
+    for(Index i = 0; i < half; ++i)
+    {
+        const double idx = static_cast<double>(2 * i);
+        out[i] = static_cast<float>(1.0 / std::pow(base, idx / dim));
+    }
+}
+
+void rope_sin_cos_from_position_ids(
+    GptneoxConfig const& config,
+    std::int64_t const* position_ids,
+    Index n_seq,
+    Index n_batch,
+    float* out_sin,
+    float* out_cos)
+{
+    config.validate();
+    if(position_ids == nullptr || out_sin == nullptr || out_cos == nullptr)
+    {
+        throw std::invalid_argument(
+            "rope_sin_cos_from_position_ids: null pointer");
+    }
+    const Index rope_dim = gptneox_rope_dim(config);
+    const Index half = rope_dim / 2;
+    if(half <= 0)
+    {
+        throw std::invalid_argument(
+            "rope_sin_cos_from_position_ids: invalid rope_dim");
+    }
+    std::vector<float> inv(static_cast<std::size_t>(half));
+    rope_inv_freq_gptneox(config, inv.data());
+    for(Index b = 0; b < n_batch; ++b)
+    {
+        for(Index s = 0; s < n_seq; ++s)
+        {
+            const std::int64_t pos = position_ids[s + n_seq * b];
+            for(Index h = 0; h < half; ++h)
+            {
+                const double angle =
+                    static_cast<double>(pos) * static_cast<double>(inv[h]);
+                const Index idx = h + half * (s + n_seq * b);
+                out_cos[idx] = static_cast<float>(std::cos(angle));
+                out_sin[idx] = static_cast<float>(std::sin(angle));
+            }
+        }
+    }
+}
+
+} // namespace nntile::model::gptneox

--- a/tests/graph/model/CMakeLists.txt
+++ b/tests/graph/model/CMakeLists.txt
@@ -286,3 +286,80 @@ foreach(test_path IN LISTS TESTS_MODEL_GPTNEO)
         endif()
     endif()
 endforeach()
+
+# GPT-NeoX test data: generated at test time via CTest fixtures (one per block)
+set(GPTNEOX_DATA_DIR "${CMAKE_CURRENT_BINARY_DIR}/gptneox_data")
+set(GPTNEOX_GENERATE_SCRIPT
+    "${CMAKE_CURRENT_SOURCE_DIR}/gptneox/generate_test_data.py")
+
+set(TESTS_MODEL_GPTNEOX
+    "gptneox/gptneox_config"
+    "gptneox/gptneox_mlp"
+    "gptneox/gptneox_attention"
+    "gptneox/gptneox_decoder"
+    "gptneox/gptneox_model"
+    "gptneox/gptneox_causal"
+)
+
+foreach(test_path IN LISTS TESTS_MODEL_GPTNEOX)
+    get_filename_component(test_name ${test_path} NAME)
+    string(REPLACE "gptneox_" "" block_name "${test_name}")
+    add_test_set(TARGET_NAME tests_graph_model_${test_name}
+        EXEC_NAME test_${test_name}
+        SOURCES ${test_path}.cc
+        LINK_LIBRARIES nntile Catch2::Catch2WithMain
+        COV_ENABLE ${BUILD_COVERAGE}
+        COV_NAME coverage_graph_model_${test_name}
+        COV_GLOBAL coverage_graph_model coverage
+    )
+    target_include_directories(tests_graph_model_${test_name} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${CMAKE_CURRENT_SOURCE_DIR}/../..
+        ${CMAKE_CURRENT_SOURCE_DIR}/../nn
+    )
+    set_target_properties(tests_graph_model_${test_name} PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gptneox)
+    if(NOT test_name STREQUAL "gptneox_config")
+        target_compile_definitions(tests_graph_model_${test_name} PRIVATE
+            GPTNEOX_DATA_DIR="${GPTNEOX_DATA_DIR}"
+        )
+        if(Python3_Interpreter_FOUND)
+            add_test(NAME tests_graph_model_${test_name}_data_setup
+                COMMAND "${GRAPH_MODEL_DATA_PYTHON}" "${GPTNEOX_GENERATE_SCRIPT}"
+                    --block "${block_name}" --output "${GPTNEOX_DATA_DIR}"
+                    --seed 42
+                WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+            )
+            set_tests_properties(tests_graph_model_${test_name}_data_setup
+                PROPERTIES
+                    FIXTURES_SETUP "tests_graph_model_${test_name}_data"
+                    ENVIRONMENT
+                        "PYTHONPATH=${CMAKE_BINARY_DIR}/wrappers/python:$ENV{PYTHONPATH}"
+            )
+            set(required_fixtures "tests_graph_model_${test_name}_data")
+
+            if(test_name STREQUAL "gptneox_attention")
+                add_test(NAME tests_graph_model_gptneox_attention_causal_data_setup
+                    COMMAND "${GRAPH_MODEL_DATA_PYTHON}" "${GPTNEOX_GENERATE_SCRIPT}"
+                        --block attention_causal
+                        --output "${GPTNEOX_DATA_DIR}" --seed 42
+                    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                )
+                set_tests_properties(
+                    tests_graph_model_gptneox_attention_causal_data_setup
+                    PROPERTIES
+                        FIXTURES_SETUP
+                            "tests_graph_model_gptneox_attention_causal_data"
+                        ENVIRONMENT
+                            "PYTHONPATH=${CMAKE_BINARY_DIR}/wrappers/python:$ENV{PYTHONPATH}"
+                )
+                list(APPEND required_fixtures
+                    "tests_graph_model_gptneox_attention_causal_data")
+            endif()
+            set_tests_properties(tests_graph_model_${test_name} PROPERTIES
+                FIXTURES_REQUIRED "${required_fixtures}"
+            )
+        endif()
+    endif()
+endforeach()

--- a/tests/graph/model/gptneox/generate_test_data.py
+++ b/tests/graph/model/gptneox/generate_test_data.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+# @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#                2023-present Artificial Intelligence Research Institute
+#                              (AIRI), Russia. All rights reserved.
+#
+# @file tests/graph/model/gptneox/generate_test_data.py
+# Generate GPT-NeoX building-block test data in safetensors format.
+#
+# @version 1.1.0
+
+"""Generate reference test data for NNTile GPT-NeoX graph C++ tests.
+
+For each block the script creates ``gptneox_<block>.safetensors`` plus a paired
+``.json`` sidecar (geometry, tolerances) read by the corresponding C++ tests.
+
+Uses HuggingFace ``modeling_gpt_neox`` with NNTile layout per
+``examples/gpt_neox_generate.py``. Reference forwards use HF LayerNorm
+(gamma/beta), GELU for MLP, merged QKV split into Q/K/V, and bias-free linear
+ops to match the graph modules. Decoder forward matches C++ ``GptneoxDecoder``
+parallel residual (``post_attention_layernorm`` on the residual stream ``x``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from safetensors.numpy import save_file
+from transformers import GPTNeoXConfig
+from transformers.models.gpt_neox.modeling_gpt_neox import (
+    GPTNeoXAttention as PtAttention,
+    GPTNeoXForCausalLM as PtCausalLM,
+    GPTNeoXLayer as PtLayer,
+    GPTNeoXModel as PtModel,
+    GPTNeoXMLP as PtMLP,
+    GPTNeoXRotaryEmbedding,
+    apply_rotary_pos_emb,
+)
+
+# ── Test dimension bundles ────────────────────────────────────────────────
+
+
+@dataclass
+class TestDims:
+    hidden: int
+    intermediate: int
+    n_heads: int
+    seq: int
+    batch: int
+    vocab: int
+    num_layers: int
+    layer_norm_eps: float = 1e-5
+    rotary_pct: float = 1.0
+    rotary_emb_base: float = 10000.0
+
+    @property
+    def head_size(self) -> int:
+        return self.hidden // self.n_heads
+
+
+MLP_DIMS = TestDims(
+    hidden=8, intermediate=16, n_heads=4,
+    seq=4, batch=2, vocab=100, num_layers=1,
+)
+
+ATTENTION_DIMS = TestDims(
+    hidden=64, intermediate=256, n_heads=4,
+    seq=8, batch=2, vocab=100, num_layers=1,
+)
+
+DECODER_DIMS = ATTENTION_DIMS
+MODEL_DIMS = ATTENTION_DIMS
+CAUSAL_DIMS = ATTENTION_DIMS
+
+
+def fortran_order(arr: np.ndarray) -> np.ndarray:
+    a = np.asarray(arr, dtype=np.float32)
+    return a.ravel("F").reshape(a.shape)
+
+
+def fortran_order_int64(arr: np.ndarray) -> np.ndarray:
+    a = np.asarray(arr, dtype=np.int64)
+    return a.ravel("F").reshape(a.shape)
+
+
+def _make_config(dims: TestDims) -> GPTNeoXConfig:
+    return GPTNeoXConfig(
+        vocab_size=dims.vocab,
+        hidden_size=dims.hidden,
+        num_hidden_layers=dims.num_layers,
+        num_attention_heads=dims.n_heads,
+        intermediate_size=dims.intermediate,
+        max_position_embeddings=max(dims.seq * 2, 128),
+        layer_norm_epsilon=dims.layer_norm_eps,
+        rotary_pct=dims.rotary_pct,
+        rotary_emb_base=dims.rotary_emb_base,
+        use_parallel_residual=True,
+        attention_bias=False,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        _attn_implementation="eager",
+    )
+
+
+def _layer_norm(ln, prefix: str) -> dict[str, np.ndarray]:
+    return {
+        f"{prefix}.gamma": fortran_order(ln.weight.detach().numpy()),
+        f"{prefix}.beta": fortran_order(ln.bias.detach().numpy()),
+    }
+
+
+def _gptneox_attn_weights(
+    attn: PtAttention, prefix: str, dims: TestDims,
+) -> dict[str, np.ndarray]:
+    """Map HF ``query_key_value`` + ``dense`` to NNTile layouts."""
+    H = dims.hidden
+    nh = dims.n_heads
+    hd = dims.head_size
+    qkv_w = attn.query_key_value.weight.detach().numpy()
+    qkv = qkv_w.reshape(nh, 3 * hd, H)
+    q = qkv[:, :hd, :]
+    k = qkv[:, hd : 2 * hd, :]
+    v = qkv[:, 2 * hd : 3 * hd, :]
+    o = attn.dense.weight.detach().numpy().reshape(H, nh, hd)
+    return {
+        f"{prefix}.q_weight": fortran_order(q),
+        f"{prefix}.k_weight": fortran_order(k),
+        f"{prefix}.v_weight": fortran_order(v),
+        f"{prefix}.o_weight": fortran_order(o),
+    }
+
+
+def _gptneox_mlp_weights(mlp: PtMLP, prefix: str) -> dict[str, np.ndarray]:
+    return {
+        f"{prefix}.fc1.weight": fortran_order(
+            mlp.dense_h_to_4h.weight.detach().numpy().T),
+        f"{prefix}.fc2.weight": fortran_order(
+            mlp.dense_4h_to_h.weight.detach().numpy().T),
+    }
+
+
+def _gptneox_decoder_weights(
+    layer: PtLayer, prefix: str, dims: TestDims,
+) -> dict[str, np.ndarray]:
+    d: dict[str, np.ndarray] = {}
+    d.update(_layer_norm(layer.input_layernorm, f"{prefix}.input_norm"))
+    d.update(_gptneox_attn_weights(layer.attention, f"{prefix}.attention", dims))
+    d.update(_layer_norm(
+        layer.post_attention_layernorm, f"{prefix}.post_attn_norm"))
+    d.update(_gptneox_mlp_weights(layer.mlp, f"{prefix}.mlp"))
+    return d
+
+
+def _embed(embed, prefix: str) -> dict[str, np.ndarray]:
+    return {f"{prefix}.vocab": fortran_order(embed.weight.detach().numpy().T)}
+
+
+def _model_weights(model: PtModel, prefix: str, dims: TestDims) -> dict[str, np.ndarray]:
+    d: dict[str, np.ndarray] = {}
+    d.update(_embed(model.embed_in, f"{prefix}.embed_tokens"))
+    d.update(_layer_norm(model.final_layer_norm, f"{prefix}.norm"))
+    for i, layer in enumerate(model.layers):
+        d.update(_gptneox_decoder_weights(layer, f"{prefix}.layers_{i}", dims))
+    return d
+
+
+def _lm_head_to_linear_weight(lm) -> np.ndarray:
+    return fortran_order(lm.weight.detach().numpy().T)
+
+
+def _hidden_input(rng, dims: TestDims, scale: float = 0.1):
+    x = rng.standard_normal(
+        (dims.hidden, dims.seq, dims.batch),
+    ).astype(np.float32) * scale
+    x_nt = fortran_order(x)
+    x_pt = torch.tensor(x.transpose(2, 1, 0).copy(), requires_grad=True)
+    return x_nt, x_pt
+
+
+def _grad_output(rng, pt_out: torch.Tensor, scale: float = 0.1):
+    g = rng.standard_normal(pt_out.shape).astype(np.float32) * scale
+    g_pt = torch.tensor(g)
+    g_nt = fortran_order(g.transpose(2, 1, 0))
+    return g_nt, g_pt
+
+
+def _ids_input(rng, dims: TestDims):
+    ids = rng.integers(
+        0, dims.vocab, size=(dims.seq, dims.batch),
+    ).astype(np.int64)
+    ids_nt = ids.ravel("F").reshape(ids.shape)
+    ids_pt = torch.tensor(ids.T.copy(), dtype=torch.long)
+    return ids_nt, ids_pt
+
+
+def _position_ids(dims: TestDims) -> np.ndarray:
+    pos = np.arange(dims.seq, dtype=np.int64)[:, None]
+    pos = np.broadcast_to(pos, (dims.seq, dims.batch)).copy()
+    return fortran_order_int64(pos)
+
+
+def _position_ids_pt(dims: TestDims, device: torch.device) -> torch.Tensor:
+    return torch.arange(
+        dims.seq, device=device, dtype=torch.long,
+    ).unsqueeze(0).expand(dims.batch, dims.seq)
+
+
+def _out_to_nntile(pt_out: torch.Tensor) -> np.ndarray:
+    return fortran_order(pt_out.detach().numpy().transpose(2, 1, 0))
+
+
+def _sdpa_causal_mask_fortran(seq: int) -> np.ndarray:
+    kk = np.arange(seq, dtype=np.int64)[:, None]
+    qq = np.arange(seq, dtype=np.int64)[None, :]
+    allowed = (kk <= qq).astype(np.float32)
+    return fortran_order(allowed)
+
+
+def _causal_additive_mask_torch(
+    batch: int, seq: int, device: torch.device,
+) -> torch.Tensor:
+    mask = np.array(np.triu(np.ones((seq, seq))), dtype=bool, order="F")
+    mask_torch = torch.tensor(
+        np.array(1 - mask, dtype=np.float32),
+    ).T * torch.finfo(torch.float32).min
+    mask_torch = mask_torch.to(device=device, dtype=torch.float32)
+    return mask_torch[None, None, :, :].expand(batch, 1, -1, -1)
+
+
+def _rope_half_from_hf(
+    cos: torch.Tensor, sin: torch.Tensor, dims: TestDims,
+) -> tuple[np.ndarray, np.ndarray]:
+    """HF ``(B,S,D)`` cos/sin → NNTile-graph ``(half,S,B)`` float32."""
+    half = dims.head_size // 2
+    cos_half = cos[:, :, :half].to(torch.float32).detach().cpu().numpy()
+    sin_half = sin[:, :, :half].to(torch.float32).detach().cpu().numpy()
+    cos_np = np.transpose(cos_half, (2, 1, 0))
+    sin_np = np.transpose(sin_half, (2, 1, 0))
+    return cos_np, sin_np
+
+
+def _rope_from_rotary(
+    rotary: GPTNeoXRotaryEmbedding,
+    attn: PtAttention,
+    pos_ids_pt: torch.Tensor,
+    x_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    H = attn.query_key_value.weight.shape[1]
+    v_slice = attn.query_key_value.weight[H * 2 : H * 3, :]
+    cos, sin = rotary(v_slice, pos_ids_pt)
+    return cos.to(dtype=x_dtype), sin.to(dtype=x_dtype)
+
+
+def _gptneox_mlp_forward(mlp: PtMLP, x_pt: torch.Tensor) -> torch.Tensor:
+    """Bias-free MLP forward (matches graph ``GptneoxMlp``)."""
+    h = F.linear(x_pt, mlp.dense_h_to_4h.weight, None)
+    h = mlp.act(h)
+    return F.linear(h, mlp.dense_4h_to_h.weight, None)
+
+
+def _gptneox_attn_forward(
+    attn: PtAttention,
+    x_pt: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    *,
+    attn_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Q/K/V + RoPE + SDPA + dense, bias-free (matches graph GptneoxAttention)."""
+    n_emb = x_pt.shape[-1]
+    n_head = attn.config.num_attention_heads
+    head_dim = attn.head_size
+    qkv = F.linear(x_pt, attn.query_key_value.weight, None)
+    shape = (*x_pt.shape[:2], n_head, 3 * head_dim)
+    qkv = qkv.view(*shape).transpose(1, 2)
+    q, k, v = qkv.chunk(3, dim=-1)
+    q, k = apply_rotary_pos_emb(q, k, cos, sin)
+    ctx = F.scaled_dot_product_attention(
+        q, k, v,
+        attn_mask=attn_mask,
+        is_causal=False,
+    )
+    ctx = ctx.transpose(1, 2).contiguous().view(*x_pt.shape)
+    return F.linear(ctx, attn.dense.weight, None)
+
+
+def _gptneox_decoder_forward(
+    layer: PtLayer,
+    x_pt: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    *,
+    attn_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Matches C++ ``GptneoxDecoder`` with ``use_parallel_residual=True``."""
+    residual = x_pt
+    x_norm = layer.input_layernorm(x_pt)
+    attn_out = _gptneox_attn_forward(
+        layer.attention, x_norm, cos, sin, attn_mask=attn_mask,
+    )
+    post_attn = residual + attn_out
+    mlp_in = layer.post_attention_layernorm(residual)
+    mlp_out = _gptneox_mlp_forward(layer.mlp, mlp_in)
+    return post_attn + mlp_out
+
+
+def _gptneox_model_forward(
+    model: PtModel,
+    ids_pt: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    *,
+    attn_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    x = model.embed_in(ids_pt)
+    for layer in model.layers:
+        x = _gptneox_decoder_forward(layer, x, cos, sin, attn_mask=attn_mask)
+    return model.final_layer_norm(x)
+
+
+def _gptneox_fixture_json(
+    stem: str,
+    dims: TestDims,
+    forward_tol: float,
+    backward_tol: float,
+) -> dict:
+    return {
+        "version": 2,
+        "stem": stem,
+        "safetensors": f"{stem}.safetensors",
+        "sequence_length": dims.seq,
+        "batch": dims.batch,
+        "gptneox": {
+            "vocab_size": dims.vocab,
+            "hidden_size": dims.hidden,
+            "intermediate_size": dims.intermediate,
+            "num_hidden_layers": dims.num_layers,
+            "num_attention_heads": dims.n_heads,
+            "head_dim": dims.head_size,
+            "max_position_embeddings": max(dims.seq * 2, 128),
+            "layer_norm_eps": dims.layer_norm_eps,
+            "rotary_pct": dims.rotary_pct,
+            "rotary_emb_base": dims.rotary_emb_base,
+            "use_parallel_residual": True,
+            "attention_bias": False,
+        },
+        "tolerances": {
+            "forward": forward_tol,
+            "backward": backward_tol,
+        },
+    }
+
+
+def write_fixture_json(
+    out: Path, stem: str, dims: TestDims, forward_tol: float, backward_tol: float,
+) -> None:
+    path = out / f"{stem}.json"
+    path.write_text(
+        json.dumps(
+            _gptneox_fixture_json(stem, dims, forward_tol, backward_tol),
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    print(f"Saved {path}")
+
+
+def _write_rope_and_position(
+    data: dict[str, np.ndarray],
+    rotary: GPTNeoXRotaryEmbedding,
+    attn: PtAttention,
+    pos_ids_pt: torch.Tensor,
+    dims: TestDims,
+    x_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cos, sin = _rope_from_rotary(rotary, attn, pos_ids_pt, x_dtype)
+    cos_np, sin_np = _rope_half_from_hf(cos, sin, dims)
+    data["rope_cos"] = fortran_order(cos_np)
+    data["rope_sin"] = fortran_order(sin_np)
+    pos_nntile = pos_ids_pt.detach().cpu().numpy().T.astype(np.int64)
+    data["position_ids"] = fortran_order_int64(pos_nntile)
+    return cos, sin
+
+
+def generate_mlp(seed: int, dims: TestDims = MLP_DIMS) -> dict[str, np.ndarray]:
+    torch.manual_seed(seed)
+    rng = np.random.default_rng(seed)
+    config = _make_config(dims)
+    pt = PtMLP(config)
+    pt.eval()
+    data = _gptneox_mlp_weights(pt, "mlp")
+    x_nt, x_pt = _hidden_input(rng, dims)
+    data["input"] = x_nt
+    out = _gptneox_mlp_forward(pt, x_pt)
+    data["output_ref"] = _out_to_nntile(out)
+    g_nt, g_pt = _grad_output(rng, out)
+    data["grad_output"] = g_nt
+    out.backward(g_pt)
+    data["grad_input"] = _out_to_nntile(x_pt.grad)
+    return data
+
+
+def generate_attention(
+    seed: int,
+    dims: TestDims = ATTENTION_DIMS,
+    *,
+    use_causal_mask: bool = False,
+) -> dict[str, np.ndarray]:
+    torch.manual_seed(seed)
+    rng = np.random.default_rng(seed)
+    config = _make_config(dims)
+    pt = PtAttention(config, layer_idx=0)
+    pt.eval()
+    rotary = GPTNeoXRotaryEmbedding(config, device=torch.device("cpu"))
+    data = _gptneox_attn_weights(pt, "attn", dims)
+    x_nt, x_pt = _hidden_input(rng, dims)
+    data["input"] = x_nt
+    pos_ids_pt = _position_ids_pt(dims, x_pt.device)
+    cos, sin = _write_rope_and_position(
+        data, rotary, pt, pos_ids_pt, dims, x_pt.dtype,
+    )
+    attn_mask = None
+    if use_causal_mask:
+        attn_mask = _causal_additive_mask_torch(
+            dims.batch, dims.seq, x_pt.device,
+        )
+        data["attn_mask"] = _sdpa_causal_mask_fortran(dims.seq)
+    out = _gptneox_attn_forward(pt, x_pt, cos, sin, attn_mask=attn_mask)
+    data["output_ref"] = _out_to_nntile(out)
+    g_nt, g_pt = _grad_output(rng, out)
+    data["grad_output"] = g_nt
+    out.backward(g_pt)
+    data["grad_input"] = _out_to_nntile(x_pt.grad)
+    return data
+
+
+def generate_decoder(
+    seed: int, dims: TestDims = DECODER_DIMS, *, use_causal_mask: bool = True,
+) -> dict[str, np.ndarray]:
+    torch.manual_seed(seed)
+    rng = np.random.default_rng(seed)
+    config = _make_config(dims)
+    pt = PtLayer(config, layer_idx=0)
+    pt.eval()
+    rotary = GPTNeoXRotaryEmbedding(config, device=torch.device("cpu"))
+    data = _gptneox_decoder_weights(pt, "decoder", dims)
+    x_nt, x_pt = _hidden_input(rng, dims)
+    data["input"] = x_nt
+    pos_ids_pt = _position_ids_pt(dims, x_pt.device)
+    cos, sin = _write_rope_and_position(
+        data, rotary, pt.attention, pos_ids_pt, dims, x_pt.dtype,
+    )
+    attn_mask = _causal_additive_mask_torch(
+        dims.batch, dims.seq, x_pt.device,
+    )
+    data["attn_mask"] = _sdpa_causal_mask_fortran(dims.seq)
+    out = _gptneox_decoder_forward(
+        pt, x_pt, cos, sin, attn_mask=attn_mask,
+    )
+    data["output_ref"] = _out_to_nntile(out)
+    g_nt, g_pt = _grad_output(rng, out)
+    data["grad_output"] = g_nt
+    out.backward(g_pt)
+    data["grad_input"] = _out_to_nntile(x_pt.grad)
+    return data
+
+
+def generate_model(seed: int, dims: TestDims = MODEL_DIMS) -> dict[str, np.ndarray]:
+    torch.manual_seed(seed)
+    rng = np.random.default_rng(seed)
+    config = _make_config(dims)
+    pt = PtModel(config)
+    pt.eval()
+    rotary = pt.rotary_emb
+    data = _model_weights(pt, "model", dims)
+    ids_nt, ids_pt = _ids_input(rng, dims)
+    data["input_ids"] = ids_nt
+    data["position_ids"] = _position_ids(dims)
+    data["attn_mask"] = _sdpa_causal_mask_fortran(dims.seq)
+    pos_ids_pt = _position_ids_pt(dims, ids_pt.device)
+    embeds = pt.embed_in(ids_pt)
+    cos, sin = rotary(embeds, pos_ids_pt)
+    cos_np, sin_np = _rope_half_from_hf(cos, sin, dims)
+    data["rope_cos"] = fortran_order(cos_np)
+    data["rope_sin"] = fortran_order(sin_np)
+    attn_mask = _causal_additive_mask_torch(
+        dims.batch, dims.seq, ids_pt.device,
+    )
+    out = _gptneox_model_forward(
+        pt, ids_pt, cos, sin, attn_mask=attn_mask,
+    )
+    data["output_ref"] = _out_to_nntile(out)
+    g_nt, g_pt = _grad_output(rng, out)
+    data["grad_output"] = g_nt
+    out.backward(g_pt)
+    data["grad_embed_tokens_vocab"] = fortran_order(
+        pt.embed_in.weight.grad.detach().numpy().T)
+    return data
+
+
+def generate_causal(seed: int, dims: TestDims = CAUSAL_DIMS) -> dict[str, np.ndarray]:
+    torch.manual_seed(seed)
+    rng = np.random.default_rng(seed)
+    config = _make_config(dims)
+    pt = PtCausalLM(config)
+    pt.eval()
+    rotary = pt.gpt_neox.rotary_emb
+    data = _model_weights(pt.gpt_neox, "model.model", dims)
+    data["model.lm_head.weight"] = _lm_head_to_linear_weight(pt.embed_out)
+    ids_nt, ids_pt = _ids_input(rng, dims)
+    data["input_ids"] = ids_nt
+    data["position_ids"] = _position_ids(dims)
+    data["attn_mask"] = _sdpa_causal_mask_fortran(dims.seq)
+    pos_ids_pt = _position_ids_pt(dims, ids_pt.device)
+    embeds = pt.gpt_neox.embed_in(ids_pt)
+    cos, sin = rotary(embeds, pos_ids_pt)
+    cos_np, sin_np = _rope_half_from_hf(cos, sin, dims)
+    data["rope_cos"] = fortran_order(cos_np)
+    data["rope_sin"] = fortran_order(sin_np)
+    attn_mask = _causal_additive_mask_torch(
+        dims.batch, dims.seq, ids_pt.device,
+    )
+    hidden = _gptneox_model_forward(
+        pt.gpt_neox, ids_pt, cos, sin, attn_mask=attn_mask,
+    )
+    logits = F.linear(hidden, pt.embed_out.weight, None)
+    data["output_ref"] = _out_to_nntile(logits)
+    g_nt, g_pt = _grad_output(rng, logits)
+    logits.backward(g_pt)
+    data["grad_output"] = g_nt
+    data["grad_embed_tokens_vocab"] = fortran_order(
+        pt.gpt_neox.embed_in.weight.grad.detach().numpy().T)
+    return data
+
+
+GENERATORS = {
+    "mlp": generate_mlp,
+    "attention": lambda seed: generate_attention(seed, use_causal_mask=False),
+    "attention_causal": lambda seed: generate_attention(
+        seed, use_causal_mask=True,
+    ),
+    "decoder": generate_decoder,
+    "model": generate_model,
+    "causal": generate_causal,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate GPT-NeoX block test data (safetensors)",
+    )
+    parser.add_argument(
+        "--block",
+        choices=GENERATORS,
+        required=True,
+        help="GPT-NeoX block to generate data for",
+    )
+    parser.add_argument(
+        "--output", "-o", required=True, help="Output directory",
+    )
+    parser.add_argument(
+        "--seed", "-s", type=int, default=42, help="Random seed",
+    )
+    args = parser.parse_args()
+
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+
+    data = GENERATORS[args.block](args.seed)
+    stem = f"gptneox_{args.block}"
+    bundle_path = str(out / f"{stem}.safetensors")
+    save_file(data, bundle_path)
+    print(f"Saved {bundle_path}")
+
+    if args.block == "mlp":
+        write_fixture_json(out, stem, MLP_DIMS, 2e-5, 2e-5)
+    elif args.block in ("attention", "attention_causal"):
+        # SDPA/RoPE vs PyTorch eager can differ slightly at tight tol.
+        write_fixture_json(out, stem, ATTENTION_DIMS, 5e-3, 5e-3)
+    elif args.block == "decoder":
+        # Full decoder (LN + attn + MLP + parallel residual) vs eager PyTorch.
+        write_fixture_json(out, stem, DECODER_DIMS, 2e-1, 2e-1)
+    elif args.block in ("model", "causal"):
+        write_fixture_json(out, stem, MODEL_DIMS, 2e-1, 2e-1)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/graph/model/gptneox/generate_test_data.py
+++ b/tests/graph/model/gptneox/generate_test_data.py
@@ -40,8 +40,6 @@ from transformers.models.gpt_neox.modeling_gpt_neox import (
     GPTNeoXLayer as PtLayer,
     GPTNeoXModel as PtModel,
     GPTNeoXMLP as PtMLP,
-    GPTNeoXRotaryEmbedding,
-    apply_rotary_pos_emb,
 )
 
 # ── Test dimension bundles ────────────────────────────────────────────────
@@ -141,8 +139,12 @@ def _gptneox_mlp_weights(mlp: PtMLP, prefix: str) -> dict[str, np.ndarray]:
     return {
         f"{prefix}.fc1.weight": fortran_order(
             mlp.dense_h_to_4h.weight.detach().numpy().T),
+        f"{prefix}.fc1.bias": fortran_order(
+            mlp.dense_h_to_4h.bias.detach().numpy()),
         f"{prefix}.fc2.weight": fortran_order(
             mlp.dense_4h_to_h.weight.detach().numpy().T),
+        f"{prefix}.fc2.bias": fortran_order(
+            mlp.dense_4h_to_h.bias.detach().numpy()),
     }
 
 
@@ -234,54 +236,123 @@ def _causal_additive_mask_torch(
     return mask_torch[None, None, :, :].expand(batch, 1, -1, -1)
 
 
-def _rope_half_from_hf(
-    cos: torch.Tensor, sin: torch.Tensor, dims: TestDims,
+def _gptneox_rope_dim(dims: TestDims) -> int:
+    """Match C++ ``gptneox_rope_dim`` (even, from ``rotary_pct``)."""
+    pct = dims.rotary_pct
+    dim = int(round(dims.head_size * pct))
+    if dim < 2:
+        dim = 2
+    if dim % 2 != 0:
+        dim -= 1
+    if dim > dims.head_size:
+        dim = dims.head_size
+        if dim % 2 != 0:
+            dim -= 1
+    return dim
+
+
+def _rope_sin_cos_nntile_arrays(
+    dims: TestDims,
+    position_ids: np.ndarray,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """HF ``(B,S,D)`` cos/sin → NNTile-graph ``(half,S,B)`` float32."""
-    half = dims.head_size // 2
-    cos_half = cos[:, :, :half].to(torch.float32).detach().cpu().numpy()
-    sin_half = sin[:, :, :half].to(torch.float32).detach().cpu().numpy()
-    cos_np = np.transpose(cos_half, (2, 1, 0))
-    sin_np = np.transpose(sin_half, (2, 1, 0))
-    return cos_np, sin_np
+    """``(half, seq, batch)`` sin/cos like C++ ``rope_sin_cos_from_position_ids``.
+
+    ``position_ids`` is NNTile layout ``(seq, batch)`` (Fortran).
+    """
+    n_seq, n_batch = dims.seq, dims.batch
+    rope_dim = _gptneox_rope_dim(dims)
+    half = rope_dim // 2
+    inv = np.array(
+        [
+            1.0
+            / (dims.rotary_emb_base ** (2.0 * i / float(rope_dim)))
+            for i in range(half)
+        ],
+        dtype=np.float64,
+    )
+    cos = np.zeros((half, n_seq, n_batch), dtype=np.float32)
+    sin = np.zeros((half, n_seq, n_batch), dtype=np.float32)
+    for b in range(n_batch):
+        for s in range(n_seq):
+            pos = float(position_ids[s, b])
+            angles = pos * inv
+            cos[:, s, b] = np.cos(angles).astype(np.float32)
+            sin[:, s, b] = np.sin(angles).astype(np.float32)
+    return fortran_order(cos), fortran_order(sin)
 
 
-def _rope_from_rotary(
-    rotary: GPTNeoXRotaryEmbedding,
-    attn: PtAttention,
-    pos_ids_pt: torch.Tensor,
-    x_dtype: torch.dtype,
+def _apply_rope_nntile(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos_half: np.ndarray,
+    sin_half: np.ndarray,
+    rope_dim: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    H = attn.query_key_value.weight.shape[1]
-    v_slice = attn.query_key_value.weight[H * 2 : H * 3, :]
-    cos, sin = rotary(v_slice, pos_ids_pt)
-    return cos.to(dtype=x_dtype), sin.to(dtype=x_dtype)
+    """Pairwise RoPE matching NNTile ``kernel::rope`` (not HF ``rotate_half``)."""
+    half = rope_dim // 2
+    n_seq, n_batch = q.shape[2], q.shape[0]
+    cos_sb = np.array(cos_half, dtype=np.float32, order="F").reshape(
+        half, n_seq, n_batch, order="F",
+    )
+    sin_sb = np.array(sin_half, dtype=np.float32, order="F").reshape(
+        half, n_seq, n_batch, order="F",
+    )
+    c = torch.tensor(
+        np.transpose(cos_sb, (2, 1, 0)),
+        device=q.device,
+        dtype=q.dtype,
+    ).unsqueeze(1)
+    s = torch.tensor(
+        np.transpose(sin_sb, (2, 1, 0)),
+        device=q.device,
+        dtype=q.dtype,
+    ).unsqueeze(1)
+    q_rot, q_pass = q[..., :rope_dim], q[..., rope_dim:]
+    k_rot, k_pass = k[..., :rope_dim], k[..., rope_dim:]
+    q1, q2 = q_rot[..., 0::2], q_rot[..., 1::2]
+    k1, k2 = k_rot[..., 0::2], k_rot[..., 1::2]
+    qo = torch.empty_like(q_rot)
+    ko = torch.empty_like(k_rot)
+    qo[..., 0::2] = c * q1 - s * q2
+    qo[..., 1::2] = s * q1 + c * q2
+    ko[..., 0::2] = c * k1 - s * k2
+    ko[..., 1::2] = s * k1 + c * k2
+    q_out = q.clone()
+    k_out = k.clone()
+    q_out[..., :rope_dim] = qo
+    k_out[..., :rope_dim] = ko
+    if q_pass.shape[-1] > 0:
+        q_out[..., rope_dim:] = q_pass
+        k_out[..., rope_dim:] = k_pass
+    return q_out, k_out
 
 
 def _gptneox_mlp_forward(mlp: PtMLP, x_pt: torch.Tensor) -> torch.Tensor:
-    """Bias-free MLP forward (matches graph ``GptneoxMlp``)."""
-    h = F.linear(x_pt, mlp.dense_h_to_4h.weight, None)
+    """HF ``GPTNeoXMLP`` forward (matches graph ``GptneoxMlp`` with biases)."""
+    h = mlp.dense_h_to_4h(x_pt)
     h = mlp.act(h)
-    return F.linear(h, mlp.dense_4h_to_h.weight, None)
+    return mlp.dense_4h_to_h(h)
 
 
 def _gptneox_attn_forward(
     attn: PtAttention,
     x_pt: torch.Tensor,
-    cos: torch.Tensor,
-    sin: torch.Tensor,
+    cos_half: np.ndarray,
+    sin_half: np.ndarray,
+    dims: TestDims,
     *,
     attn_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Q/K/V + RoPE + SDPA + dense, bias-free (matches graph GptneoxAttention)."""
+    """Q/K/V + NNTile RoPE + SDPA + dense (matches graph ``GptneoxAttention``)."""
     n_emb = x_pt.shape[-1]
     n_head = attn.config.num_attention_heads
     head_dim = attn.head_size
+    rope_dim = _gptneox_rope_dim(dims)
     qkv = F.linear(x_pt, attn.query_key_value.weight, None)
     shape = (*x_pt.shape[:2], n_head, 3 * head_dim)
     qkv = qkv.view(*shape).transpose(1, 2)
     q, k, v = qkv.chunk(3, dim=-1)
-    q, k = apply_rotary_pos_emb(q, k, cos, sin)
+    q, k = _apply_rope_nntile(q, k, cos_half, sin_half, rope_dim)
     ctx = F.scaled_dot_product_attention(
         q, k, v,
         attn_mask=attn_mask,
@@ -294,19 +365,28 @@ def _gptneox_attn_forward(
 def _gptneox_decoder_forward(
     layer: PtLayer,
     x_pt: torch.Tensor,
-    cos: torch.Tensor,
-    sin: torch.Tensor,
+    cos_half: np.ndarray,
+    sin_half: np.ndarray,
+    dims: TestDims,
     *,
     attn_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Matches C++ ``GptneoxDecoder`` with ``use_parallel_residual=True``."""
+    """Matches C++ ``GptneoxDecoder`` (parallel or sequential residual)."""
     residual = x_pt
     x_norm = layer.input_layernorm(x_pt)
     attn_out = _gptneox_attn_forward(
-        layer.attention, x_norm, cos, sin, attn_mask=attn_mask,
+        layer.attention,
+        x_norm,
+        cos_half,
+        sin_half,
+        dims,
+        attn_mask=attn_mask,
     )
     post_attn = residual + attn_out
-    mlp_in = layer.post_attention_layernorm(residual)
+    if layer.use_parallel_residual:
+        mlp_in = layer.post_attention_layernorm(residual)
+    else:
+        mlp_in = layer.post_attention_layernorm(post_attn)
     mlp_out = _gptneox_mlp_forward(layer.mlp, mlp_in)
     return post_attn + mlp_out
 
@@ -314,14 +394,17 @@ def _gptneox_decoder_forward(
 def _gptneox_model_forward(
     model: PtModel,
     ids_pt: torch.Tensor,
-    cos: torch.Tensor,
-    sin: torch.Tensor,
+    cos_half: np.ndarray,
+    sin_half: np.ndarray,
+    dims: TestDims,
     *,
     attn_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     x = model.embed_in(ids_pt)
     for layer in model.layers:
-        x = _gptneox_decoder_forward(layer, x, cos, sin, attn_mask=attn_mask)
+        x = _gptneox_decoder_forward(
+            layer, x, cos_half, sin_half, dims, attn_mask=attn_mask,
+        )
     return model.final_layer_norm(x)
 
 
@@ -374,19 +457,15 @@ def write_fixture_json(
 
 def _write_rope_and_position(
     data: dict[str, np.ndarray],
-    rotary: GPTNeoXRotaryEmbedding,
-    attn: PtAttention,
     pos_ids_pt: torch.Tensor,
     dims: TestDims,
-    x_dtype: torch.dtype,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    cos, sin = _rope_from_rotary(rotary, attn, pos_ids_pt, x_dtype)
-    cos_np, sin_np = _rope_half_from_hf(cos, sin, dims)
-    data["rope_cos"] = fortran_order(cos_np)
-    data["rope_sin"] = fortran_order(sin_np)
+) -> tuple[np.ndarray, np.ndarray]:
     pos_nntile = pos_ids_pt.detach().cpu().numpy().T.astype(np.int64)
     data["position_ids"] = fortran_order_int64(pos_nntile)
-    return cos, sin
+    cos_np, sin_np = _rope_sin_cos_nntile_arrays(dims, pos_nntile)
+    data["rope_cos"] = cos_np
+    data["rope_sin"] = sin_np
+    return cos_np, sin_np
 
 
 def generate_mlp(seed: int, dims: TestDims = MLP_DIMS) -> dict[str, np.ndarray]:
@@ -418,21 +497,20 @@ def generate_attention(
     config = _make_config(dims)
     pt = PtAttention(config, layer_idx=0)
     pt.eval()
-    rotary = GPTNeoXRotaryEmbedding(config, device=torch.device("cpu"))
     data = _gptneox_attn_weights(pt, "attn", dims)
     x_nt, x_pt = _hidden_input(rng, dims)
     data["input"] = x_nt
     pos_ids_pt = _position_ids_pt(dims, x_pt.device)
-    cos, sin = _write_rope_and_position(
-        data, rotary, pt, pos_ids_pt, dims, x_pt.dtype,
-    )
+    cos_np, sin_np = _write_rope_and_position(data, pos_ids_pt, dims)
     attn_mask = None
     if use_causal_mask:
         attn_mask = _causal_additive_mask_torch(
             dims.batch, dims.seq, x_pt.device,
         )
         data["attn_mask"] = _sdpa_causal_mask_fortran(dims.seq)
-    out = _gptneox_attn_forward(pt, x_pt, cos, sin, attn_mask=attn_mask)
+    out = _gptneox_attn_forward(
+        pt, x_pt, cos_np, sin_np, dims, attn_mask=attn_mask,
+    )
     data["output_ref"] = _out_to_nntile(out)
     g_nt, g_pt = _grad_output(rng, out)
     data["grad_output"] = g_nt
@@ -447,23 +525,36 @@ def generate_decoder(
     torch.manual_seed(seed)
     rng = np.random.default_rng(seed)
     config = _make_config(dims)
-    pt = PtLayer(config, layer_idx=0)
-    pt.eval()
-    rotary = GPTNeoXRotaryEmbedding(config, device=torch.device("cpu"))
+    # Use layer 0 from ``PtModel`` so weights match ``generate_model`` (embed init
+    # advances the PyTorch RNG before layers are built).
+    model = PtModel(config)
+    model.eval()
+    pt = model.layers[0]
     data = _gptneox_decoder_weights(pt, "decoder", dims)
     x_nt, x_pt = _hidden_input(rng, dims)
     data["input"] = x_nt
     pos_ids_pt = _position_ids_pt(dims, x_pt.device)
-    cos, sin = _write_rope_and_position(
-        data, rotary, pt.attention, pos_ids_pt, dims, x_pt.dtype,
-    )
+    cos_np, sin_np = _write_rope_and_position(data, pos_ids_pt, dims)
     attn_mask = _causal_additive_mask_torch(
         dims.batch, dims.seq, x_pt.device,
     )
     data["attn_mask"] = _sdpa_causal_mask_fortran(dims.seq)
-    out = _gptneox_decoder_forward(
-        pt, x_pt, cos, sin, attn_mask=attn_mask,
+    residual = x_pt
+    x_norm = pt.input_layernorm(x_pt)
+    data["input_norm_out"] = _out_to_nntile(x_norm)
+    attn_out = _gptneox_attn_forward(
+        pt.attention, x_norm, cos_np, sin_np, dims, attn_mask=attn_mask,
     )
+    data["attn_out"] = _out_to_nntile(attn_out)
+    post_attn = residual + attn_out
+    data["post_attn"] = _out_to_nntile(post_attn)
+    if pt.use_parallel_residual:
+        mlp_in = pt.post_attention_layernorm(residual)
+    else:
+        mlp_in = pt.post_attention_layernorm(post_attn)
+    mlp_out = pt.mlp(mlp_in)
+    data["mlp_out"] = _out_to_nntile(mlp_out)
+    out = post_attn + mlp_out
     data["output_ref"] = _out_to_nntile(out)
     g_nt, g_pt = _grad_output(rng, out)
     data["grad_output"] = g_nt
@@ -478,23 +569,17 @@ def generate_model(seed: int, dims: TestDims = MODEL_DIMS) -> dict[str, np.ndarr
     config = _make_config(dims)
     pt = PtModel(config)
     pt.eval()
-    rotary = pt.rotary_emb
     data = _model_weights(pt, "model", dims)
     ids_nt, ids_pt = _ids_input(rng, dims)
     data["input_ids"] = ids_nt
-    data["position_ids"] = _position_ids(dims)
     data["attn_mask"] = _sdpa_causal_mask_fortran(dims.seq)
     pos_ids_pt = _position_ids_pt(dims, ids_pt.device)
-    embeds = pt.embed_in(ids_pt)
-    cos, sin = rotary(embeds, pos_ids_pt)
-    cos_np, sin_np = _rope_half_from_hf(cos, sin, dims)
-    data["rope_cos"] = fortran_order(cos_np)
-    data["rope_sin"] = fortran_order(sin_np)
+    cos_np, sin_np = _write_rope_and_position(data, pos_ids_pt, dims)
     attn_mask = _causal_additive_mask_torch(
         dims.batch, dims.seq, ids_pt.device,
     )
     out = _gptneox_model_forward(
-        pt, ids_pt, cos, sin, attn_mask=attn_mask,
+        pt, ids_pt, cos_np, sin_np, dims, attn_mask=attn_mask,
     )
     data["output_ref"] = _out_to_nntile(out)
     g_nt, g_pt = _grad_output(rng, out)
@@ -511,24 +596,18 @@ def generate_causal(seed: int, dims: TestDims = CAUSAL_DIMS) -> dict[str, np.nda
     config = _make_config(dims)
     pt = PtCausalLM(config)
     pt.eval()
-    rotary = pt.gpt_neox.rotary_emb
     data = _model_weights(pt.gpt_neox, "model.model", dims)
     data["model.lm_head.weight"] = _lm_head_to_linear_weight(pt.embed_out)
     ids_nt, ids_pt = _ids_input(rng, dims)
     data["input_ids"] = ids_nt
-    data["position_ids"] = _position_ids(dims)
     data["attn_mask"] = _sdpa_causal_mask_fortran(dims.seq)
     pos_ids_pt = _position_ids_pt(dims, ids_pt.device)
-    embeds = pt.gpt_neox.embed_in(ids_pt)
-    cos, sin = rotary(embeds, pos_ids_pt)
-    cos_np, sin_np = _rope_half_from_hf(cos, sin, dims)
-    data["rope_cos"] = fortran_order(cos_np)
-    data["rope_sin"] = fortran_order(sin_np)
+    cos_np, sin_np = _write_rope_and_position(data, pos_ids_pt, dims)
     attn_mask = _causal_additive_mask_torch(
         dims.batch, dims.seq, ids_pt.device,
     )
     hidden = _gptneox_model_forward(
-        pt.gpt_neox, ids_pt, cos, sin, attn_mask=attn_mask,
+        pt.gpt_neox, ids_pt, cos_np, sin_np, dims, attn_mask=attn_mask,
     )
     logits = F.linear(hidden, pt.embed_out.weight, None)
     data["output_ref"] = _out_to_nntile(logits)
@@ -585,10 +664,11 @@ def main() -> int:
         # SDPA/RoPE vs PyTorch eager can differ slightly at tight tol.
         write_fixture_json(out, stem, ATTENTION_DIMS, 5e-3, 5e-3)
     elif args.block == "decoder":
-        # Full decoder (LN + attn + MLP + parallel residual) vs eager PyTorch.
-        write_fixture_json(out, stem, DECODER_DIMS, 2e-1, 2e-1)
+        # Full block stacks LN, RoPE, masked SDPA, and biased MLP; allow slightly
+        # more slack on forward than standalone attention.
+        write_fixture_json(out, stem, DECODER_DIMS, 2e-2, 5e-3)
     elif args.block in ("model", "causal"):
-        write_fixture_json(out, stem, MODEL_DIMS, 2e-1, 2e-1)
+        write_fixture_json(out, stem, MODEL_DIMS, 2e-2, 2e-2)
 
     return 0
 

--- a/tests/graph/model/gptneox/gptneox_attention.cc
+++ b/tests/graph/model/gptneox/gptneox_attention.cc
@@ -1,0 +1,366 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file tests/graph/model/gptneox/gptneox_attention.cc
+ * Tests for GptneoxAttention.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_attention.hh"
+
+#include "context_fixture.hh"
+#include "nntile/graph.hh"
+#include "nntile/graph/io/safetensors.hh"
+#include "nntile/graph/model/gptneox/gptneox_config.hh"
+#include "test_frobenius.hh"
+#include "test_gptneox_fixture_helpers.hh"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+using namespace nntile;
+using namespace nntile::graph;
+using namespace nntile::model::gptneox;
+using namespace nntile::graph::io;
+
+#ifndef GPTNEOX_DATA_DIR
+
+TEST_CASE(
+    "GptneoxAttention tests skipped (GPTNEOX_DATA_DIR undefined)", "[model][gptneox]")
+{
+    SKIP("GPTNEOX_DATA_DIR not defined at compile time.");
+}
+
+#else
+
+namespace attn_fixture_stem
+{
+
+constexpr char gptneox_attention[] = "gptneox_attention";
+constexpr char gptneox_attention_causal[] = "gptneox_attention_causal";
+} // namespace attn_fixture_stem
+
+namespace
+{
+
+using namespace nntile::test::gptneox_fixture;
+
+struct AttentionFixtureSpec
+{
+    GptneoxConfig config{};
+    Index seq = 0;
+    Index batch = 0;
+    Index hidden = 0;
+    float forward_tol = 0.f;
+    float backward_tol = 0.f;
+    std::string stem;
+};
+
+inline bool try_load_attention_fixture_spec(const std::string &data_dir,
+    const char *stem_cstr,
+    AttentionFixtureSpec &out)
+{
+    out = {};
+    out.stem = stem_cstr;
+    const std::string jpath = data_dir + "/" + out.stem + ".json";
+    std::ifstream jf(jpath);
+    if (!jf)
+    {
+        return false;
+    }
+    nlohmann::json j;
+    try
+    {
+        jf >> j;
+        if (j.at("version").get<int>() != 2)
+        {
+            return false;
+        }
+        if (j.at("stem").get<std::string>() != out.stem)
+        {
+            return false;
+        }
+        const std::string expected_st = out.stem + ".safetensors";
+        if (j.at("safetensors").get<std::string>() != expected_st)
+        {
+            return false;
+        }
+        const auto &G = j.at("gptneox");
+        out.config.hidden_size = json_index(G, "hidden_size");
+        out.config.intermediate_size = json_index(G, "intermediate_size");
+        out.config.num_attention_heads = json_index(G, "num_attention_heads");
+        out.config.head_dim = json_index(G, "head_dim");
+        out.config.max_position_embeddings =
+            json_index(G, "max_position_embeddings");
+        if(G.contains("rotary_pct"))
+        {
+            out.config.rotary_pct =
+                static_cast<float>(G.at("rotary_pct").get<double>());
+        }
+        if(G.contains("rotary_emb_base"))
+        {
+            out.config.rotary_emb_base =
+                static_cast<float>(G.at("rotary_emb_base").get<double>());
+        }
+        out.hidden = out.config.hidden_size;
+        out.seq = json_index(j, "sequence_length");
+        out.batch = json_index(j, "batch");
+        out.forward_tol =
+            static_cast<float>(j.at("tolerances").at("forward").get<double>());
+        out.backward_tol = static_cast<float>(
+            j.at("tolerances").at("backward").get<double>());
+        out.config.validate();
+    }
+    catch (...)
+    {
+        return false;
+    }
+    prepare_gptneox_config(out.config);
+    return true;
+}
+
+inline std::string attention_fixture_safetensors_path(
+    const std::string &data_dir, const AttentionFixtureSpec &spec)
+{
+    return data_dir + "/" + spec.stem + ".safetensors";
+}
+
+inline bool skip_unless_fixture_ready(
+    const char *stem, AttentionFixtureSpec &fx)
+{
+    const std::string dir = std::string(GPTNEOX_DATA_DIR);
+    if (!try_load_attention_fixture_spec(dir, stem, fx))
+    {
+        return false;
+    }
+    std::ifstream st(attention_fixture_safetensors_path(dir, fx));
+    return st.good();
+}
+
+void gptneox_attention_forward_compare_ref(const AttentionFixtureSpec &fx)
+{
+    const std::string full_path =
+        attention_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+
+    std::vector<std::uint8_t> input_bytes = reader.read_tensor("input");
+    std::vector<float> input_data(input_bytes.size() / sizeof(float));
+    std::memcpy(input_data.data(), input_bytes.data(), input_bytes.size());
+
+    std::vector<float> result;
+    {
+        NNGraph g(std::string("attn_ref_") + fx.stem);
+        auto *input = g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32)
+                          ->set_name("input");
+        GptneoxRopeInputs rope;
+        load_gptneox_rope_inputs(g, reader, fx.config, fx.seq, fx.batch, rope);
+        NNGraph::TensorNode *mask = nullptr;
+        std::vector<std::uint8_t> mask_bytes;
+        load_attn_mask_bool(g, reader, fx.seq, mask, mask_bytes);
+
+        GptneoxAttention attn(&g, "attn", fx.config);
+        attn.load(full_path);
+
+        auto *output = attn.forward(input, rope.sin, rope.cos, mask);
+        input->mark_input(true);
+        output->mark_output(true);
+        mark_rope_inputs(rope);
+        mark_mask_input(mask);
+
+        TileGraph tile_graph = TileGraph::from_tensor_graph(g.tensor_graph());
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(input, input_data);
+        bind_rope_inputs(runtime, rope);
+        bind_mask_input(runtime, mask, mask_bytes);
+        runtime.execute();
+        runtime.wait();
+
+        result = runtime.get_output<float>(output);
+    }
+
+    std::vector<std::uint8_t> ref_bytes = reader.read_tensor("output_ref");
+    std::vector<float> ref_data(ref_bytes.size() / sizeof(float));
+    std::memcpy(ref_data.data(), ref_bytes.data(), ref_bytes.size());
+
+    REQUIRE(result.size() == ref_data.size());
+    require_relative_frobenius_error(result, ref_data, fx.forward_tol);
+}
+
+void gptneox_attention_backward_compare_ref(const AttentionFixtureSpec &fx)
+{
+    const std::string full_path =
+        attention_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+
+    std::vector<std::uint8_t> input_bytes = reader.read_tensor("input");
+    std::vector<float> input_data(input_bytes.size() / sizeof(float));
+    std::memcpy(input_data.data(), input_bytes.data(), input_bytes.size());
+
+    std::vector<std::uint8_t> grad_out_bytes =
+        reader.read_tensor("grad_output");
+    std::vector<float> grad_out_data(grad_out_bytes.size() / sizeof(float));
+    std::memcpy(
+        grad_out_data.data(), grad_out_bytes.data(), grad_out_bytes.size());
+
+    std::vector<float> grad_input_result;
+    {
+        NNGraph g(std::string("attn_bwd_") + fx.stem);
+        auto *input = g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32, true)
+                          ->set_name("input");
+        GptneoxRopeInputs rope;
+        load_gptneox_rope_inputs(g, reader, fx.config, fx.seq, fx.batch, rope);
+        NNGraph::TensorNode *mask = nullptr;
+        std::vector<std::uint8_t> mask_bytes;
+        load_attn_mask_bool(g, reader, fx.seq, mask, mask_bytes);
+
+        GptneoxAttention attn(&g, "attn", fx.config);
+        attn.load(full_path);
+
+        auto *output = attn.forward(input, rope.sin, rope.cos, mask);
+
+        input->mark_input(true);
+        output->mark_output(true);
+        mark_rope_inputs(rope);
+        mark_mask_input(mask);
+
+        auto [grad_output_tensor, _] =
+            g.get_or_create_grad(output, "grad_output");
+        grad_output_tensor->mark_input(true);
+        output->backward();
+        input->grad()->mark_output(true);
+
+        TileGraph tile_graph = TileGraph::from_tensor_graph(g.tensor_graph());
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(input, input_data);
+        runtime.bind_data(grad_output_tensor, grad_out_data);
+        bind_rope_inputs(runtime, rope);
+        bind_mask_input(runtime, mask, mask_bytes);
+        runtime.execute();
+        runtime.wait();
+
+        grad_input_result = runtime.get_output<float>(input->grad());
+    }
+
+    std::vector<std::uint8_t> ref_bytes = reader.read_tensor("grad_input");
+    std::vector<float> grad_input_ref(ref_bytes.size() / sizeof(float));
+    std::memcpy(grad_input_ref.data(), ref_bytes.data(), ref_bytes.size());
+
+    REQUIRE(grad_input_result.size() == grad_input_ref.size());
+    require_relative_frobenius_error(
+        grad_input_result, grad_input_ref, fx.backward_tol);
+}
+
+
+
+} // namespace
+
+TEST_CASE("GptneoxAttention forward builds output", "[model][gptneox]")
+{
+    AttentionFixtureSpec fx;
+    if (!skip_unless_fixture_ready(attn_fixture_stem::gptneox_attention, fx))
+    {
+        SKIP("Missing or invalid gptneox_attention.json / .safetensors.");
+    }
+    NNGraph g("gptneox_attn");
+    GptneoxAttention attn(&g, "attn", fx.config);
+    auto *input = g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32)
+                      ->set_name("input");
+    auto *output = attn.forward(input, nullptr, nullptr, nullptr);
+
+    REQUIRE(output != nullptr);
+    REQUIRE(
+        output->shape() == std::vector<Index>({fx.hidden, fx.seq, fx.batch}));
+    REQUIRE(attn.parameters_recursive().size() == 4);
+}
+
+TEST_CASE("GptneoxAttention load from safetensors roundtrip", "[model][gptneox][io]")
+{
+    AttentionFixtureSpec fx;
+    if (!skip_unless_fixture_ready(attn_fixture_stem::gptneox_attention, fx))
+    {
+        SKIP("Missing or invalid gptneox_attention.json / .safetensors.");
+    }
+    const std::string data_path =
+        attention_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+
+    NNGraph g1("load_graph");
+    GptneoxAttention attn1(&g1, "attn", fx.config);
+    attn1.load(data_path);
+
+    const std::string save_path =
+        "/tmp/nntile_gptneox_attn_roundtrip.safetensors";
+    attn1.save(save_path);
+
+    SafeTensorsReader reader(data_path);
+    SafeTensorsReader reader2(save_path);
+    for (const auto &name : reader2.tensor_names())
+    {
+        REQUIRE(reader.has_tensor(name));
+        REQUIRE(reader.read_tensor(name) == reader2.read_tensor(name));
+    }
+    std::remove(save_path.c_str());
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxAttention forward matches PyTorch reference (no mask)",
+    "[model][gptneox][nomask]")
+{
+    AttentionFixtureSpec fx;
+    if (!skip_unless_fixture_ready(attn_fixture_stem::gptneox_attention, fx))
+    {
+        SKIP("GPT-NeoX attention fixture not found.");
+    }
+    gptneox_attention_forward_compare_ref(fx);
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxAttention backward matches PyTorch reference (no mask)",
+    "[model][gptneox][nomask]")
+{
+    AttentionFixtureSpec fx;
+    if (!skip_unless_fixture_ready(attn_fixture_stem::gptneox_attention, fx))
+    {
+        SKIP("GPT-NeoX attention fixture not found.");
+    }
+    gptneox_attention_backward_compare_ref(fx);
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxAttention causal forward matches PyTorch reference",
+    "[model][gptneox][causal_mask]")
+{
+    AttentionFixtureSpec fx;
+    if (!skip_unless_fixture_ready(
+            attn_fixture_stem::gptneox_attention_causal, fx))
+    {
+        SKIP("GPT-NeoX causal attention fixture not found.");
+    }
+    gptneox_attention_forward_compare_ref(fx);
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxAttention causal backward matches PyTorch reference",
+    "[model][gptneox][causal_mask]")
+{
+    AttentionFixtureSpec fx;
+    if (!skip_unless_fixture_ready(
+            attn_fixture_stem::gptneox_attention_causal, fx))
+    {
+        SKIP("GPT-NeoX causal attention fixture not found.");
+    }
+    gptneox_attention_backward_compare_ref(fx);
+}
+
+
+#endif

--- a/tests/graph/model/gptneox/gptneox_causal.cc
+++ b/tests/graph/model/gptneox/gptneox_causal.cc
@@ -1,0 +1,334 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file tests/graph/model/gptneox/gptneox_causal.cc
+ * Tests for GptneoxCausal.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_causal.hh"
+
+#include "context_fixture.hh"
+#include "nntile/graph.hh"
+#include "nntile/graph/io/safetensors.hh"
+#include "nntile/graph/model/gptneox/gptneox_config.hh"
+#include "test_frobenius.hh"
+#include "test_gptneox_fixture_helpers.hh"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+using namespace nntile;
+using namespace nntile::graph;
+using namespace nntile::model::gptneox;
+using namespace nntile::graph::io;
+
+#ifndef GPTNEOX_DATA_DIR
+
+TEST_CASE(
+    "GptneoxCausal tests skipped (GPTNEOX_DATA_DIR undefined)", "[model][gptneox]")
+{
+    SKIP("GPTNEOX_DATA_DIR not defined at compile time.");
+}
+
+#else
+
+namespace causal_fixture_stem
+{
+
+constexpr char gptneox_causal[] = "gptneox_causal";
+
+} // namespace causal_fixture_stem
+
+namespace
+{
+
+using namespace nntile::test::gptneox_fixture;
+
+struct CausalFixtureSpec
+{
+    GptneoxConfig config{};
+    Index seq = 0;
+    Index batch = 0;
+    float forward_tol = 0.f;
+    float backward_tol = 0.f;
+    std::string stem;
+};
+
+inline bool try_load_causal_fixture_spec(const std::string &data_dir,
+    const char *stem_cstr,
+    CausalFixtureSpec &out)
+{
+    out = {};
+    out.stem = stem_cstr;
+    const std::string jpath = data_dir + "/" + out.stem + ".json";
+    std::ifstream jf(jpath);
+    if (!jf)
+    {
+        return false;
+    }
+    nlohmann::json j;
+    try
+    {
+        jf >> j;
+        if (j.at("version").get<int>() != 2)
+        {
+            return false;
+        }
+        if (j.at("stem").get<std::string>() != out.stem)
+        {
+            return false;
+        }
+        const std::string expected_st = out.stem + ".safetensors";
+        if (j.at("safetensors").get<std::string>() != expected_st)
+        {
+            return false;
+        }
+        const auto &G = j.at("gptneox");
+        out.config.vocab_size = json_index(G, "vocab_size");
+        out.config.hidden_size = json_index(G, "hidden_size");
+        out.config.intermediate_size = json_index(G, "intermediate_size");
+        out.config.num_hidden_layers = json_index(G, "num_hidden_layers");
+        out.config.num_attention_heads = json_index(G, "num_attention_heads");
+        out.config.head_dim = json_index(G, "head_dim");
+        out.config.max_position_embeddings =
+            json_index(G, "max_position_embeddings");
+        if(G.contains("rotary_pct"))
+        {
+            out.config.rotary_pct =
+                static_cast<float>(G.at("rotary_pct").get<double>());
+        }
+        if(G.contains("rotary_emb_base"))
+        {
+            out.config.rotary_emb_base =
+                static_cast<float>(G.at("rotary_emb_base").get<double>());
+        }
+        out.seq = json_index(j, "sequence_length");
+        out.batch = json_index(j, "batch");
+        out.forward_tol =
+            static_cast<float>(j.at("tolerances").at("forward").get<double>());
+        out.backward_tol = static_cast<float>(
+            j.at("tolerances").at("backward").get<double>());
+        out.config.validate();
+    }
+    catch (...)
+    {
+        return false;
+    }
+    prepare_gptneox_config(out.config);
+    return true;
+}
+
+inline std::string causal_fixture_safetensors_path(
+    const std::string &data_dir, const CausalFixtureSpec &spec)
+{
+    return data_dir + "/" + spec.stem + ".safetensors";
+}
+
+inline bool skip_unless_fixture_ready(const char *stem, CausalFixtureSpec &fx)
+{
+    const std::string dir = std::string(GPTNEOX_DATA_DIR);
+    if (!try_load_causal_fixture_spec(dir, stem, fx))
+    {
+        return false;
+    }
+    std::ifstream st(causal_fixture_safetensors_path(dir, fx));
+    return st.good();
+}
+
+void causal_backward_compare_ref(const CausalFixtureSpec &fx)
+{
+    const std::string full_path =
+        causal_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+
+    std::vector<std::uint8_t> ids_bytes = reader.read_tensor("input_ids");
+    std::vector<std::int64_t> ids_data(ids_bytes.size() / sizeof(std::int64_t));
+    std::memcpy(ids_data.data(), ids_bytes.data(), ids_bytes.size());
+
+    std::vector<std::uint8_t> grad_out_bytes =
+        reader.read_tensor("grad_output");
+    std::vector<float> grad_out_data(grad_out_bytes.size() / sizeof(float));
+    std::memcpy(
+        grad_out_data.data(), grad_out_bytes.data(), grad_out_bytes.size());
+
+    std::vector<std::uint8_t> ref_embed_bytes =
+        reader.read_tensor("grad_embed_tokens_vocab");
+    std::vector<float> grad_embed_ref(ref_embed_bytes.size() / sizeof(float));
+    std::memcpy(
+        grad_embed_ref.data(), ref_embed_bytes.data(), ref_embed_bytes.size());
+
+    std::vector<float> grad_embed_result;
+    {
+        NNGraph g("causal_bwd");
+        auto *input_ids =
+            g.tensor({fx.seq, fx.batch}, DataType::INT64, true)
+                ->set_name("input_ids");
+        GptneoxRopeInputs rope;
+        load_gptneox_rope_inputs(g, reader, fx.config, fx.seq, fx.batch, rope);
+        NNGraph::TensorNode *mask = nullptr;
+        std::vector<std::uint8_t> mask_bytes;
+        REQUIRE(load_attn_mask_bool(g, reader, fx.seq, mask, mask_bytes));
+
+        GptneoxCausal causal(&g, "model", fx.config);
+        causal.load(full_path);
+        auto *output = causal.forward(input_ids, rope.sin, rope.cos, mask);
+
+        input_ids->mark_input(true);
+        output->mark_output(true);
+        mark_rope_inputs(rope);
+        mark_mask_input(mask);
+
+        auto [grad_output_tensor, _] =
+            g.get_or_create_grad(output, "grad_output");
+        grad_output_tensor->mark_input(true);
+        output->backward();
+        causal.model()->embed_vocab_tensor()->grad()->mark_output(true);
+
+        TileGraph tile_graph = TileGraph::from_tensor_graph(g.tensor_graph());
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(input_ids, ids_data);
+        runtime.bind_data(grad_output_tensor, grad_out_data);
+        bind_rope_inputs(runtime, rope);
+        bind_mask_input(runtime, mask, mask_bytes);
+        runtime.execute();
+        runtime.wait();
+
+        grad_embed_result = runtime.get_output<float>(
+            causal.model()->embed_vocab_tensor()->grad());
+    }
+
+    REQUIRE(grad_embed_result.size() == grad_embed_ref.size());
+    require_relative_frobenius_error(
+        grad_embed_result, grad_embed_ref, fx.backward_tol);
+}
+
+
+} // namespace
+
+TEST_CASE("GptneoxCausal forward builds output", "[model][gptneox]")
+{
+    CausalFixtureSpec fx;
+    if (!skip_unless_fixture_ready(causal_fixture_stem::gptneox_causal, fx))
+    {
+        SKIP("Missing or invalid gptneox_causal.json / .safetensors.");
+    }
+    NNGraph g("gptneox_causal");
+    GptneoxCausal model(&g, "model", fx.config);
+    auto *input_ids =
+        g.tensor({fx.seq, fx.batch}, DataType::INT64)->set_name("input_ids");
+    auto *output = model.forward(input_ids, nullptr, nullptr, nullptr);
+
+    REQUIRE(output != nullptr);
+    REQUIRE(output->shape() ==
+            std::vector<Index>({fx.config.vocab_size, fx.seq, fx.batch}));
+}
+
+TEST_CASE("GptneoxCausal load from safetensors roundtrip", "[model][gptneox][io]")
+{
+    CausalFixtureSpec fx;
+    if (!skip_unless_fixture_ready(causal_fixture_stem::gptneox_causal, fx))
+    {
+        SKIP("Missing or invalid gptneox_causal.json / .safetensors.");
+    }
+    const std::string data_path =
+        causal_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+
+    NNGraph g1("load_graph");
+    GptneoxCausal model1(&g1, "model", fx.config);
+    model1.load(data_path);
+
+    const std::string save_path =
+        "/tmp/nntile_gptneox_causal_roundtrip.safetensors";
+    model1.save(save_path);
+
+    SafeTensorsReader reader(data_path);
+    SafeTensorsReader reader2(save_path);
+    for (const auto &name : reader2.tensor_names())
+    {
+        REQUIRE(reader.has_tensor(name));
+        REQUIRE(reader.read_tensor(name) == reader2.read_tensor(name));
+    }
+    std::remove(save_path.c_str());
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxCausal forward matches PyTorch reference", "[model][gptneox]")
+{
+    CausalFixtureSpec fx;
+    if (!skip_unless_fixture_ready(causal_fixture_stem::gptneox_causal, fx))
+    {
+        SKIP("GPT-NeoX causal fixture not found.");
+    }
+    const std::string full_path =
+        causal_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+
+    std::vector<std::uint8_t> ids_bytes = reader.read_tensor("input_ids");
+    std::vector<std::int64_t> ids_data(ids_bytes.size() / sizeof(std::int64_t));
+    std::memcpy(ids_data.data(), ids_bytes.data(), ids_bytes.size());
+
+    std::vector<float> result;
+    {
+        NNGraph g("causal_ref");
+        auto *input_ids =
+            g.tensor({fx.seq, fx.batch}, DataType::INT64)->set_name("input_ids");
+        GptneoxRopeInputs rope;
+        load_gptneox_rope_inputs(g, reader, fx.config, fx.seq, fx.batch, rope);
+        NNGraph::TensorNode *mask = nullptr;
+        std::vector<std::uint8_t> mask_bytes;
+        REQUIRE(load_attn_mask_bool(g, reader, fx.seq, mask, mask_bytes));
+
+        GptneoxCausal causal(&g, "model", fx.config);
+        causal.load(full_path);
+
+        auto *output = causal.forward(input_ids, rope.sin, rope.cos, mask);
+        input_ids->mark_input(true);
+        output->mark_output(true);
+        mark_rope_inputs(rope);
+        mark_mask_input(mask);
+
+        TileGraph tile_graph = TileGraph::from_tensor_graph(g.tensor_graph());
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(input_ids, ids_data);
+        bind_rope_inputs(runtime, rope);
+        bind_mask_input(runtime, mask, mask_bytes);
+        runtime.execute();
+        runtime.wait();
+
+        result = runtime.get_output<float>(output);
+    }
+
+    std::vector<std::uint8_t> ref_bytes = reader.read_tensor("output_ref");
+    std::vector<float> ref_data(ref_bytes.size() / sizeof(float));
+    std::memcpy(ref_data.data(), ref_bytes.data(), ref_bytes.size());
+
+    REQUIRE(result.size() == ref_data.size());
+    require_relative_frobenius_error(result, ref_data, fx.forward_tol);
+}
+
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxCausal backward matches PyTorch reference",
+    "[model][gptneox]")
+{
+    CausalFixtureSpec fx;
+    if (!skip_unless_fixture_ready(causal_fixture_stem::gptneox_causal, fx))
+    {
+        SKIP("GPT-NeoX causal fixture not found.");
+    }
+    causal_backward_compare_ref(fx);
+}
+
+#endif

--- a/tests/graph/model/gptneox/gptneox_config.cc
+++ b/tests/graph/model/gptneox/gptneox_config.cc
@@ -1,0 +1,116 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file tests/graph/model/gptneox/gptneox_config.cc
+ * Tests for GptneoxConfig.
+ *
+ * @version 1.1.0
+ * */
+
+#include <catch2/catch_test_macros.hpp>
+#include <nlohmann/json.hpp>
+
+#include "nntile/graph/model/gptneox/gptneox_config.hh"
+#include "nntile/graph/model/gptneox/gptneox_config_json.hh"
+
+using nntile::Index;
+using namespace nntile::model::gptneox;
+
+TEST_CASE("GptneoxConfig default values", "[model][gptneox]")
+{
+    GptneoxConfig config;
+    REQUIRE(config.vocab_size == 50280);
+    REQUIRE(config.hidden_size == 1024);
+    REQUIRE(config.num_attention_heads == 16);
+    REQUIRE(config.head_dim == 64);
+}
+
+TEST_CASE("GptneoxConfig compute_head_dim", "[model][gptneox]")
+{
+    GptneoxConfig config;
+    config.hidden_size = 512;
+    config.num_attention_heads = 8;
+    config.compute_head_dim();
+    REQUIRE(config.head_dim == 64);
+}
+
+TEST_CASE("GptneoxConfig validate", "[model][gptneox]")
+{
+    GptneoxConfig config;
+    config.hidden_size = 512;
+    config.num_attention_heads = 8;
+    config.head_dim = 64;
+    REQUIRE_NOTHROW(config.validate());
+}
+
+TEST_CASE("GptneoxConfig validate fails on bad head_dim", "[model][gptneox]")
+{
+    GptneoxConfig config;
+    config.hidden_size = 512;
+    config.num_attention_heads = 8;
+    config.head_dim = 63;
+    REQUIRE_THROWS(config.validate());
+}
+
+TEST_CASE("GptneoxConfig build_attention_layers default", "[model][gptneox]")
+{
+    GptneoxConfig config;
+    config.num_hidden_layers = 4;
+    config.build_attention_layers();
+    REQUIRE(config.attention_layers.size() == 4);
+    REQUIRE(config.attention_layers[0] == "global");
+    REQUIRE(config.attention_layers[1] == "local");
+    REQUIRE(config.is_local_attention_layer(1));
+    REQUIRE_FALSE(config.is_local_attention_layer(0));
+}
+
+TEST_CASE(
+    "GptneoxConfig parse attention_types matches HuggingFace expand",
+    "[model][gptneox]")
+{
+    nlohmann::json j = {
+        {"num_hidden_layers", 12},
+        {"attention_types", {{{"global", "local"}, 6}}}};
+    GptneoxConfig config;
+    config.num_hidden_layers = 12;
+    parse_gptneox_attention_layers(j, config);
+    REQUIRE(config.attention_layers.size() == 12);
+    for (Index i = 0; i < 12; ++i)
+    {
+        REQUIRE(
+            config.attention_layers[static_cast<std::size_t>(i)] ==
+            (i % 2 == 0 ? "global" : "local"));
+    }
+}
+
+
+TEST_CASE(
+    "GptneoxConfig parse HF default attention_types produces 24 layers",
+    "[model][gptneox]")
+{
+    nlohmann::json j = {
+        {"num_hidden_layers", 24},
+        {"attention_types", {{{"global", "local"}, 12}}}};
+    GptneoxConfig config;
+    config.num_hidden_layers = 24;
+    config.hidden_size = 2048;
+    config.num_attention_heads = 16;
+    config.head_dim = 128;
+    parse_gptneox_attention_layers(j, config);
+    REQUIRE(config.attention_layers.size() == 24);
+    REQUIRE_NOTHROW(config.validate());
+}
+
+TEST_CASE(
+    "GptneoxConfig parse attention_layers array round-trip",
+    "[model][gptneox]")
+{
+    nlohmann::json j = {
+        {"attention_layers", {"global", "local", "global"}}};
+    GptneoxConfig config;
+    parse_gptneox_attention_layers(j, config);
+    REQUIRE(config.attention_layers.size() == 3);
+    REQUIRE(config.attention_layers[2] == "global");
+}

--- a/tests/graph/model/gptneox/gptneox_decoder.cc
+++ b/tests/graph/model/gptneox/gptneox_decoder.cc
@@ -12,6 +12,7 @@
 #include "nntile/graph/model/gptneox/gptneox_decoder.hh"
 
 #include "context_fixture.hh"
+#include "nntile/graph/nn/ops/add.hh"
 #include "nntile/graph.hh"
 #include "nntile/graph/io/safetensors.hh"
 #include "nntile/graph/model/gptneox/gptneox_config.hh"
@@ -19,6 +20,7 @@
 #include "test_gptneox_fixture_helpers.hh"
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstring>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -110,6 +112,11 @@ inline bool try_load_decoder_fixture_spec(const std::string &data_dir,
         {
             out.config.rotary_emb_base =
                 static_cast<float>(G.at("rotary_emb_base").get<double>());
+        }
+        if(G.contains("use_parallel_residual"))
+        {
+            out.config.use_parallel_residual =
+                G.at("use_parallel_residual").get<bool>();
         }
         out.hidden = out.config.hidden_size;
         out.seq = json_index(j, "sequence_length");
@@ -260,6 +267,144 @@ void decoder_backward_compare_ref(const DecoderFixtureSpec &fx)
         grad_input_result, grad_input_ref, fx.backward_tol);
 }
 
+void decoder_run_and_compare_ref(
+    const DecoderFixtureSpec &fx,
+    const char *ref_tensor,
+    NNGraph &g,
+    graph::NNGraph::TensorNode *input,
+    graph::NNGraph::TensorNode *out,
+    const GptneoxRopeInputs *rope,
+    graph::NNGraph::TensorNode *mask,
+    const std::vector<std::uint8_t> *mask_bytes,
+    const std::vector<float> &input_data)
+{
+    const std::string full_path =
+        decoder_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+    if(!reader.has_tensor(ref_tensor))
+    {
+        SKIP(std::string("Fixture missing intermediate tensor ") + ref_tensor);
+    }
+
+    input->mark_input(true);
+    out->mark_output(true);
+    if(rope != nullptr)
+    {
+        mark_rope_inputs(*rope);
+    }
+    mark_mask_input(mask);
+
+    TileGraph tile_graph = TileGraph::from_tensor_graph(g.tensor_graph());
+    Runtime runtime(tile_graph);
+    runtime.compile();
+    runtime.bind_data(input, input_data);
+    if(rope != nullptr)
+    {
+        bind_rope_inputs(runtime, *rope);
+    }
+    if(mask != nullptr && mask_bytes != nullptr)
+    {
+        bind_mask_input(runtime, mask, *mask_bytes);
+    }
+    runtime.execute();
+    runtime.wait();
+    std::vector<float> result = runtime.get_output<float>(out);
+
+    std::vector<std::uint8_t> ref_bytes = reader.read_tensor(ref_tensor);
+    std::vector<float> ref_data(ref_bytes.size() / sizeof(float));
+    std::memcpy(ref_data.data(), ref_bytes.data(), ref_bytes.size());
+    REQUIRE(result.size() == ref_data.size());
+    require_relative_frobenius_error(result, ref_data, fx.forward_tol);
+}
+
+void decoder_input_norm_compare_ref(const DecoderFixtureSpec &fx)
+{
+    const std::string full_path =
+        decoder_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+    std::vector<std::uint8_t> input_bytes = reader.read_tensor("input");
+    std::vector<float> input_data(input_bytes.size() / sizeof(float));
+    std::memcpy(input_data.data(), input_bytes.data(), input_bytes.size());
+
+    NNGraph g("decoder_input_norm");
+    auto *input = g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32)
+                      ->set_name("input");
+    GptneoxDecoder decoder(&g, "decoder", fx.config);
+    decoder.load(full_path);
+    auto *out = decoder.input_norm().forward(input);
+    decoder_run_and_compare_ref(
+        fx, "input_norm_out", g, input, out, nullptr, nullptr, nullptr, input_data);
+}
+
+void decoder_attn_out_compare_ref(const DecoderFixtureSpec &fx)
+{
+    const std::string full_path =
+        decoder_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+    std::vector<std::uint8_t> input_bytes = reader.read_tensor("input");
+    std::vector<float> input_data(input_bytes.size() / sizeof(float));
+    std::memcpy(input_data.data(), input_bytes.data(), input_bytes.size());
+
+    NNGraph g("decoder_attn");
+    auto *input = g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32)
+                      ->set_name("input");
+    GptneoxRopeInputs rope;
+    load_gptneox_rope_inputs(g, reader, fx.config, fx.seq, fx.batch, rope);
+    NNGraph::TensorNode *mask = nullptr;
+    std::vector<std::uint8_t> mask_bytes;
+    load_attn_mask_bool(g, reader, fx.seq, mask, mask_bytes);
+    GptneoxDecoder decoder(&g, "decoder", fx.config);
+    decoder.load(full_path);
+    auto *x_norm = decoder.input_norm().forward(input);
+    auto *out = decoder.attention().forward(x_norm, rope.sin, rope.cos, mask);
+    decoder_run_and_compare_ref(fx,
+        "attn_out",
+        g,
+        input,
+        out,
+        &rope,
+        mask,
+        &mask_bytes,
+        input_data);
+}
+
+void decoder_mlp_out_compare_ref(const DecoderFixtureSpec &fx)
+{
+    const std::string full_path =
+        decoder_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+    std::vector<std::uint8_t> input_bytes = reader.read_tensor("input");
+    std::vector<float> input_data(input_bytes.size() / sizeof(float));
+    std::memcpy(input_data.data(), input_bytes.data(), input_bytes.size());
+
+    NNGraph g("decoder_mlp");
+    auto *input = g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32)
+                      ->set_name("input");
+    GptneoxRopeInputs rope;
+    load_gptneox_rope_inputs(g, reader, fx.config, fx.seq, fx.batch, rope);
+    NNGraph::TensorNode *mask = nullptr;
+    std::vector<std::uint8_t> mask_bytes;
+    load_attn_mask_bool(g, reader, fx.seq, mask, mask_bytes);
+    GptneoxDecoder decoder(&g, "decoder", fx.config);
+    decoder.load(full_path);
+    auto *x_norm = decoder.input_norm().forward(input);
+    auto *attn_out =
+        decoder.attention().forward(x_norm, rope.sin, rope.cos, mask);
+    auto *post_attn = graph::add(1.0, input, 1.0, attn_out);
+    auto *mlp_in = fx.config.use_parallel_residual
+        ? decoder.post_attn_norm().forward(input)
+        : decoder.post_attn_norm().forward(post_attn);
+    auto *out = decoder.mlp().forward(mlp_in);
+    decoder_run_and_compare_ref(fx,
+        "mlp_out",
+        g,
+        input,
+        out,
+        &rope,
+        mask,
+        &mask_bytes,
+        input_data);
+}
 
 } // namespace
 
@@ -307,6 +452,39 @@ TEST_CASE("GptneoxDecoder load from safetensors roundtrip", "[model][gptneox][io
         REQUIRE(reader.read_tensor(name) == reader2.read_tensor(name));
     }
     std::remove(save_path.c_str());
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxDecoder input_norm matches PyTorch reference", "[model][gptneox]")
+{
+    DecoderFixtureSpec fx;
+    if (!skip_unless_fixture_ready(decoder_fixture_stem::gptneox_decoder, fx))
+    {
+        SKIP("GPT-NeoX decoder fixture not found.");
+    }
+    decoder_input_norm_compare_ref(fx);
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxDecoder attention matches PyTorch reference", "[model][gptneox]")
+{
+    DecoderFixtureSpec fx;
+    if (!skip_unless_fixture_ready(decoder_fixture_stem::gptneox_decoder, fx))
+    {
+        SKIP("GPT-NeoX decoder fixture not found.");
+    }
+    decoder_attn_out_compare_ref(fx);
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxDecoder mlp matches PyTorch reference", "[model][gptneox]")
+{
+    DecoderFixtureSpec fx;
+    if (!skip_unless_fixture_ready(decoder_fixture_stem::gptneox_decoder, fx))
+    {
+        SKIP("GPT-NeoX decoder fixture not found.");
+    }
+    decoder_mlp_out_compare_ref(fx);
 }
 
 TEST_CASE_METHOD(nntile::test::ContextFixture,

--- a/tests/graph/model/gptneox/gptneox_decoder.cc
+++ b/tests/graph/model/gptneox/gptneox_decoder.cc
@@ -1,0 +1,336 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file tests/graph/model/gptneox/gptneox_decoder.cc
+ * Tests for GptneoxDecoder.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_decoder.hh"
+
+#include "context_fixture.hh"
+#include "nntile/graph.hh"
+#include "nntile/graph/io/safetensors.hh"
+#include "nntile/graph/model/gptneox/gptneox_config.hh"
+#include "test_frobenius.hh"
+#include "test_gptneox_fixture_helpers.hh"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+using namespace nntile;
+using namespace nntile::graph;
+using namespace nntile::model::gptneox;
+using namespace nntile::graph::io;
+
+#ifndef GPTNEOX_DATA_DIR
+
+TEST_CASE(
+    "GptneoxDecoder tests skipped (GPTNEOX_DATA_DIR undefined)", "[model][gptneox]")
+{
+    SKIP("GPTNEOX_DATA_DIR not defined at compile time.");
+}
+
+#else
+
+namespace decoder_fixture_stem
+{
+
+constexpr char gptneox_decoder[] = "gptneox_decoder";
+
+} // namespace decoder_fixture_stem
+
+namespace
+{
+
+using namespace nntile::test::gptneox_fixture;
+
+struct DecoderFixtureSpec
+{
+    GptneoxConfig config{};
+    Index seq = 0;
+    Index batch = 0;
+    Index hidden = 0;
+    float forward_tol = 0.f;
+    float backward_tol = 0.f;
+    std::string stem;
+};
+
+inline bool try_load_decoder_fixture_spec(const std::string &data_dir,
+    const char *stem_cstr,
+    DecoderFixtureSpec &out)
+{
+    out = {};
+    out.stem = stem_cstr;
+    const std::string jpath = data_dir + "/" + out.stem + ".json";
+    std::ifstream jf(jpath);
+    if (!jf)
+    {
+        return false;
+    }
+    nlohmann::json j;
+    try
+    {
+        jf >> j;
+        if (j.at("version").get<int>() != 2)
+        {
+            return false;
+        }
+        if (j.at("stem").get<std::string>() != out.stem)
+        {
+            return false;
+        }
+        const std::string expected_st = out.stem + ".safetensors";
+        if (j.at("safetensors").get<std::string>() != expected_st)
+        {
+            return false;
+        }
+        const auto &G = j.at("gptneox");
+        out.config.hidden_size = json_index(G, "hidden_size");
+        out.config.intermediate_size = json_index(G, "intermediate_size");
+        out.config.num_attention_heads = json_index(G, "num_attention_heads");
+        out.config.head_dim = json_index(G, "head_dim");
+        out.config.max_position_embeddings =
+            json_index(G, "max_position_embeddings");
+        if(G.contains("rotary_pct"))
+        {
+            out.config.rotary_pct =
+                static_cast<float>(G.at("rotary_pct").get<double>());
+        }
+        if(G.contains("rotary_emb_base"))
+        {
+            out.config.rotary_emb_base =
+                static_cast<float>(G.at("rotary_emb_base").get<double>());
+        }
+        out.hidden = out.config.hidden_size;
+        out.seq = json_index(j, "sequence_length");
+        out.batch = json_index(j, "batch");
+        out.forward_tol =
+            static_cast<float>(j.at("tolerances").at("forward").get<double>());
+        out.backward_tol = static_cast<float>(
+            j.at("tolerances").at("backward").get<double>());
+        out.config.validate();
+    }
+    catch (...)
+    {
+        return false;
+    }
+    prepare_gptneox_config(out.config);
+    return true;
+}
+
+inline std::string decoder_fixture_safetensors_path(
+    const std::string &data_dir, const DecoderFixtureSpec &spec)
+{
+    return data_dir + "/" + spec.stem + ".safetensors";
+}
+
+inline bool skip_unless_fixture_ready(const char *stem, DecoderFixtureSpec &fx)
+{
+    const std::string dir = std::string(GPTNEOX_DATA_DIR);
+    if (!try_load_decoder_fixture_spec(dir, stem, fx))
+    {
+        return false;
+    }
+    std::ifstream st(decoder_fixture_safetensors_path(dir, fx));
+    return st.good();
+}
+
+void decoder_forward_compare_ref(const DecoderFixtureSpec &fx)
+{
+    const std::string full_path =
+        decoder_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+
+    std::vector<std::uint8_t> input_bytes = reader.read_tensor("input");
+    std::vector<float> input_data(input_bytes.size() / sizeof(float));
+    std::memcpy(input_data.data(), input_bytes.data(), input_bytes.size());
+
+    std::vector<float> result;
+    {
+        NNGraph g(std::string("decoder_ref_") + fx.stem);
+        auto *input = g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32)
+                          ->set_name("input");
+        GptneoxRopeInputs rope;
+        load_gptneox_rope_inputs(g, reader, fx.config, fx.seq, fx.batch, rope);
+        NNGraph::TensorNode *mask = nullptr;
+        std::vector<std::uint8_t> mask_bytes;
+        load_attn_mask_bool(g, reader, fx.seq, mask, mask_bytes);
+
+        GptneoxDecoder decoder(&g, "decoder", fx.config);
+        decoder.load(full_path);
+
+        auto *output = decoder.forward(input, rope.sin, rope.cos, mask);
+        input->mark_input(true);
+        output->mark_output(true);
+        mark_rope_inputs(rope);
+        mark_mask_input(mask);
+
+        TileGraph tile_graph = TileGraph::from_tensor_graph(g.tensor_graph());
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(input, input_data);
+        bind_rope_inputs(runtime, rope);
+        bind_mask_input(runtime, mask, mask_bytes);
+        runtime.execute();
+        runtime.wait();
+
+        result = runtime.get_output<float>(output);
+    }
+
+    std::vector<std::uint8_t> ref_bytes = reader.read_tensor("output_ref");
+    std::vector<float> ref_data(ref_bytes.size() / sizeof(float));
+    std::memcpy(ref_data.data(), ref_bytes.data(), ref_bytes.size());
+
+    REQUIRE(result.size() == ref_data.size());
+    require_relative_frobenius_error(result, ref_data, fx.forward_tol);
+}
+
+void decoder_backward_compare_ref(const DecoderFixtureSpec &fx)
+{
+    const std::string full_path =
+        decoder_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+
+    std::vector<std::uint8_t> input_bytes = reader.read_tensor("input");
+    std::vector<float> input_data(input_bytes.size() / sizeof(float));
+    std::memcpy(input_data.data(), input_bytes.data(), input_bytes.size());
+
+    std::vector<std::uint8_t> grad_out_bytes =
+        reader.read_tensor("grad_output");
+    std::vector<float> grad_out_data(grad_out_bytes.size() / sizeof(float));
+    std::memcpy(
+        grad_out_data.data(), grad_out_bytes.data(), grad_out_bytes.size());
+
+    std::vector<std::uint8_t> ref_bytes = reader.read_tensor("grad_input");
+    std::vector<float> grad_input_ref(ref_bytes.size() / sizeof(float));
+    std::memcpy(grad_input_ref.data(), ref_bytes.data(), ref_bytes.size());
+
+    std::vector<float> grad_input_result;
+    {
+        NNGraph g(std::string("decoder_bwd_") + fx.stem);
+        auto *input =
+            g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32, true)
+                ->set_name("input");
+        GptneoxRopeInputs rope;
+        load_gptneox_rope_inputs(g, reader, fx.config, fx.seq, fx.batch, rope);
+        NNGraph::TensorNode *mask = nullptr;
+        std::vector<std::uint8_t> mask_bytes;
+        load_attn_mask_bool(g, reader, fx.seq, mask, mask_bytes);
+
+        GptneoxDecoder decoder(&g, "decoder", fx.config);
+        decoder.load(full_path);
+        auto *output = decoder.forward(input, rope.sin, rope.cos, mask);
+
+        input->mark_input(true);
+        output->mark_output(true);
+        mark_rope_inputs(rope);
+        mark_mask_input(mask);
+
+        auto [grad_output_tensor, _] =
+            g.get_or_create_grad(output, "grad_output");
+        grad_output_tensor->mark_input(true);
+        output->backward();
+        input->grad()->mark_output(true);
+
+        TileGraph tile_graph = TileGraph::from_tensor_graph(g.tensor_graph());
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(input, input_data);
+        runtime.bind_data(grad_output_tensor, grad_out_data);
+        bind_rope_inputs(runtime, rope);
+        bind_mask_input(runtime, mask, mask_bytes);
+        runtime.execute();
+        runtime.wait();
+
+        grad_input_result = runtime.get_output<float>(input->grad());
+    }
+
+    REQUIRE(grad_input_result.size() == grad_input_ref.size());
+    require_relative_frobenius_error(
+        grad_input_result, grad_input_ref, fx.backward_tol);
+}
+
+
+} // namespace
+
+TEST_CASE("GptneoxDecoder forward builds output", "[model][gptneox]")
+{
+    DecoderFixtureSpec fx;
+    if (!skip_unless_fixture_ready(decoder_fixture_stem::gptneox_decoder, fx))
+    {
+        SKIP("Missing or invalid gptneox_decoder.json / .safetensors.");
+    }
+    NNGraph g("gptneox_decoder");
+    GptneoxDecoder decoder(&g, "decoder", fx.config);
+    auto *input = g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32)
+                      ->set_name("input");
+    auto *output = decoder.forward(input, nullptr, nullptr, nullptr);
+
+    REQUIRE(output != nullptr);
+    REQUIRE(
+        output->shape() == std::vector<Index>({fx.hidden, fx.seq, fx.batch}));
+}
+
+TEST_CASE("GptneoxDecoder load from safetensors roundtrip", "[model][gptneox][io]")
+{
+    DecoderFixtureSpec fx;
+    if (!skip_unless_fixture_ready(decoder_fixture_stem::gptneox_decoder, fx))
+    {
+        SKIP("Missing or invalid gptneox_decoder.json / .safetensors.");
+    }
+    const std::string data_path =
+        decoder_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+
+    NNGraph g1("load_graph");
+    GptneoxDecoder decoder1(&g1, "decoder", fx.config);
+    decoder1.load(data_path);
+
+    const std::string save_path =
+        "/tmp/nntile_gptneox_decoder_roundtrip.safetensors";
+    decoder1.save(save_path);
+
+    SafeTensorsReader reader(data_path);
+    SafeTensorsReader reader2(save_path);
+    for (const auto &name : reader2.tensor_names())
+    {
+        REQUIRE(reader.has_tensor(name));
+        REQUIRE(reader.read_tensor(name) == reader2.read_tensor(name));
+    }
+    std::remove(save_path.c_str());
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxDecoder forward matches PyTorch reference", "[model][gptneox]")
+{
+    DecoderFixtureSpec fx;
+    if (!skip_unless_fixture_ready(decoder_fixture_stem::gptneox_decoder, fx))
+    {
+        SKIP("GPT-NeoX decoder fixture not found.");
+    }
+    decoder_forward_compare_ref(fx);
+}
+
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxDecoder backward matches PyTorch reference",
+    "[model][gptneox]")
+{
+    DecoderFixtureSpec fx;
+    if (!skip_unless_fixture_ready(decoder_fixture_stem::gptneox_decoder, fx))
+    {
+        SKIP("GPT-NeoX decoder fixture not found.");
+    }
+    decoder_backward_compare_ref(fx);
+}
+
+#endif

--- a/tests/graph/model/gptneox/gptneox_mlp.cc
+++ b/tests/graph/model/gptneox/gptneox_mlp.cc
@@ -148,7 +148,7 @@ TEST_CASE("GptneoxMlp forward builds output", "[model][gptneox]")
     REQUIRE(output != nullptr);
     REQUIRE(
         output->shape() == std::vector<Index>({fx.hidden, fx.seq, fx.batch}));
-    REQUIRE(mlp.parameters_recursive().size() == 2);
+    REQUIRE(mlp.parameters_recursive().size() == 4);
 }
 
 TEST_CASE("GptneoxMlp load from safetensors roundtrip", "[model][gptneox][io]")

--- a/tests/graph/model/gptneox/gptneox_mlp.cc
+++ b/tests/graph/model/gptneox/gptneox_mlp.cc
@@ -1,0 +1,301 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file tests/graph/model/gptneox/gptneox_mlp.cc
+ * Tests for GptneoxMlp.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_mlp.hh"
+
+#include "context_fixture.hh"
+#include "nntile/graph.hh"
+#include "nntile/graph/io/safetensors.hh"
+#include "nntile/graph/model/gptneox/gptneox_config.hh"
+#include "test_frobenius.hh"
+#include "test_gptneox_fixture_helpers.hh"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+using namespace nntile;
+using namespace nntile::graph;
+using namespace nntile::model::gptneox;
+using namespace nntile::graph::io;
+
+#ifndef GPTNEOX_DATA_DIR
+
+TEST_CASE(
+    "GptneoxMlp tests skipped (GPTNEOX_DATA_DIR undefined)", "[model][gptneox]")
+{
+    SKIP("GPTNEOX_DATA_DIR not defined at compile time.");
+}
+
+#else
+
+namespace mlp_fixture_stem
+{
+
+constexpr char gptneox_mlp[] = "gptneox_mlp";
+
+} // namespace mlp_fixture_stem
+
+namespace
+{
+
+using namespace nntile::test::gptneox_fixture;
+
+struct MlpFixtureSpec
+{
+    GptneoxConfig config{};
+    Index seq = 0;
+    Index batch = 0;
+    Index hidden = 0;
+    float forward_tol = 0.f;
+    float backward_tol = 0.f;
+    std::string stem;
+};
+
+inline bool try_load_mlp_fixture_spec(
+    const std::string &data_dir, const char *stem_cstr, MlpFixtureSpec &out)
+{
+    out = {};
+    out.stem = stem_cstr;
+    const std::string jpath = data_dir + "/" + out.stem + ".json";
+    std::ifstream jf(jpath);
+    if (!jf)
+    {
+        return false;
+    }
+    nlohmann::json j;
+    try
+    {
+        jf >> j;
+        if (j.at("version").get<int>() != 2)
+        {
+            return false;
+        }
+        if (j.at("stem").get<std::string>() != out.stem)
+        {
+            return false;
+        }
+        const std::string expected_st = out.stem + ".safetensors";
+        if (j.at("safetensors").get<std::string>() != expected_st)
+        {
+            return false;
+        }
+        const auto &G = j.at("gptneox");
+        out.config.hidden_size = json_index(G, "hidden_size");
+        out.config.intermediate_size = json_index(G, "intermediate_size");
+        out.config.num_attention_heads = json_index(G, "num_attention_heads");
+        out.hidden = out.config.hidden_size;
+        out.seq = json_index(j, "sequence_length");
+        out.batch = json_index(j, "batch");
+        out.forward_tol =
+            static_cast<float>(j.at("tolerances").at("forward").get<double>());
+        out.backward_tol = static_cast<float>(
+            j.at("tolerances").at("backward").get<double>());
+    }
+    catch (...)
+    {
+        return false;
+    }
+    prepare_gptneox_config(out.config);
+    return true;
+}
+
+inline std::string mlp_fixture_safetensors_path(
+    const std::string &data_dir, const MlpFixtureSpec &spec)
+{
+    return data_dir + "/" + spec.stem + ".safetensors";
+}
+
+inline bool skip_unless_fixture_ready(const char *stem, MlpFixtureSpec &fx)
+{
+    const std::string dir = std::string(GPTNEOX_DATA_DIR);
+    if (!try_load_mlp_fixture_spec(dir, stem, fx))
+    {
+        return false;
+    }
+    std::ifstream st(mlp_fixture_safetensors_path(dir, fx));
+    return st.good();
+}
+
+} // namespace
+
+TEST_CASE("GptneoxMlp forward builds output", "[model][gptneox]")
+{
+    MlpFixtureSpec fx;
+    if (!skip_unless_fixture_ready(mlp_fixture_stem::gptneox_mlp, fx))
+    {
+        SKIP("Missing or invalid gptneox_mlp.json / .safetensors.");
+    }
+    NNGraph g("gptneox_mlp");
+    GptneoxMlp mlp(&g, "mlp", fx.config);
+    auto *input = g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32)
+                      ->set_name("input");
+    auto *output = mlp.forward(input);
+
+    REQUIRE(output != nullptr);
+    REQUIRE(
+        output->shape() == std::vector<Index>({fx.hidden, fx.seq, fx.batch}));
+    REQUIRE(mlp.parameters_recursive().size() == 2);
+}
+
+TEST_CASE("GptneoxMlp load from safetensors roundtrip", "[model][gptneox][io]")
+{
+    MlpFixtureSpec fx;
+    if (!skip_unless_fixture_ready(mlp_fixture_stem::gptneox_mlp, fx))
+    {
+        SKIP("Missing or invalid gptneox_mlp.json / .safetensors.");
+    }
+    const std::string data_path =
+        mlp_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+
+    NNGraph g1("load_graph");
+    GptneoxMlp mlp1(&g1, "mlp", fx.config);
+    mlp1.load(data_path);
+
+    const std::string save_path =
+        "/tmp/nntile_gptneox_mlp_roundtrip.safetensors";
+    mlp1.save(save_path);
+
+    SafeTensorsReader reader(data_path);
+    SafeTensorsReader reader2(save_path);
+
+    for (const auto &name : reader2.tensor_names())
+    {
+        REQUIRE(reader.has_tensor(name));
+        auto orig = reader.read_tensor(name);
+        auto loaded = reader2.read_tensor(name);
+        REQUIRE(orig.size() == loaded.size());
+        REQUIRE(orig == loaded);
+    }
+
+    std::remove(save_path.c_str());
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxMlp matches PyTorch reference",
+    "[model][gptneox]")
+{
+    MlpFixtureSpec fx;
+    if (!skip_unless_fixture_ready(mlp_fixture_stem::gptneox_mlp, fx))
+    {
+        SKIP("GPT-NeoX MLP fixture pair not found.");
+    }
+    const std::string full_path =
+        mlp_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+
+    SafeTensorsReader reader(full_path);
+    std::vector<std::uint8_t> input_bytes = reader.read_tensor("input");
+    std::vector<float> input_data(input_bytes.size() / sizeof(float));
+    std::memcpy(input_data.data(), input_bytes.data(), input_bytes.size());
+
+    std::vector<std::uint8_t> ref_bytes = reader.read_tensor("output_ref");
+    std::vector<float> ref_data(ref_bytes.size() / sizeof(float));
+    std::memcpy(ref_data.data(), ref_bytes.data(), ref_bytes.size());
+
+    std::vector<float> result;
+    {
+        NNGraph g("mlp_ref");
+        auto *input = g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32)
+                          ->set_name("input");
+        GptneoxMlp mlp(&g, "mlp", fx.config);
+        auto *output = mlp.forward(input);
+        input->mark_input(true);
+        output->mark_output(true);
+
+        mlp.load(full_path);
+
+        TensorGraph &tg = g.tensor_graph();
+        TileGraph tile_graph = TileGraph::from_tensor_graph(tg);
+
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(input, input_data);
+        runtime.execute();
+        runtime.wait();
+
+        result = runtime.get_output<float>(output);
+    }
+
+    REQUIRE(result.size() == ref_data.size());
+    require_relative_frobenius_error(result, ref_data, fx.forward_tol);
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxMlp backward matches PyTorch reference",
+    "[model][gptneox]")
+{
+    MlpFixtureSpec fx;
+    if (!skip_unless_fixture_ready(mlp_fixture_stem::gptneox_mlp, fx))
+    {
+        SKIP("GPT-NeoX MLP fixture pair not found.");
+    }
+    const std::string full_path =
+        mlp_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+
+    SafeTensorsReader reader(full_path);
+    std::vector<std::uint8_t> input_bytes = reader.read_tensor("input");
+    std::vector<float> input_data(input_bytes.size() / sizeof(float));
+    std::memcpy(input_data.data(), input_bytes.data(), input_bytes.size());
+
+    std::vector<std::uint8_t> grad_out_bytes =
+        reader.read_tensor("grad_output");
+    std::vector<float> grad_out_data(grad_out_bytes.size() / sizeof(float));
+    std::memcpy(
+        grad_out_data.data(), grad_out_bytes.data(), grad_out_bytes.size());
+
+    std::vector<std::uint8_t> ref_bytes = reader.read_tensor("grad_input");
+    std::vector<float> grad_input_ref(ref_bytes.size() / sizeof(float));
+    std::memcpy(grad_input_ref.data(), ref_bytes.data(), ref_bytes.size());
+
+    std::vector<float> grad_input_result;
+    {
+        NNGraph g("mlp_bwd");
+        auto *input =
+            g.tensor({fx.hidden, fx.seq, fx.batch}, DataType::FP32, true)
+                ->set_name("input");
+        GptneoxMlp mlp(&g, "mlp", fx.config);
+        auto *output = mlp.forward(input);
+
+        input->mark_input(true);
+        output->mark_output(true);
+
+        auto [grad_output_tensor, _] =
+            g.get_or_create_grad(output, "grad_output");
+        grad_output_tensor->mark_input(true);
+        output->backward();
+        input->grad()->mark_output(true);
+
+        mlp.load(full_path);
+
+        TensorGraph &tg = g.tensor_graph();
+        TileGraph tile_graph = TileGraph::from_tensor_graph(tg);
+
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(input, input_data);
+        runtime.bind_data(grad_output_tensor, grad_out_data);
+        runtime.execute();
+        runtime.wait();
+
+        grad_input_result = runtime.get_output<float>(input->grad());
+    }
+
+    REQUIRE(grad_input_result.size() == grad_input_ref.size());
+    require_relative_frobenius_error(
+        grad_input_result, grad_input_ref, fx.backward_tol);
+}
+
+#endif

--- a/tests/graph/model/gptneox/gptneox_model.cc
+++ b/tests/graph/model/gptneox/gptneox_model.cc
@@ -1,0 +1,336 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file tests/graph/model/gptneox/gptneox_model.cc
+ * Tests for GptneoxModel.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/graph/model/gptneox/gptneox_model.hh"
+
+#include "context_fixture.hh"
+#include "nntile/graph.hh"
+#include "nntile/graph/io/safetensors.hh"
+#include "nntile/graph/model/gptneox/gptneox_config.hh"
+#include "test_frobenius.hh"
+#include "test_gptneox_fixture_helpers.hh"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+using namespace nntile;
+using namespace nntile::graph;
+using namespace nntile::model::gptneox;
+using namespace nntile::graph::io;
+
+#ifndef GPTNEOX_DATA_DIR
+
+TEST_CASE(
+    "GptneoxModel tests skipped (GPTNEOX_DATA_DIR undefined)", "[model][gptneox]")
+{
+    SKIP("GPTNEOX_DATA_DIR not defined at compile time.");
+}
+
+#else
+
+namespace model_fixture_stem
+{
+
+constexpr char gptneox_model[] = "gptneox_model";
+
+} // namespace model_fixture_stem
+
+namespace
+{
+
+using namespace nntile::test::gptneox_fixture;
+
+struct ModelFixtureSpec
+{
+    GptneoxConfig config{};
+    Index seq = 0;
+    Index batch = 0;
+    Index hidden = 0;
+    float forward_tol = 0.f;
+    float backward_tol = 0.f;
+    std::string stem;
+};
+
+inline bool try_load_model_fixture_spec(const std::string &data_dir,
+    const char *stem_cstr,
+    ModelFixtureSpec &out)
+{
+    out = {};
+    out.stem = stem_cstr;
+    const std::string jpath = data_dir + "/" + out.stem + ".json";
+    std::ifstream jf(jpath);
+    if (!jf)
+    {
+        return false;
+    }
+    nlohmann::json j;
+    try
+    {
+        jf >> j;
+        if (j.at("version").get<int>() != 2)
+        {
+            return false;
+        }
+        if (j.at("stem").get<std::string>() != out.stem)
+        {
+            return false;
+        }
+        const std::string expected_st = out.stem + ".safetensors";
+        if (j.at("safetensors").get<std::string>() != expected_st)
+        {
+            return false;
+        }
+        const auto &G = j.at("gptneox");
+        out.config.vocab_size = json_index(G, "vocab_size");
+        out.config.hidden_size = json_index(G, "hidden_size");
+        out.config.intermediate_size = json_index(G, "intermediate_size");
+        out.config.num_hidden_layers = json_index(G, "num_hidden_layers");
+        out.config.num_attention_heads = json_index(G, "num_attention_heads");
+        out.config.head_dim = json_index(G, "head_dim");
+        out.config.max_position_embeddings =
+            json_index(G, "max_position_embeddings");
+        if(G.contains("rotary_pct"))
+        {
+            out.config.rotary_pct =
+                static_cast<float>(G.at("rotary_pct").get<double>());
+        }
+        if(G.contains("rotary_emb_base"))
+        {
+            out.config.rotary_emb_base =
+                static_cast<float>(G.at("rotary_emb_base").get<double>());
+        }
+        out.hidden = out.config.hidden_size;
+        out.seq = json_index(j, "sequence_length");
+        out.batch = json_index(j, "batch");
+        out.forward_tol =
+            static_cast<float>(j.at("tolerances").at("forward").get<double>());
+        out.backward_tol = static_cast<float>(
+            j.at("tolerances").at("backward").get<double>());
+        out.config.validate();
+    }
+    catch (...)
+    {
+        return false;
+    }
+    prepare_gptneox_config(out.config);
+    return true;
+}
+
+inline std::string model_fixture_safetensors_path(
+    const std::string &data_dir, const ModelFixtureSpec &spec)
+{
+    return data_dir + "/" + spec.stem + ".safetensors";
+}
+
+inline bool skip_unless_fixture_ready(const char *stem, ModelFixtureSpec &fx)
+{
+    const std::string dir = std::string(GPTNEOX_DATA_DIR);
+    if (!try_load_model_fixture_spec(dir, stem, fx))
+    {
+        return false;
+    }
+    std::ifstream st(model_fixture_safetensors_path(dir, fx));
+    return st.good();
+}
+
+void model_backward_compare_ref(const ModelFixtureSpec &fx)
+{
+    const std::string full_path =
+        model_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+
+    std::vector<std::uint8_t> ids_bytes = reader.read_tensor("input_ids");
+    std::vector<std::int64_t> ids_data(ids_bytes.size() / sizeof(std::int64_t));
+    std::memcpy(ids_data.data(), ids_bytes.data(), ids_bytes.size());
+
+    std::vector<std::uint8_t> grad_out_bytes =
+        reader.read_tensor("grad_output");
+    std::vector<float> grad_out_data(grad_out_bytes.size() / sizeof(float));
+    std::memcpy(
+        grad_out_data.data(), grad_out_bytes.data(), grad_out_bytes.size());
+
+    std::vector<std::uint8_t> ref_embed_bytes =
+        reader.read_tensor("grad_embed_tokens_vocab");
+    std::vector<float> grad_embed_ref(ref_embed_bytes.size() / sizeof(float));
+    std::memcpy(
+        grad_embed_ref.data(), ref_embed_bytes.data(), ref_embed_bytes.size());
+
+    std::vector<float> grad_embed_result;
+    {
+        NNGraph g("model_bwd");
+        auto *input_ids =
+            g.tensor({fx.seq, fx.batch}, DataType::INT64, true)
+                ->set_name("input_ids");
+        GptneoxRopeInputs rope;
+        load_gptneox_rope_inputs(g, reader, fx.config, fx.seq, fx.batch, rope);
+        NNGraph::TensorNode *mask = nullptr;
+        std::vector<std::uint8_t> mask_bytes;
+        REQUIRE(load_attn_mask_bool(g, reader, fx.seq, mask, mask_bytes));
+
+        GptneoxModel model(&g, "model", fx.config);
+        model.load(full_path);
+        auto *output = model.forward(input_ids, rope.sin, rope.cos, mask);
+
+        input_ids->mark_input(true);
+        output->mark_output(true);
+        mark_rope_inputs(rope);
+        mark_mask_input(mask);
+
+        auto [grad_output_tensor, _] =
+            g.get_or_create_grad(output, "grad_output");
+        grad_output_tensor->mark_input(true);
+        output->backward();
+        model.embed_vocab_tensor()->grad()->mark_output(true);
+
+        TileGraph tile_graph = TileGraph::from_tensor_graph(g.tensor_graph());
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(input_ids, ids_data);
+        runtime.bind_data(grad_output_tensor, grad_out_data);
+        bind_rope_inputs(runtime, rope);
+        bind_mask_input(runtime, mask, mask_bytes);
+        runtime.execute();
+        runtime.wait();
+
+        grad_embed_result =
+            runtime.get_output<float>(model.embed_vocab_tensor()->grad());
+    }
+
+    REQUIRE(grad_embed_result.size() == grad_embed_ref.size());
+    require_relative_frobenius_error(
+        grad_embed_result, grad_embed_ref, fx.backward_tol);
+}
+
+
+} // namespace
+
+TEST_CASE("GptneoxModel forward builds output", "[model][gptneox]")
+{
+    ModelFixtureSpec fx;
+    if (!skip_unless_fixture_ready(model_fixture_stem::gptneox_model, fx))
+    {
+        SKIP("Missing or invalid gptneox_model.json / .safetensors.");
+    }
+    NNGraph g("gptneox_model");
+    GptneoxModel model(&g, "model", fx.config);
+    auto *input_ids =
+        g.tensor({fx.seq, fx.batch}, DataType::INT64)->set_name("input_ids");
+    auto *output = model.forward(input_ids, nullptr, nullptr, nullptr);
+
+    REQUIRE(output != nullptr);
+    REQUIRE(
+        output->shape() == std::vector<Index>({fx.hidden, fx.seq, fx.batch}));
+}
+
+TEST_CASE("GptneoxModel load from safetensors roundtrip", "[model][gptneox][io]")
+{
+    ModelFixtureSpec fx;
+    if (!skip_unless_fixture_ready(model_fixture_stem::gptneox_model, fx))
+    {
+        SKIP("Missing or invalid gptneox_model.json / .safetensors.");
+    }
+    const std::string data_path =
+        model_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+
+    NNGraph g1("load_graph");
+    GptneoxModel model1(&g1, "model", fx.config);
+    model1.load(data_path);
+
+    const std::string save_path =
+        "/tmp/nntile_gptneox_model_roundtrip.safetensors";
+    model1.save(save_path);
+
+    SafeTensorsReader reader(data_path);
+    SafeTensorsReader reader2(save_path);
+    for (const auto &name : reader2.tensor_names())
+    {
+        REQUIRE(reader.has_tensor(name));
+        REQUIRE(reader.read_tensor(name) == reader2.read_tensor(name));
+    }
+    std::remove(save_path.c_str());
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxModel forward matches PyTorch reference", "[model][gptneox]")
+{
+    ModelFixtureSpec fx;
+    if (!skip_unless_fixture_ready(model_fixture_stem::gptneox_model, fx))
+    {
+        SKIP("GPT-NeoX model fixture not found.");
+    }
+    const std::string full_path =
+        model_fixture_safetensors_path(std::string(GPTNEOX_DATA_DIR), fx);
+    SafeTensorsReader reader(full_path);
+
+    std::vector<std::uint8_t> ids_bytes = reader.read_tensor("input_ids");
+    std::vector<std::int64_t> ids_data(ids_bytes.size() / sizeof(std::int64_t));
+    std::memcpy(ids_data.data(), ids_bytes.data(), ids_bytes.size());
+
+    std::vector<float> result;
+    {
+        NNGraph g("model_ref");
+        auto *input_ids =
+            g.tensor({fx.seq, fx.batch}, DataType::INT64)->set_name("input_ids");
+        GptneoxRopeInputs rope;
+        load_gptneox_rope_inputs(g, reader, fx.config, fx.seq, fx.batch, rope);
+        NNGraph::TensorNode *mask = nullptr;
+        std::vector<std::uint8_t> mask_bytes;
+        REQUIRE(load_attn_mask_bool(g, reader, fx.seq, mask, mask_bytes));
+
+        GptneoxModel model(&g, "model", fx.config);
+        model.load(full_path);
+
+        auto *output = model.forward(input_ids, rope.sin, rope.cos, mask);
+        input_ids->mark_input(true);
+        output->mark_output(true);
+        mark_rope_inputs(rope);
+        mark_mask_input(mask);
+
+        TileGraph tile_graph = TileGraph::from_tensor_graph(g.tensor_graph());
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(input_ids, ids_data);
+        bind_rope_inputs(runtime, rope);
+        bind_mask_input(runtime, mask, mask_bytes);
+        runtime.execute();
+        runtime.wait();
+
+        result = runtime.get_output<float>(output);
+    }
+
+    std::vector<std::uint8_t> ref_bytes = reader.read_tensor("output_ref");
+    std::vector<float> ref_data(ref_bytes.size() / sizeof(float));
+    std::memcpy(ref_data.data(), ref_bytes.data(), ref_bytes.size());
+
+    REQUIRE(result.size() == ref_data.size());
+    require_relative_frobenius_error(result, ref_data, fx.forward_tol);
+}
+
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "GptneoxModel backward matches PyTorch reference",
+    "[model][gptneox]")
+{
+    ModelFixtureSpec fx;
+    if (!skip_unless_fixture_ready(model_fixture_stem::gptneox_model, fx))
+    {
+        SKIP("GPT-NeoX model fixture not found.");
+    }
+    model_backward_compare_ref(fx);
+}
+
+#endif

--- a/tests/graph/model/test_gptneox_fixture_helpers.hh
+++ b/tests/graph/model/test_gptneox_fixture_helpers.hh
@@ -1,0 +1,174 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file tests/graph/model/test_gptneox_fixture_helpers.hh
+ * Shared JSON, RoPE, and attention-mask helpers for GPT-NeoX graph model tests.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <nlohmann/json.hpp>
+#include <nntile/graph.hh>
+#include <nntile/graph/io/safetensors.hh>
+#include <nntile/graph/model/gptneox/gptneox_config.hh>
+#include <nntile/graph/model/gptneox/gptneox_rope.hh>
+#include <stdexcept>
+#include <vector>
+
+namespace nntile::test::gptneox_fixture
+{
+
+inline void prepare_gptneox_config(model::gptneox::GptneoxConfig &cfg)
+{
+    cfg.compute_head_dim();
+    cfg.validate();
+}
+
+inline Index json_index(const nlohmann::json &o, const char *key)
+{
+    return static_cast<Index>(o.at(key).get<std::int64_t>());
+}
+
+struct GptneoxRopeInputs
+{
+    nntile::graph::NNGraph::TensorNode *sin = nullptr;
+    nntile::graph::NNGraph::TensorNode *cos = nullptr;
+    std::vector<float> sin_data;
+    std::vector<float> cos_data;
+};
+
+inline bool load_gptneox_rope_inputs(
+    nntile::graph::NNGraph &g,
+    const nntile::graph::io::SafeTensorsReader &reader,
+    const nntile::model::gptneox::GptneoxConfig &config,
+    Index n_seq,
+    Index n_batch,
+    GptneoxRopeInputs &out)
+{
+    out = {};
+    if(!reader.has_tensor("rope_sin") || !reader.has_tensor("rope_cos"))
+    {
+        return false;
+    }
+    const Index rope_dim = nntile::model::gptneox::gptneox_rope_dim(config);
+    const Index half = rope_dim / 2;
+    if(half <= 0)
+    {
+        return false;
+    }
+    out.sin = g.tensor({half, n_seq, n_batch}, nntile::graph::DataType::FP32)
+                  ->set_name("rope_sin");
+    out.cos = g.tensor({half, n_seq, n_batch}, nntile::graph::DataType::FP32)
+                  ->set_name("rope_cos");
+    auto read_f = [&](const char *name, std::vector<float> &dst)
+    {
+        std::vector<std::uint8_t> b = reader.read_tensor(name);
+        dst.resize(b.size() / sizeof(float));
+        std::memcpy(dst.data(), b.data(), b.size());
+    };
+    read_f("rope_sin", out.sin_data);
+    read_f("rope_cos", out.cos_data);
+    return true;
+}
+
+inline void mark_rope_inputs(const GptneoxRopeInputs &rope)
+{
+    if(rope.sin == nullptr)
+    {
+        return;
+    }
+    rope.sin->mark_input(true);
+    rope.cos->mark_input(true);
+}
+
+inline void bind_rope_inputs(
+    nntile::graph::Runtime &runtime, const GptneoxRopeInputs &rope)
+{
+    if(rope.sin == nullptr)
+    {
+        return;
+    }
+    runtime.bind_data(rope.sin, rope.sin_data);
+    runtime.bind_data(rope.cos, rope.cos_data);
+}
+
+inline bool load_attn_mask_bool(nntile::graph::NNGraph &g,
+    const nntile::graph::io::SafeTensorsReader &reader,
+    Index n_seq,
+    nntile::graph::NNGraph::TensorNode *&out_mask,
+    std::vector<std::uint8_t> &mask_bytes)
+{
+    out_mask = nullptr;
+    mask_bytes.clear();
+    if(!reader.has_tensor("attn_mask"))
+    {
+        return false;
+    }
+    const auto &info = reader.tensor_info("attn_mask");
+    if(info.shape.size() != 2 || info.shape[0] != n_seq ||
+       info.shape[1] != n_seq)
+    {
+        throw std::runtime_error(
+            "GPT-NeoX test fixture: attn_mask shape mismatch");
+    }
+    const auto n_el = static_cast<size_t>(n_seq * n_seq);
+    out_mask = g.tensor({n_seq, n_seq}, nntile::graph::DataType::BOOL, false)
+                   ->set_name("attn_mask");
+    auto raw = reader.read_tensor("attn_mask");
+    if(info.dtype == nntile::graph::DataType::BOOL)
+    {
+        if(raw.size() != n_el)
+        {
+            throw std::runtime_error(
+                "GPT-NeoX test fixture: BOOL attn_mask byte size mismatch");
+        }
+        mask_bytes = std::move(raw);
+        return true;
+    }
+    if(info.dtype == nntile::graph::DataType::FP32)
+    {
+        if(raw.size() != n_el * sizeof(float))
+        {
+            throw std::runtime_error(
+                "GPT-NeoX test fixture: F32 attn_mask byte size mismatch");
+        }
+        mask_bytes.resize(n_el);
+        const auto *p = reinterpret_cast<const float *>(raw.data());
+        for(size_t i = 0; i < n_el; ++i)
+        {
+            mask_bytes[i] = (p[i] > 0.5f) ? static_cast<std::uint8_t>(1)
+                                          : static_cast<std::uint8_t>(0);
+        }
+        return true;
+    }
+    throw std::runtime_error(
+        "GPT-NeoX test fixture: attn_mask must be BOOL or F32");
+}
+
+inline void mark_mask_input(nntile::graph::NNGraph::TensorNode *mask)
+{
+    if(mask != nullptr)
+    {
+        mask->mark_input(true);
+    }
+}
+
+inline void bind_mask_input(nntile::graph::Runtime &runtime,
+    nntile::graph::NNGraph::TensorNode *mask,
+    const std::vector<std::uint8_t> &mask_bytes)
+{
+    if(mask == nullptr)
+    {
+        return;
+    }
+    runtime.bind_data(mask, mask_bytes);
+}
+
+} // namespace nntile::test::gptneox_fixture


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GPT-NeoX graph model, tests, training/generation examples, and graph fixes.

**Decoder (`gptneox_decoder.cc`):** Parallel residual no longer builds `post_attn = x + attn_out` before the final sum; it accumulates `attn_out + mlp_out` then adds `x`. Sequential path still uses `post_attn` for `ln2(post_attn)`.

**Generation / conversion:** RoPE + causal mask in `gpt_neox_generate.cc`; MLP biases in `gpt_neox_generate.py`.

**Earlier:** C++ MLP biases, NNTile RoPE test refs, layer-0 fixture weights.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e67a1f49-d72f-4caa-b713-ae93b397d7cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e67a1f49-d72f-4caa-b713-ae93b397d7cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

