### PR TITLE
Tighten graph model test tolerances and add RoBERTa training demo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -54,6 +54,14 @@ cmake --build build --target t5_graph_training t5_generate
 ./examples/run_t5_graph_training_demo.sh
 ```
 
+**BERT / RoBERTa** (in-process toy MLM batches; no `train.bin`)
+
+```bash
+cmake --build build --target bert_graph_training roberta_graph_training
+./examples/run_bert_graph_training_demo.sh
+./examples/run_roberta_graph_training_demo.sh
+```
+
 Each script writes data under `build/examples/demo_data/<model>/` and prints a
 short loss summary (first vs last step). Tune without editing the script:
 
@@ -201,6 +209,22 @@ Or let the binary invoke the Python converter:
     --model EleutherAI/gpt-neo-125M \
     --prompt "Hello" \
     --max-tokens 16
+```
+
+## RoBERTa
+
+| Artifact | Role |
+|----------|------|
+| `roberta_graph_training` | Tiny MLM training + save/load checkpoint (graph API) |
+| `run_roberta_graph_training_demo.sh` | Runs training and prints scratch / best / loaded losses |
+| `roberta_graph_training.cc` | Same flow as `bert_graph_training` (fixed toy batch) |
+| `roberta_mlm_inference` | Forward-only MLM smoke test |
+
+Example:
+
+```bash
+cmake --build build --target roberta_graph_training
+./examples/run_roberta_graph_training_demo.sh
 ```
 
 ## T5

--- a/examples/run_roberta_graph_training_demo.sh
+++ b/examples/run_roberta_graph_training_demo.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#                2023-present Artificial Intelligence Research Institute
+#                              (AIRI), Russia. All rights reserved.
+#
+# @file examples/run_roberta_graph_training_demo.sh
+# Tiny RoBERTa MLM graph training, then checkpoint load on the same batch.
+#
+# Usage (from repo root, after building roberta_graph_training):
+#   ./examples/run_roberta_graph_training_demo.sh
+#
+# Optional environment variables:
+#   BUILD_DIR  CMake build directory (default: <repo>/build)
+#   DATA_DIR   Where to write training.log (default: <build>/examples/demo_data/roberta)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=demo_common.sh
+source "${SCRIPT_DIR}/demo_common.sh"
+
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="$(demo_resolve_build_dir "${REPO_ROOT}")"
+DATA_DIR="${DATA_DIR:-${BUILD_DIR}/examples/demo_data/roberta}"
+LOG_FILE="${DATA_DIR}/training.log"
+BIN="${BUILD_DIR}/examples/roberta_graph_training"
+
+demo_require_executable "${BIN}" "roberta_graph_training"
+
+echo "=== RoBERTa graph training demo ==="
+echo "Build dir:  ${BUILD_DIR}"
+echo "Data dir:   ${DATA_DIR}"
+echo ""
+
+mkdir -p "${DATA_DIR}"
+"${BIN}" 2>&1 | tee "${LOG_FILE}"
+
+echo ""
+echo "--- Loss summary ---"
+python3 - "${LOG_FILE}" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+losses = []
+scratch = best = loaded = None
+for line in open(path, encoding="utf-8", errors="replace"):
+    m = re.search(r"^Batch \d+\s+loss=([0-9.eE+-]+)", line)
+    if m:
+        losses.append(float(m.group(1)))
+    m = re.search(r"Scratch first loss=([0-9.eE+-]+)", line)
+    if m:
+        scratch = float(m.group(1))
+    m = re.search(r"best training loss=([0-9.eE+-]+)", line)
+    if m:
+        best = float(m.group(1))
+    m = re.search(r"Loaded checkpoint loss=([0-9.eE+-]+)", line)
+    if m:
+        loaded = float(m.group(1))
+if losses:
+    print(f"Training steps: {len(losses)}")
+    print(f"First batch loss: {losses[0]:.6f}")
+    print(f"Last batch loss:  {losses[-1]:.6f}")
+if scratch is not None:
+    print(f"Scratch first loss:     {scratch:.6f}")
+if best is not None:
+    print(f"Best training loss:     {best:.6f}")
+if loaded is not None:
+    print(f"Loaded checkpoint loss: {loaded:.6f}")
+if scratch is not None and best is not None and best < scratch:
+    print("Loss decreased over training (demo OK).")
+elif losses and losses[-1] < losses[0]:
+    print("Loss decreased over training (demo OK).")
+else:
+    print("Warning: loss did not decrease as expected.")
+PY

--- a/tests/graph/model/bert/generate_test_data.py
+++ b/tests/graph/model/bert/generate_test_data.py
@@ -452,7 +452,7 @@ def main() -> int:
     save_file(data, bundle_path)
     print(f"Saved {bundle_path}")
 
-    tol = 2e-5
+    tol = 1e-6
     if args.block == "intermediate":
         write_fixture_json(out, stem, INTERMEDIATE_DIMS, tol, tol)
     elif args.block == "attention":

--- a/tests/graph/model/gpt2/generate_test_data.py
+++ b/tests/graph/model/gpt2/generate_test_data.py
@@ -476,14 +476,15 @@ def main() -> int:
     save_file(data, bundle_path)
     print(f"Saved {bundle_path}")
 
+    tol = 1e-6
     if args.block == "mlp":
-        write_fixture_json(out, stem, MLP_DIMS, 2e-5, 2e-5)
+        write_fixture_json(out, stem, MLP_DIMS, tol, tol)
     elif args.block in ("attention", "attention_causal"):
-        write_fixture_json(out, stem, ATTENTION_DIMS, 2e-5, 2e-5)
+        write_fixture_json(out, stem, ATTENTION_DIMS, tol, tol)
     elif args.block == "block":
-        write_fixture_json(out, stem, BLOCK_DIMS, 2e-5, 2e-5)
+        write_fixture_json(out, stem, BLOCK_DIMS, tol, tol)
     elif args.block in ("model", "causal"):
-        write_fixture_json(out, stem, MODEL_DIMS, 2e-5, 2e-5)
+        write_fixture_json(out, stem, MODEL_DIMS, tol, tol)
 
     return 0
 

--- a/tests/graph/model/gptneo/generate_test_data.py
+++ b/tests/graph/model/gptneo/generate_test_data.py
@@ -577,14 +577,15 @@ def main() -> int:
     save_file(data, bundle_path)
     print(f"Saved {bundle_path}")
 
+    tol = 1e-6
     if args.block == "mlp":
-        write_fixture_json(out, stem, MLP_DIMS, 2e-5, 2e-5)
+        write_fixture_json(out, stem, MLP_DIMS, tol, tol)
     elif args.block in ("attention", "attention_causal", "attention_local"):
-        write_fixture_json(out, stem, ATTENTION_DIMS, 2e-5, 2e-5)
+        write_fixture_json(out, stem, ATTENTION_DIMS, tol, tol)
     elif args.block == "decoder":
-        write_fixture_json(out, stem, DECODER_DIMS, 2e-5, 2e-5)
+        write_fixture_json(out, stem, DECODER_DIMS, tol, tol)
     elif args.block in ("model", "causal"):
-        write_fixture_json(out, stem, MODEL_DIMS, 2e-5, 2e-5)
+        write_fixture_json(out, stem, MODEL_DIMS, tol, tol)
 
     return 0
 

--- a/tests/graph/model/gptneox/generate_test_data.py
+++ b/tests/graph/model/gptneox/generate_test_data.py
@@ -674,16 +674,14 @@ def main() -> int:
     print(f"Saved {bundle_path}")
 
     if args.block == "mlp":
-        write_fixture_json(out, stem, MLP_DIMS, 2e-5, 2e-5)
+        write_fixture_json(out, stem, MLP_DIMS, 1e-6, 1e-6)
     elif args.block in ("attention", "attention_causal"):
-        # SDPA/RoPE vs PyTorch eager can differ slightly at tight tol.
+        # RoPE + ``sdpa_eager`` vs PyTorch SDPA (~3e-3 rel. Frobenius).
         write_fixture_json(out, stem, ATTENTION_DIMS, 5e-3, 5e-3)
     elif args.block == "decoder":
-        # Full block stacks LN, RoPE, masked SDPA, and biased MLP;
-        # allow slightly more slack on forward than standalone attention.
-        write_fixture_json(out, stem, DECODER_DIMS, 2e-2, 5e-3)
+        write_fixture_json(out, stem, DECODER_DIMS, 1.6e-2, 5e-3)
     elif args.block in ("model", "causal"):
-        write_fixture_json(out, stem, MODEL_DIMS, 2e-2, 2e-2)
+        write_fixture_json(out, stem, MODEL_DIMS, 1.2e-2, 1.2e-2)
 
     return 0
 

--- a/tests/graph/model/roberta/generate_test_data.py
+++ b/tests/graph/model/roberta/generate_test_data.py
@@ -483,7 +483,7 @@ def main() -> int:
     save_file(data, bundle_path)
     print(f"Saved {bundle_path}")
 
-    tol = 2e-5
+    tol = 1e-6
     if args.block == "intermediate":
         write_fixture_json(out, stem, INTERMEDIATE_DIMS, tol, tol)
     elif args.block == "attention":

--- a/tests/graph/model/t5/generate_test_data.py
+++ b/tests/graph/model/t5/generate_test_data.py
@@ -864,7 +864,7 @@ def main() -> int:
     save_file(data, bundle_path)
     print(f"Saved {bundle_path}")
 
-    tol = 2e-5
+    tol = 1e-6
     if args.block == "ff":
         write_fixture_json(out, stem, FF_DIMS, tol, tol)
     elif args.block in ("attention", "attention_causal"):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tightens relative Frobenius error thresholds in graph model C++ test fixtures (except Llama) and adds a RoBERTa graph training demo script.

## Test tolerances

| Model | Previous | New |
|-------|----------|-----|
| GPT-2, GPT-Neo, BERT, RoBERTa, T5 | 2e-5 | **1e-6** |
| GPT-NeoX MLP | 2e-5 | **1e-6** |
| GPT-NeoX attention | 5e-3 | 5e-3 (unchanged; ~3e-3 observed vs PyTorch SDPA) |
| GPT-NeoX decoder | 2e-2 / 5e-3 | **1.6e-2** / 5e-3 |
| GPT-NeoX model / causal | 2e-2 | **1.2e-2** |
| Llama | 1e-6 | unchanged |

All 79 non-Llama graph model CTest targets pass after regenerating fixtures at test time.

## RoBERTa demo

- New `examples/run_roberta_graph_training_demo.sh` (mirrors BERT: tiny MLM training, checkpoint save/load, loss summary)
- Documented in `examples/README.md` with BERT quick-start entry

## Verification

```bash
ctest -R 'tests_graph_model_(gpt2|gptneo|gptneox|bert|roberta|t5)'
./examples/run_roberta_graph_training_demo.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a319074-747e-46f0-8ec5-6bc84bc4fb1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a319074-747e-46f0-8ec5-6bc84bc4fb1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

