### PR TITLE
Add tiling.json support for GPT-2 graph training

### DIFF
--- a/nntile/examples/README.md
+++ b/nntile/examples/README.md
@@ -9,6 +9,8 @@ incremental training phases) and small Llama / GPT-2 workflows.
 - `json_config_helpers.hh` — `config_get_int` / `config_get_float` for JSON configs
   (used by GPT-2 and Llama graph examples).
 - `gpt2_config_json.hh` — `load_gpt2_config_json` / `save_gpt2_config_json` (HF + NNTile keys).
+- `tiling_config_json.hh` — `load_tiling_json` / `save_tiling_json` (`default` + `layers` in `tiling.json`).
+- `gpt2_axis_naming.hh` — name axis groups for GPT-2 graph training before applying tiling.
 - `t5_config_json.hh` — `load_t5_config_json` / `save_t5_config_json` for T5 graph examples.
 - `gptneo_config_json.hh` — load/save for examples; HF `attention_types` parsing lives in `include/nntile/model/gptneo/gptneo_config_json.hh`.
 
@@ -150,6 +152,32 @@ Example (manual training):
 ./build/examples/gpt2_graph_training \
     --train-bin build/examples/demo_data/gpt2/train.bin \
     --tiny --seq 8 --batch 2 --epochs 3 --max-batches 24 --lr 0.003
+```
+
+Tiling uses a separate **`tiling.json`** (axis keys match `config.json` plus `seq_len` / `batch_size` for `--seq` / `--batch`):
+
+```json
+{
+  "default": {
+    "batch_size": 1,
+    "seq_len": [4, 4],
+    "hidden_size": 32,
+    "intermediate_size": [64, 64]
+  },
+  "layers": {
+    "h_1": { "intermediate_size": [40, 88] }
+  }
+}
+```
+
+Demo configs: `examples/demo_configs/gpt2_tiny_config.json` and `gpt2_tiny_tiling.json`.
+
+```bash
+./build/examples/gpt2_graph_training \
+    --train-bin build/examples/demo_data/gpt2/train.bin \
+    --config examples/demo_configs/gpt2_tiny_config.json \
+    --tiling examples/demo_configs/gpt2_tiny_tiling.json \
+    --seq 8 --batch 2 --epochs 2 --max-batches 8
 ```
 
 Example (generation):

--- a/nntile/examples/demo_configs/gpt2_tiny_config.json
+++ b/nntile/examples/demo_configs/gpt2_tiny_config.json
@@ -1,0 +1,11 @@
+{
+  "vocab_size": 256,
+  "hidden_size": 64,
+  "intermediate_size": 128,
+  "num_hidden_layers": 2,
+  "num_attention_heads": 4,
+  "max_position_embeddings": 512,
+  "layer_norm_eps": 1e-5,
+  "eos_token_id": 255,
+  "bos_token_id": 255
+}

--- a/nntile/examples/demo_configs/gpt2_tiny_tiling.json
+++ b/nntile/examples/demo_configs/gpt2_tiny_tiling.json
@@ -1,0 +1,18 @@
+{
+  "default": {
+    "batch_size": 1,
+    "seq_len": [4, 4],
+    "hidden_size": 32,
+    "intermediate_size": [64, 64],
+    "num_attention_heads": 2
+  },
+  "layers": {
+    "h_0": {
+      "intermediate_size": [32, 32, 32, 32]
+    },
+    "h_1": {
+      "intermediate_size": [40, 88],
+      "num_attention_heads": 4
+    }
+  }
+}

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -124,6 +124,12 @@ inline bool axis_group_looks_like_seq(AxisDescriptor const *ad)
     return false;
 }
 
+//! Training tensors named by ``seq_len`` / ``batch_size``, not config keys.
+inline bool axis_group_is_runtime_training_io(AxisDescriptor const *ad)
+{
+    return axis_group_looks_like_seq(ad) || axis_group_looks_like_batch(ad);
+}
+
 inline void name_gpt2_layer_local_axis_groups(
     TensorGraph &tg,
     model::gpt2::Gpt2Config const &cfg)
@@ -220,18 +226,21 @@ inline void name_gpt2_global_axis_groups(
                 }
             }
         }
-        if (ad->extent == cfg.vocab_size)
+        if (ad->extent == cfg.vocab_size &&
+            !axis_group_is_runtime_training_io(ad))
         {
             ad->name = "vocab_size";
             continue;
         }
         if (ad->extent == cfg.hidden_size &&
-            !axis_group_member_name_contains(ad, "_attn_"))
+            !axis_group_member_name_contains(ad, "_attn_") &&
+            !axis_group_is_runtime_training_io(ad))
         {
             ad->name = "hidden_size";
             continue;
         }
-        if (ad->extent == cfg.max_position_embeddings)
+        if (ad->extent == cfg.max_position_embeddings &&
+            !axis_group_is_runtime_training_io(ad))
         {
             ad->name = "max_position_embeddings";
             continue;

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -130,6 +130,89 @@ inline bool axis_group_is_runtime_training_io(AxisDescriptor const *ad)
     return axis_group_looks_like_seq(ad) || axis_group_looks_like_batch(ad);
 }
 
+//! Per-layer axis role from MLP parameter layout (``Linear`` is in×out).
+inline std::optional<std::string> gpt2_mlp_layer_axis_role(
+    std::string const &tname,
+    size_t axis_idx,
+    model::gpt2::Gpt2Config const &cfg,
+    Index extent)
+{
+    if (tname.find("_mlp_") == std::string::npos)
+    {
+        return std::nullopt;
+    }
+    bool const is_fc1 = tname.find("fc1") != std::string::npos;
+    bool const is_fc2 = tname.find("fc2") != std::string::npos;
+    if (!is_fc1 && !is_fc2)
+    {
+        return std::nullopt;
+    }
+    if (tname.find("bias") != std::string::npos)
+    {
+        if (is_fc1 && extent == cfg.intermediate_size)
+        {
+            return "intermediate_size";
+        }
+        return std::nullopt;
+    }
+    if (tname.find("weight") == std::string::npos)
+    {
+        return std::nullopt;
+    }
+    if (is_fc1 && axis_idx == 1 && extent == cfg.intermediate_size)
+    {
+        return "intermediate_size";
+    }
+    if (is_fc2 && axis_idx == 0 && extent == cfg.intermediate_size)
+    {
+        return "intermediate_size";
+    }
+    return std::nullopt;
+}
+
+//! Per-layer axis role from attention parameter layout.
+inline std::optional<std::string> gpt2_attn_layer_axis_role(
+    std::string const &tname,
+    size_t axis_idx,
+    model::gpt2::Gpt2Config const &cfg,
+    Index extent)
+{
+    if (tname.find("_attn_") == std::string::npos ||
+        extent != cfg.num_attention_heads)
+    {
+        return std::nullopt;
+    }
+    if (tname.find("q_weight") != std::string::npos ||
+        tname.find("k_weight") != std::string::npos ||
+        tname.find("v_weight") != std::string::npos)
+    {
+        if (axis_idx == 0)
+        {
+            return "num_attention_heads";
+        }
+        return std::nullopt;
+    }
+    if (tname.find("o_weight") != std::string::npos)
+    {
+        if (axis_idx == 1)
+        {
+            return "num_attention_heads";
+        }
+        return std::nullopt;
+    }
+    if (tname.find("q_bias") != std::string::npos ||
+        tname.find("k_bias") != std::string::npos ||
+        tname.find("v_bias") != std::string::npos)
+    {
+        if (axis_idx == 1)
+        {
+            return "num_attention_heads";
+        }
+        return std::nullopt;
+    }
+    return std::nullopt;
+}
+
 inline void name_gpt2_layer_local_axis_groups(
     TensorGraph &tg,
     model::gpt2::Gpt2Config const &cfg)
@@ -140,53 +223,47 @@ inline void name_gpt2_layer_local_axis_groups(
         {
             continue;
         }
-        if (ad->extent != cfg.intermediate_size &&
-            ad->extent != cfg.num_attention_heads)
-        {
-            continue;
-        }
         std::optional<Index> layer_idx;
-        bool is_mlp = false;
-        bool is_attn = false;
+        std::optional<std::string> axis_role;
         for (auto const &[node_ptr, axis_idx] : ad->members)
         {
-            (void) axis_idx;
             auto *node = static_cast<TensorGraph::TensorNode *>(node_ptr);
             std::string const &tname = node->name();
-            if (tname.find("_mlp_") != std::string::npos)
-            {
-                is_mlp = true;
-            }
-            if (tname.find("_attn_") != std::string::npos)
-            {
-                is_attn = true;
-            }
             auto parsed = parse_h_layer_index_from_tensor_name(tname);
             if (parsed.has_value())
             {
                 if (layer_idx.has_value() && *layer_idx != *parsed)
                 {
                     layer_idx = std::nullopt;
+                    axis_role = std::nullopt;
                     break;
                 }
                 layer_idx = parsed;
             }
+            std::optional<std::string> role = gpt2_mlp_layer_axis_role(
+                tname, axis_idx, cfg, ad->extent);
+            if (!role.has_value())
+            {
+                role = gpt2_attn_layer_axis_role(
+                    tname, axis_idx, cfg, ad->extent);
+            }
+            if (!role.has_value())
+            {
+                axis_role = std::nullopt;
+                break;
+            }
+            if (axis_role.has_value() && *axis_role != *role)
+            {
+                axis_role = std::nullopt;
+                break;
+            }
+            axis_role = role;
         }
-        if (!layer_idx.has_value())
+        if (!layer_idx.has_value() || !axis_role.has_value())
         {
             continue;
         }
-        if (is_mlp && ad->extent == cfg.intermediate_size)
-        {
-            ad->name = "layer." + std::to_string(*layer_idx) +
-                       ".intermediate_size";
-            continue;
-        }
-        if (is_attn && ad->extent == cfg.num_attention_heads)
-        {
-            ad->name = "layer." + std::to_string(*layer_idx) +
-                       ".num_attention_heads";
-        }
+        ad->name = "layer." + std::to_string(*layer_idx) + "." + *axis_role;
     }
 }
 

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -50,45 +50,56 @@ inline std::optional<Index> parse_h_layer_index_from_tensor_name(
     return idx;
 }
 
-inline void name_gpt2_training_axis_groups(
-    TensorGraph &tg,
-    model::gpt2::Gpt2Config const &cfg,
-    Index seq_len,
-    Index batch_size)
+inline bool axis_group_member_name_contains(
+    AxisDescriptor const *ad,
+    char const *needle)
 {
-    for (AxisDescriptor *ad : tg.axis_groups())
+    for (auto const &[node_ptr, axis_idx] : ad->members)
     {
-        if (!ad->name.empty())
+        (void) axis_idx;
+        auto *node = static_cast<TensorGraph::TensorNode const *>(node_ptr);
+        if (node->name().find(needle) != std::string::npos)
         {
-            continue;
-        }
-        if (ad->extent == batch_size)
-        {
-            ad->name = "batch_size";
-            continue;
-        }
-        if (ad->extent == seq_len)
-        {
-            ad->name = "seq_len";
-            continue;
-        }
-        if (ad->extent == cfg.vocab_size)
-        {
-            ad->name = "vocab_size";
-            continue;
-        }
-        if (ad->extent == cfg.hidden_size)
-        {
-            ad->name = "hidden_size";
-            continue;
-        }
-        if (ad->extent == cfg.max_position_embeddings)
-        {
-            ad->name = "max_position_embeddings";
-            continue;
+            return true;
         }
     }
+    return false;
+}
 
+inline bool axis_group_looks_like_batch(AxisDescriptor const *ad)
+{
+    if (axis_group_member_name_contains(ad, "_attn_"))
+    {
+        return false;
+    }
+    if (axis_group_member_name_contains(ad, "input_ids") ||
+        axis_group_member_name_contains(ad, "labels") ||
+        axis_group_member_name_contains(ad, "position_ids"))
+    {
+        return true;
+    }
+    return !axis_group_member_name_contains(ad, "_h_");
+}
+
+inline bool axis_group_looks_like_seq(AxisDescriptor const *ad)
+{
+    if (axis_group_member_name_contains(ad, "attn_mask"))
+    {
+        return true;
+    }
+    if (axis_group_member_name_contains(ad, "input_ids") ||
+        axis_group_member_name_contains(ad, "labels") ||
+        axis_group_member_name_contains(ad, "position_ids"))
+    {
+        return true;
+    }
+    return !axis_group_member_name_contains(ad, "_attn_");
+}
+
+inline void name_gpt2_layer_local_axis_groups(
+    TensorGraph &tg,
+    model::gpt2::Gpt2Config const &cfg)
+{
     for (AxisDescriptor *ad : tg.axis_groups())
     {
         if (!ad->name.empty())
@@ -138,6 +149,58 @@ inline void name_gpt2_training_axis_groups(
                        ".num_attention_heads";
         }
     }
+}
+
+inline void name_gpt2_global_axis_groups(
+    TensorGraph &tg,
+    model::gpt2::Gpt2Config const &cfg,
+    Index seq_len,
+    Index batch_size)
+{
+    for (AxisDescriptor *ad : tg.axis_groups())
+    {
+        if (!ad->name.empty())
+        {
+            continue;
+        }
+        if (ad->extent == batch_size && batch_size > 0 &&
+            axis_group_looks_like_batch(ad))
+        {
+            ad->name = "batch_size";
+            continue;
+        }
+        if (ad->extent == seq_len && seq_len > 0 &&
+            axis_group_looks_like_seq(ad))
+        {
+            ad->name = "seq_len";
+            continue;
+        }
+        if (ad->extent == cfg.vocab_size)
+        {
+            ad->name = "vocab_size";
+            continue;
+        }
+        if (ad->extent == cfg.hidden_size &&
+            !axis_group_member_name_contains(ad, "_attn_"))
+        {
+            ad->name = "hidden_size";
+            continue;
+        }
+        if (ad->extent == cfg.max_position_embeddings)
+        {
+            ad->name = "max_position_embeddings";
+        }
+    }
+}
+
+inline void name_gpt2_training_axis_groups(
+    TensorGraph &tg,
+    model::gpt2::Gpt2Config const &cfg,
+    Index seq_len,
+    Index batch_size)
+{
+    name_gpt2_layer_local_axis_groups(tg, cfg);
+    name_gpt2_global_axis_groups(tg, cfg, seq_len, batch_size);
 }
 
 } // namespace nntile::examples

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -330,17 +330,17 @@ inline void name_gpt2_global_axis_groups(
                 }
             }
         }
-        if (ad->extent == cfg.vocab_size &&
-            !axis_group_is_runtime_training_io(ad))
-        {
-            ad->name = "vocab_size";
-            continue;
-        }
         auto const wpe_axis = axis_group_wpe_axis_index(ad);
         if (wpe_axis.has_value() && *wpe_axis == 0 &&
             ad->extent == cfg.max_position_embeddings)
         {
             ad->name = "max_position_embeddings";
+            continue;
+        }
+        if (ad->extent == cfg.vocab_size &&
+            !axis_group_is_runtime_training_io(ad) && !wpe_axis.has_value())
+        {
+            ad->name = "vocab_size";
             continue;
         }
         if (ad->extent == cfg.hidden_size &&

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -14,6 +14,7 @@
 #include <nntile/base_types.hh>
 #include <nntile/model/gpt2/gpt2_config.hh>
 #include <nntile/tensor/axis_descriptor.hh>
+#include <nntile/tensor/graph_data_node.hh>
 #include <nntile/tensor/graph_decl.hh>
 
 #include <cctype>

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -14,8 +14,7 @@
 #include <nntile/base_types.hh>
 #include <nntile/model/gpt2/gpt2_config.hh>
 #include <nntile/tensor/axis_descriptor.hh>
-#include <nntile/tensor/graph_data_node.hh>
-#include <nntile/tensor/graph_decl.hh>
+#include <nntile/tensor/graph.hh>
 
 #include <cctype>
 #include <optional>

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -107,6 +107,10 @@ inline bool axis_group_looks_like_batch(AxisDescriptor const *ad)
 
 inline bool axis_group_looks_like_seq(AxisDescriptor const *ad)
 {
+    if (axis_group_member_name_contains(ad, "_h_"))
+    {
+        return false;
+    }
     if (axis_group_member_name_contains(ad, "attn_mask"))
     {
         return true;
@@ -117,7 +121,7 @@ inline bool axis_group_looks_like_seq(AxisDescriptor const *ad)
     {
         return true;
     }
-    return !axis_group_member_name_contains(ad, "_attn_");
+    return false;
 }
 
 inline void name_gpt2_layer_local_axis_groups(
@@ -154,6 +158,11 @@ inline void name_gpt2_layer_local_axis_groups(
             auto parsed = parse_h_layer_index_from_tensor_name(tname);
             if (parsed.has_value())
             {
+                if (layer_idx.has_value() && *layer_idx != *parsed)
+                {
+                    layer_idx = std::nullopt;
+                    break;
+                }
                 layer_idx = parsed;
             }
         }
@@ -217,12 +226,6 @@ inline void name_gpt2_global_axis_groups(
             ad->name = "batch_size";
             continue;
         }
-        if (ad->extent == seq_len && seq_len > 0 &&
-            axis_group_looks_like_seq(ad))
-        {
-            ad->name = "seq_len";
-            continue;
-        }
         if (ad->extent == cfg.vocab_size)
         {
             ad->name = "vocab_size";
@@ -232,6 +235,12 @@ inline void name_gpt2_global_axis_groups(
             !axis_group_member_name_contains(ad, "_attn_"))
         {
             ad->name = "hidden_size";
+            continue;
+        }
+        if (ad->extent == seq_len && seq_len > 0 &&
+            axis_group_looks_like_seq(ad))
+        {
+            ad->name = "seq_len";
             continue;
         }
         if (ad->extent == cfg.max_position_embeddings)

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -157,6 +157,33 @@ inline std::optional<size_t> axis_group_wpe_axis_index(
     return idx;
 }
 
+//! Axis index on ``wte`` embedding members, if consistent.
+inline std::optional<size_t> axis_group_wte_axis_index(
+    AxisDescriptor const *ad)
+{
+    std::optional<size_t> idx;
+    bool saw_wte = false;
+    for (auto const &[node_ptr, axis_idx] : ad->members)
+    {
+        auto *node = static_cast<TensorGraph::TensorNode const *>(node_ptr);
+        if (node->name().find("wte") == std::string::npos)
+        {
+            continue;
+        }
+        saw_wte = true;
+        if (idx.has_value() && *idx != axis_idx)
+        {
+            return std::nullopt;
+        }
+        idx = axis_idx;
+    }
+    if (!saw_wte)
+    {
+        return std::nullopt;
+    }
+    return idx;
+}
+
 //! Per-layer axis role from MLP parameter layout (``Linear`` is in×out).
 inline std::optional<std::string> gpt2_mlp_layer_axis_role(
     std::string const &tname,
@@ -331,6 +358,7 @@ inline void name_gpt2_global_axis_groups(
             }
         }
         auto const wpe_axis = axis_group_wpe_axis_index(ad);
+        auto const wte_axis = axis_group_wte_axis_index(ad);
         if (wpe_axis.has_value() && *wpe_axis == 0 &&
             ad->extent == cfg.max_position_embeddings)
         {
@@ -338,7 +366,8 @@ inline void name_gpt2_global_axis_groups(
             continue;
         }
         if (ad->extent == cfg.vocab_size &&
-            !axis_group_is_runtime_training_io(ad) && !wpe_axis.has_value())
+            !axis_group_is_runtime_training_io(ad) && !wpe_axis.has_value() &&
+            (!wte_axis.has_value() || *wte_axis == 0))
         {
             ad->name = "vocab_size";
             continue;
@@ -346,7 +375,8 @@ inline void name_gpt2_global_axis_groups(
         if (ad->extent == cfg.hidden_size &&
             !axis_group_member_name_contains(ad, "_attn_") &&
             !axis_group_is_runtime_training_io(ad) &&
-            (!wpe_axis.has_value() || *wpe_axis == 1))
+            (!wpe_axis.has_value() || *wpe_axis == 1) &&
+            (!wte_axis.has_value() || *wte_axis == 1))
         {
             ad->name = "hidden_size";
             continue;

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -130,6 +130,33 @@ inline bool axis_group_is_runtime_training_io(AxisDescriptor const *ad)
     return axis_group_looks_like_seq(ad) || axis_group_looks_like_batch(ad);
 }
 
+//! Axis index on ``wpe`` embedding members, if consistent.
+inline std::optional<size_t> axis_group_wpe_axis_index(
+    AxisDescriptor const *ad)
+{
+    std::optional<size_t> idx;
+    bool saw_wpe = false;
+    for (auto const &[node_ptr, axis_idx] : ad->members)
+    {
+        auto *node = static_cast<TensorGraph::TensorNode const *>(node_ptr);
+        if (node->name().find("wpe") == std::string::npos)
+        {
+            continue;
+        }
+        saw_wpe = true;
+        if (idx.has_value() && *idx != axis_idx)
+        {
+            return std::nullopt;
+        }
+        idx = axis_idx;
+    }
+    if (!saw_wpe)
+    {
+        return std::nullopt;
+    }
+    return idx;
+}
+
 //! Per-layer axis role from MLP parameter layout (``Linear`` is in×out).
 inline std::optional<std::string> gpt2_mlp_layer_axis_role(
     std::string const &tname,
@@ -309,15 +336,23 @@ inline void name_gpt2_global_axis_groups(
             ad->name = "vocab_size";
             continue;
         }
+        auto const wpe_axis = axis_group_wpe_axis_index(ad);
+        if (wpe_axis.has_value() && *wpe_axis == 0 &&
+            ad->extent == cfg.max_position_embeddings)
+        {
+            ad->name = "max_position_embeddings";
+            continue;
+        }
         if (ad->extent == cfg.hidden_size &&
             !axis_group_member_name_contains(ad, "_attn_") &&
-            !axis_group_is_runtime_training_io(ad))
+            !axis_group_is_runtime_training_io(ad) &&
+            (!wpe_axis.has_value() || *wpe_axis == 1))
         {
             ad->name = "hidden_size";
             continue;
         }
         if (ad->extent == cfg.max_position_embeddings &&
-            !axis_group_is_runtime_training_io(ad))
+            !axis_group_is_runtime_training_io(ad) && !wpe_axis.has_value())
         {
             ad->name = "max_position_embeddings";
             continue;

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -92,17 +92,17 @@ inline std::optional<size_t> axis_group_training_io_axis_index(
 
 inline bool axis_group_looks_like_batch(AxisDescriptor const *ad)
 {
-    if (axis_group_member_name_contains(ad, "_attn_"))
+    if (axis_group_member_name_contains(ad, "_attn_") ||
+        axis_group_member_name_contains(ad, "_h_") ||
+        axis_group_member_name_contains(ad, "wte") ||
+        axis_group_member_name_contains(ad, "wpe") ||
+        axis_group_member_name_contains(ad, "lm_head"))
     {
         return false;
     }
-    if (axis_group_member_name_contains(ad, "input_ids") ||
-        axis_group_member_name_contains(ad, "labels") ||
-        axis_group_member_name_contains(ad, "position_ids"))
-    {
-        return true;
-    }
-    return !axis_group_member_name_contains(ad, "_h_");
+    return axis_group_member_name_contains(ad, "input_ids") ||
+           axis_group_member_name_contains(ad, "labels") ||
+           axis_group_member_name_contains(ad, "position_ids");
 }
 
 inline bool axis_group_looks_like_seq(AxisDescriptor const *ad)
@@ -220,12 +220,6 @@ inline void name_gpt2_global_axis_groups(
                 }
             }
         }
-        if (ad->extent == batch_size && batch_size > 0 &&
-            axis_group_looks_like_batch(ad))
-        {
-            ad->name = "batch_size";
-            continue;
-        }
         if (ad->extent == cfg.vocab_size)
         {
             ad->name = "vocab_size";
@@ -237,15 +231,22 @@ inline void name_gpt2_global_axis_groups(
             ad->name = "hidden_size";
             continue;
         }
+        if (ad->extent == cfg.max_position_embeddings)
+        {
+            ad->name = "max_position_embeddings";
+            continue;
+        }
+        if (ad->extent == batch_size && batch_size > 0 &&
+            axis_group_looks_like_batch(ad))
+        {
+            ad->name = "batch_size";
+            continue;
+        }
         if (ad->extent == seq_len && seq_len > 0 &&
             axis_group_looks_like_seq(ad))
         {
             ad->name = "seq_len";
             continue;
-        }
-        if (ad->extent == cfg.max_position_embeddings)
-        {
-            ad->name = "max_position_embeddings";
         }
     }
 }

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -1,0 +1,143 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file examples/gpt2_axis_naming.hh
+ * Name TensorGraph axis groups for GPT-2 training + tiling.json keys.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include <nntile/base_types.hh>
+#include <nntile/model/gpt2/gpt2_config.hh>
+#include <nntile/tensor/axis_descriptor.hh>
+#include <nntile/tensor/graph_decl.hh>
+
+#include <cctype>
+#include <optional>
+#include <string>
+
+namespace nntile::examples
+{
+
+inline std::optional<Index> parse_h_layer_index_from_tensor_name(
+    std::string const &tensor_name)
+{
+    std::string const needle = "_h_";
+    auto pos = tensor_name.find(needle);
+    if (pos == std::string::npos)
+    {
+        return std::nullopt;
+    }
+    pos += needle.size();
+    if (pos >= tensor_name.size() || !std::isdigit(tensor_name[pos]))
+    {
+        return std::nullopt;
+    }
+    Index idx = 0;
+    while (pos < tensor_name.size() && std::isdigit(tensor_name[pos]))
+    {
+        idx = idx * 10 + static_cast<Index>(tensor_name[pos] - '0');
+        ++pos;
+    }
+    if (pos < tensor_name.size() && tensor_name[pos] != '_')
+    {
+        return std::nullopt;
+    }
+    return idx;
+}
+
+inline void name_gpt2_training_axis_groups(
+    TensorGraph &tg,
+    model::gpt2::Gpt2Config const &cfg,
+    Index seq_len,
+    Index batch_size)
+{
+    for (AxisDescriptor *ad : tg.axis_groups())
+    {
+        if (!ad->name.empty())
+        {
+            continue;
+        }
+        if (ad->extent == batch_size)
+        {
+            ad->name = "batch_size";
+            continue;
+        }
+        if (ad->extent == seq_len)
+        {
+            ad->name = "seq_len";
+            continue;
+        }
+        if (ad->extent == cfg.vocab_size)
+        {
+            ad->name = "vocab_size";
+            continue;
+        }
+        if (ad->extent == cfg.hidden_size)
+        {
+            ad->name = "hidden_size";
+            continue;
+        }
+        if (ad->extent == cfg.max_position_embeddings)
+        {
+            ad->name = "max_position_embeddings";
+            continue;
+        }
+    }
+
+    for (AxisDescriptor *ad : tg.axis_groups())
+    {
+        if (!ad->name.empty())
+        {
+            continue;
+        }
+        if (ad->extent != cfg.intermediate_size &&
+            ad->extent != cfg.num_attention_heads)
+        {
+            continue;
+        }
+        std::optional<Index> layer_idx;
+        bool is_mlp = false;
+        bool is_attn = false;
+        for (auto const &[node_ptr, axis_idx] : ad->members)
+        {
+            (void) axis_idx;
+            auto *node = static_cast<TensorGraph::TensorNode *>(node_ptr);
+            std::string const &tname = node->name();
+            if (tname.find("_mlp_") != std::string::npos)
+            {
+                is_mlp = true;
+            }
+            if (tname.find("_attn_") != std::string::npos)
+            {
+                is_attn = true;
+            }
+            auto parsed = parse_h_layer_index_from_tensor_name(tname);
+            if (parsed.has_value())
+            {
+                layer_idx = parsed;
+            }
+        }
+        if (!layer_idx.has_value())
+        {
+            continue;
+        }
+        if (is_mlp && ad->extent == cfg.intermediate_size)
+        {
+            ad->name = "layer." + std::to_string(*layer_idx) +
+                       ".intermediate_size";
+            continue;
+        }
+        if (is_attn && ad->extent == cfg.num_attention_heads)
+        {
+            ad->name = "layer." + std::to_string(*layer_idx) +
+                       ".num_attention_heads";
+        }
+    }
+}
+
+} // namespace nntile::examples

--- a/nntile/examples/gpt2_axis_naming.hh
+++ b/nntile/examples/gpt2_axis_naming.hh
@@ -66,6 +66,30 @@ inline bool axis_group_member_name_contains(
     return false;
 }
 
+//! Axis index on ``input_ids`` / ``labels`` / ``position_ids`` members, if any.
+inline std::optional<size_t> axis_group_training_io_axis_index(
+    AxisDescriptor const *ad)
+{
+    std::optional<size_t> idx;
+    for (auto const &[node_ptr, axis_idx] : ad->members)
+    {
+        auto *node = static_cast<TensorGraph::TensorNode const *>(node_ptr);
+        std::string const &tname = node->name();
+        if (tname.find("input_ids") == std::string::npos &&
+            tname.find("labels") == std::string::npos &&
+            tname.find("position_ids") == std::string::npos)
+        {
+            continue;
+        }
+        if (idx.has_value() && *idx != axis_idx)
+        {
+            return std::nullopt;
+        }
+        idx = axis_idx;
+    }
+    return idx;
+}
+
 inline bool axis_group_looks_like_batch(AxisDescriptor const *ad)
 {
     if (axis_group_member_name_contains(ad, "_attn_"))
@@ -157,11 +181,35 @@ inline void name_gpt2_global_axis_groups(
     Index seq_len,
     Index batch_size)
 {
+    bool const seq_batch_same =
+        seq_len > 0 && batch_size > 0 && seq_len == batch_size;
     for (AxisDescriptor *ad : tg.axis_groups())
     {
         if (!ad->name.empty())
         {
             continue;
+        }
+        if (seq_batch_same && ad->extent == seq_len)
+        {
+            if (axis_group_member_name_contains(ad, "attn_mask"))
+            {
+                ad->name = "seq_len";
+                continue;
+            }
+            auto io_axis = axis_group_training_io_axis_index(ad);
+            if (io_axis.has_value())
+            {
+                if (*io_axis == 0)
+                {
+                    ad->name = "seq_len";
+                    continue;
+                }
+                if (*io_axis == 1)
+                {
+                    ad->name = "batch_size";
+                    continue;
+                }
+            }
         }
         if (ad->extent == batch_size && batch_size > 0 &&
             axis_group_looks_like_batch(ad))

--- a/nntile/examples/gpt2_graph_training.cc
+++ b/nntile/examples/gpt2_graph_training.cc
@@ -106,6 +106,7 @@ struct Args
 
 
 
+using nntile::examples::FlatTilingSpec;
 using nntile::examples::apply_flat_tiling_spec;
 using nntile::examples::load_gpt2_config_json;
 using nntile::examples::load_tiling_json;

--- a/nntile/examples/gpt2_graph_training.cc
+++ b/nntile/examples/gpt2_graph_training.cc
@@ -47,6 +47,7 @@
 #include <iostream>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <optional>
 
 #include "gpt2_axis_naming.hh"
 #include "gpt2_config_json.hh"
@@ -472,14 +473,16 @@ int main(int argc, char **argv)
         1e-8,
         static_cast<Scalar>(args.weight_decay));
 
+    std::optional<FlatTilingSpec> tiling_spec;
     if (!args.tiling_path.empty())
     {
-        FlatTilingSpec tiling = load_tiling_json(
+        tiling_spec = load_tiling_json(
             args.tiling_path, config.num_hidden_layers);
         name_gpt2_training_axis_groups(
             graph.tensor_graph(), config, n_seq, n_batch);
-        apply_flat_tiling_spec(
-            graph.tensor_graph(), tiling, config.num_hidden_layers);
+        apply_flat_tiling_spec(graph.tensor_graph(),
+            *tiling_spec,
+            config.num_hidden_layers);
         std::cout << "Tiling: loaded " << args.tiling_path << "\n";
     }
 
@@ -655,12 +658,10 @@ int main(int argc, char **argv)
         const std::string cfg_path = args.output_dir + "/config.json";
         const std::string w_path = args.output_dir + "/model.safetensors";
         save_gpt2_config_json(config, cfg_path);
-        if (!args.tiling_path.empty())
+        if (tiling_spec.has_value())
         {
-            FlatTilingSpec tiling = load_tiling_json(
-                args.tiling_path, config.num_hidden_layers);
             save_tiling_json(
-                tiling, args.output_dir + "/tiling.json");
+                *tiling_spec, args.output_dir + "/tiling.json");
         }
         if (graph.has_runtime())
         {

--- a/nntile/examples/gpt2_graph_training.cc
+++ b/nntile/examples/gpt2_graph_training.cc
@@ -480,9 +480,7 @@ int main(int argc, char **argv)
             args.tiling_path, config.num_hidden_layers);
         name_gpt2_training_axis_groups(
             graph.tensor_graph(), config, n_seq, n_batch);
-        apply_flat_tiling_spec(graph.tensor_graph(),
-            *tiling_spec,
-            config.num_hidden_layers);
+        apply_flat_tiling_spec(graph.tensor_graph(), *tiling_spec);
         std::cout << "Tiling: loaded " << args.tiling_path << "\n";
     }
 

--- a/nntile/examples/gpt2_graph_training.cc
+++ b/nntile/examples/gpt2_graph_training.cc
@@ -24,6 +24,8 @@
  * vs ``labels``. ``--tiny`` selects a built-in small config; ``--config`` loads
  * JSON ``Gpt2Config``; otherwise the tiny default applies.
  * ``--load-weights`` uses ``Module::load`` (SafeTensors).
+ * ``--tiling`` loads ``tiling.json`` (``default`` + ``layers``; axis keys match
+ * config + ``seq_len`` / ``batch_size``).
  *
  * Training loop matches ``llama_graph_training``: clear grads, forward, loss,
  * ``backward(true)``, ``optimizer->step(scheduled_lr)``, ``finish_phase()``,
@@ -46,7 +48,9 @@
 #include <memory>
 #include <nlohmann/json.hpp>
 
+#include "gpt2_axis_naming.hh"
 #include "gpt2_config_json.hh"
+#include "tiling_config_json.hh"
 #include <nntile.hh>
 #include <nntile/dataset/causal_lm_mmap.hh>
 #include <nntile/model/gpt2/gpt2_causal.hh>
@@ -82,6 +86,7 @@ constexpr int CONTEXT_LOGGER_PORT = 5001;
 struct Args
 {
     std::string config_path;
+    std::string tiling_path;
     std::string load_weights;
     std::string output_dir;
     std::string train_bin;
@@ -101,8 +106,12 @@ struct Args
 
 
 
+using nntile::examples::apply_flat_tiling_spec;
 using nntile::examples::load_gpt2_config_json;
+using nntile::examples::load_tiling_json;
+using nntile::examples::name_gpt2_training_axis_groups;
 using nntile::examples::save_gpt2_config_json;
+using nntile::examples::save_tiling_json;
 
 static Gpt2Config make_tiny_config()
 {
@@ -148,6 +157,10 @@ static Args parse_args(int argc, char **argv)
         std::string arg = argv[i];
         std::string s;
         if (take_string_opt(argc, argv, i, "--config", a.config_path))
+        {
+            continue;
+        }
+        if (take_string_opt(argc, argv, i, "--tiling", a.tiling_path))
         {
             continue;
         }
@@ -228,6 +241,7 @@ static Args parse_args(int argc, char **argv)
             std::cout
                 << "Usage: " << argv[0] << " [options]\n"
                 << "  --config <path>       GPT-2 JSON (optional if --tiny)\n"
+                << "  --tiling <path>       tiling.json (default + layers)\n"
                 << "  --tiny                use built-in tiny architecture\n"
                 << "  --load-weights <path> SafeTensors checkpoint\n"
                 << "  --output-dir <path>   write config.json + "
@@ -247,7 +261,7 @@ static Args parse_args(int argc, char **argv)
                 << "Options may use --opt=value or --opt value.\n";
             std::exit(EXIT_OK);
         }
-        if (arg == "--config" || arg == "--load-weights" ||
+        if (arg == "--config" || arg == "--tiling" || arg == "--load-weights" ||
             arg == "--output-dir" || arg == "--train-bin" || arg == "--seq" ||
             arg == "--batch" || arg == "--seed" || arg == "--max-batches" ||
             arg == "--lr" || arg == "--weight-decay" || arg == "--beta1" ||
@@ -457,6 +471,17 @@ int main(int argc, char **argv)
         1e-8,
         static_cast<Scalar>(args.weight_decay));
 
+    if (!args.tiling_path.empty())
+    {
+        FlatTilingSpec tiling = load_tiling_json(
+            args.tiling_path, config.num_hidden_layers);
+        name_gpt2_training_axis_groups(
+            graph.tensor_graph(), config, n_seq, n_batch);
+        apply_flat_tiling_spec(
+            graph.tensor_graph(), tiling, config.num_hidden_layers);
+        std::cout << "Tiling: loaded " << args.tiling_path << "\n";
+    }
+
     std::cout << "Optimizer: " << optimizer->repr() << "\n";
     if (args.warmup_steps > 0)
     {
@@ -629,6 +654,13 @@ int main(int argc, char **argv)
         const std::string cfg_path = args.output_dir + "/config.json";
         const std::string w_path = args.output_dir + "/model.safetensors";
         save_gpt2_config_json(config, cfg_path);
+        if (!args.tiling_path.empty())
+        {
+            FlatTilingSpec tiling = load_tiling_json(
+                args.tiling_path, config.num_hidden_layers);
+            save_tiling_json(
+                tiling, args.output_dir + "/tiling.json");
+        }
         if (graph.has_runtime())
         {
             for (NNGraph::TensorNode *ptensor : graph.parameters())

--- a/nntile/examples/tiling_config_json.hh
+++ b/nntile/examples/tiling_config_json.hh
@@ -34,36 +34,6 @@ struct FlatTilingSpec
     std::map<Index, std::map<std::string, std::vector<Index>>> per_layer;
 };
 
-bool is_tiling_axis_key(std::string const &key);
-
-std::string normalize_tiling_axis_key(std::string key);
-
-std::vector<Index> parse_tile_sizes_json(
-    nlohmann::json const &v,
-    Index extent,
-    char const *context);
-
-FlatTilingSpec load_tiling_json(
-    std::string const &path,
-    Index num_hidden_layers);
-
-FlatTilingSpec load_tiling_from_json(
-    nlohmann::json const &j,
-    Index num_hidden_layers);
-
-void save_tiling_json(FlatTilingSpec const &spec, std::string const &path);
-
-nlohmann::json flat_tiling_spec_to_json(FlatTilingSpec const &spec);
-
-Index resolve_layer_key(
-    std::string const &key,
-    Index num_hidden_layers);
-
-void apply_flat_tiling_spec(
-    TensorGraph &tg,
-    FlatTilingSpec const &spec,
-    Index num_hidden_layers);
-
 inline bool is_tiling_axis_key(std::string const &key)
 {
     return key == "vocab_size" || key == "hidden_size" ||

--- a/nntile/examples/tiling_config_json.hh
+++ b/nntile/examples/tiling_config_json.hh
@@ -364,10 +364,8 @@ inline std::vector<Index> tile_sizes_for_axis_extent(
 
 inline void apply_flat_tiling_spec(
     TensorGraph &tg,
-    FlatTilingSpec const &spec,
-    Index num_hidden_layers)
+    FlatTilingSpec const &spec)
 {
-    (void) num_hidden_layers;
     for (AxisDescriptor *ad : tg.axis_groups())
     {
         if (ad->name.empty())

--- a/nntile/examples/tiling_config_json.hh
+++ b/nntile/examples/tiling_config_json.hh
@@ -100,7 +100,7 @@ inline std::vector<Index> parse_tile_sizes_json(
 {
     if (v.is_number_integer())
     {
-        Index const t = static_cast<Index>(v.get<int>());
+        Index const t = v.get<Index>();
         if (t <= 0)
         {
             throw std::runtime_error(
@@ -135,7 +135,7 @@ inline std::vector<Index> parse_tile_sizes_json(
                 throw std::runtime_error(
                     std::string(context) + ": tile array must be integers");
             }
-            Index const t = static_cast<Index>(el.get<int>());
+            Index const t = el.get<Index>();
             if (t <= 0)
             {
                 throw std::runtime_error(

--- a/nntile/examples/tiling_config_json.hh
+++ b/nntile/examples/tiling_config_json.hh
@@ -1,0 +1,448 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file examples/tiling_config_json.hh
+ * Load/save tiling.json (``default`` + ``layers``) for graph training examples.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include "json_config_helpers.hh"
+
+#include <nlohmann/json.hpp>
+#include <nntile/base_types.hh>
+#include <nntile/tensor/axis_descriptor.hh>
+#include <nntile/tensor/graph_decl.hh>
+
+#include <fstream>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace nntile::examples
+{
+
+//! Parsed tiling.json (canonical: ``default`` + ``layers``).
+struct FlatTilingSpec
+{
+    std::map<std::string, std::vector<Index>> defaults;
+    std::map<Index, std::map<std::string, std::vector<Index>>> per_layer;
+};
+
+bool is_tiling_axis_key(std::string const &key);
+
+std::string normalize_tiling_axis_key(std::string key);
+
+std::vector<Index> parse_tile_sizes_json(
+    nlohmann::json const &v,
+    Index extent,
+    char const *context);
+
+FlatTilingSpec load_tiling_json(
+    std::string const &path,
+    Index num_hidden_layers);
+
+FlatTilingSpec load_tiling_from_json(
+    nlohmann::json const &j,
+    Index num_hidden_layers);
+
+void save_tiling_json(FlatTilingSpec const &spec, std::string const &path);
+
+nlohmann::json flat_tiling_spec_to_json(FlatTilingSpec const &spec);
+
+Index resolve_layer_key(
+    std::string const &key,
+    Index num_hidden_layers);
+
+void apply_flat_tiling_spec(
+    TensorGraph &tg,
+    FlatTilingSpec const &spec,
+    Index num_hidden_layers);
+
+inline bool is_tiling_axis_key(std::string const &key)
+{
+    return key == "vocab_size" || key == "hidden_size" ||
+           key == "intermediate_size" || key == "num_attention_heads" ||
+           key == "max_position_embeddings" || key == "seq_len" ||
+           key == "batch_size";
+}
+
+inline std::string normalize_tiling_axis_key(std::string key)
+{
+    if (key == "n_embd")
+    {
+        return "hidden_size";
+    }
+    if (key == "n_inner")
+    {
+        return "intermediate_size";
+    }
+    if (key == "n_head")
+    {
+        return "num_attention_heads";
+    }
+    if (key == "n_positions")
+    {
+        return "max_position_embeddings";
+    }
+    return key;
+}
+
+inline std::vector<Index> parse_tile_sizes_json(
+    nlohmann::json const &v,
+    Index extent,
+    char const *context)
+{
+    if (v.is_number_integer())
+    {
+        Index const t = static_cast<Index>(v.get<int>());
+        if (t <= 0)
+        {
+            throw std::runtime_error(
+                std::string(context) + ": tile size must be positive");
+        }
+        if (extent > 0 && t > extent)
+        {
+            throw std::runtime_error(
+                std::string(context) + ": uniform tile larger than extent");
+        }
+        std::vector<Index> sizes;
+        if (extent <= 0)
+        {
+            sizes.push_back(t);
+            return sizes;
+        }
+        for (Index rem = extent; rem > 0; rem -= t)
+        {
+            sizes.push_back(std::min(t, rem));
+        }
+        return sizes;
+    }
+    if (v.is_array())
+    {
+        std::vector<Index> sizes;
+        sizes.reserve(v.size());
+        Index total = 0;
+        for (auto const &el : v)
+        {
+            if (!el.is_number_integer())
+            {
+                throw std::runtime_error(
+                    std::string(context) + ": tile array must be integers");
+            }
+            Index const t = static_cast<Index>(el.get<int>());
+            if (t <= 0)
+            {
+                throw std::runtime_error(
+                    std::string(context) + ": tile size must be positive");
+            }
+            sizes.push_back(t);
+            total += t;
+        }
+        if (extent > 0 && total != extent)
+        {
+            throw std::runtime_error(
+                std::string(context) + ": tile sizes sum (" +
+                std::to_string(total) + ") != extent (" +
+                std::to_string(extent) + ")");
+        }
+        return sizes;
+    }
+    throw std::runtime_error(
+        std::string(context) + ": tile value must be int or int array");
+}
+
+inline Index resolve_layer_key(
+    std::string const &key,
+    Index num_hidden_layers)
+{
+    std::string k = key;
+    std::string const prefix = "transformer.";
+    if (k.rfind(prefix, 0) == 0)
+    {
+        k = k.substr(prefix.size());
+    }
+    if (k.rfind("h_", 0) == 0)
+    {
+        k = k.substr(2);
+    }
+    int idx = 0;
+    try
+    {
+        idx = std::stoi(k);
+    }
+    catch (...)
+    {
+        throw std::runtime_error(
+            "tiling layers: invalid layer key '" + key + "'");
+    }
+    if (idx < 0 || static_cast<Index>(idx) >= num_hidden_layers)
+    {
+        throw std::runtime_error(
+            "tiling layers: layer index " + std::to_string(idx) +
+            " out of range [0, " + std::to_string(num_hidden_layers) + ")");
+    }
+    return static_cast<Index>(idx);
+}
+
+inline FlatTilingSpec load_tiling_from_json(
+    nlohmann::json const &j,
+    Index num_hidden_layers)
+{
+    FlatTilingSpec spec;
+    if (!j.contains("default") || !j["default"].is_object())
+    {
+        throw std::runtime_error(
+            "tiling.json: missing or invalid top-level \"default\" object");
+    }
+    if (!j.contains("layers") || !j["layers"].is_object())
+    {
+        throw std::runtime_error(
+            "tiling.json: missing or invalid top-level \"layers\" object");
+    }
+    for (auto it = j["default"].begin(); it != j["default"].end(); ++it)
+    {
+        std::string const axis = normalize_tiling_axis_key(it.key());
+        if (!is_tiling_axis_key(axis))
+        {
+            throw std::runtime_error(
+                "tiling.json default: unknown axis key '" + it.key() + "'");
+        }
+        spec.defaults.emplace(
+            axis,
+            parse_tile_sizes_json(it.value(), 0, "tiling.json default"));
+    }
+    for (auto it = j["layers"].begin(); it != j["layers"].end(); ++it)
+    {
+        Index const layer = resolve_layer_key(it.key(), num_hidden_layers);
+        if (!it.value().is_object())
+        {
+            throw std::runtime_error(
+                "tiling.json layers." + it.key() +
+                ": expected object of axis tiling");
+        }
+        auto &layer_map = spec.per_layer[layer];
+        for (auto ax = it.value().begin(); ax != it.value().end(); ++ax)
+        {
+            std::string const axis = normalize_tiling_axis_key(ax.key());
+            if (axis != "intermediate_size" && axis != "num_attention_heads")
+            {
+                throw std::runtime_error(
+                    "tiling.json layers." + it.key() +
+                    ": only intermediate_size and num_attention_heads "
+                    "allowed in layers");
+            }
+            layer_map.emplace(
+                axis,
+                parse_tile_sizes_json(
+                    ax.value(), 0, "tiling.json layers"));
+        }
+    }
+    return spec;
+}
+
+inline FlatTilingSpec load_tiling_json(
+    std::string const &path,
+    Index num_hidden_layers)
+{
+    std::ifstream f(path);
+    if (!f.good())
+    {
+        throw std::runtime_error("Cannot open tiling file: " + path);
+    }
+    nlohmann::json j = nlohmann::json::parse(f);
+    return load_tiling_from_json(j, num_hidden_layers);
+}
+
+inline nlohmann::json tile_sizes_to_json(std::vector<Index> const &sizes)
+{
+    if (sizes.size() == 1)
+    {
+        return sizes[0];
+    }
+    nlohmann::json arr = nlohmann::json::array();
+    for (Index s : sizes)
+    {
+        arr.push_back(s);
+    }
+    return arr;
+}
+
+inline nlohmann::json flat_tiling_spec_to_json(FlatTilingSpec const &spec)
+{
+    nlohmann::json j;
+    nlohmann::json def = nlohmann::json::object();
+    for (auto const &[axis, sizes] : spec.defaults)
+    {
+        def[axis] = tile_sizes_to_json(sizes);
+    }
+    j["default"] = def;
+    nlohmann::json layers = nlohmann::json::object();
+    for (auto const &[layer, roles] : spec.per_layer)
+    {
+        std::string const key = "h_" + std::to_string(layer);
+        nlohmann::json lob = nlohmann::json::object();
+        for (auto const &[axis, sizes] : roles)
+        {
+            lob[axis] = tile_sizes_to_json(sizes);
+        }
+        layers[key] = lob;
+    }
+    j["layers"] = layers;
+    return j;
+}
+
+inline void save_tiling_json(
+    FlatTilingSpec const &spec,
+    std::string const &path)
+{
+    std::ofstream f(path);
+    if (!f.good())
+    {
+        throw std::runtime_error("Cannot write tiling file: " + path);
+    }
+    f << flat_tiling_spec_to_json(spec).dump(2) << "\n";
+}
+
+inline bool parse_layer_axis_group_name(
+    std::string const &name,
+    Index &layer_out,
+    std::string &axis_out)
+{
+    std::string const prefix = "layer.";
+    if (name.rfind(prefix, 0) != 0)
+    {
+        return false;
+    }
+    std::string rest = name.substr(prefix.size());
+    auto const dot = rest.find('.');
+    if (dot == std::string::npos)
+    {
+        return false;
+    }
+    try
+    {
+        layer_out = static_cast<Index>(std::stoi(rest.substr(0, dot)));
+    }
+    catch (...)
+    {
+        return false;
+    }
+    axis_out = rest.substr(dot + 1);
+    return true;
+}
+
+inline void apply_tiling_to_axis(
+    AxisDescriptor *ad,
+    std::vector<Index> const &sizes)
+{
+    if (sizes.size() == 1)
+    {
+        ad->set_tiling(sizes[0]);
+    }
+    else
+    {
+        std::vector<Index> sized = sizes;
+        Index total = 0;
+        for (Index s : sized)
+        {
+            total += s;
+        }
+        if (total != ad->extent)
+        {
+            throw std::runtime_error(
+                "tiling: sum of tile sizes for axis '" + ad->name +
+                "' (" + std::to_string(total) + ") != extent (" +
+                std::to_string(ad->extent) + ")");
+        }
+        ad->set_tiling(sized);
+    }
+}
+
+inline std::vector<Index> tile_sizes_for_axis_extent(
+    std::vector<Index> const &pattern,
+    Index extent)
+{
+    if (pattern.size() == 1)
+    {
+        Index const t = pattern[0];
+        std::vector<Index> sizes;
+        for (Index rem = extent; rem > 0; rem -= t)
+        {
+            sizes.push_back(std::min(t, rem));
+        }
+        return sizes;
+    }
+    Index total = 0;
+    for (Index s : pattern)
+    {
+        total += s;
+    }
+    if (total != extent)
+    {
+        throw std::runtime_error(
+            "tiling: tile sizes sum (" + std::to_string(total) +
+            ") != extent (" + std::to_string(extent) + ")");
+    }
+    return pattern;
+}
+
+inline void apply_flat_tiling_spec(
+    TensorGraph &tg,
+    FlatTilingSpec const &spec,
+    Index num_hidden_layers)
+{
+    (void) num_hidden_layers;
+    for (AxisDescriptor *ad : tg.axis_groups())
+    {
+        if (ad->name.empty())
+        {
+            continue;
+        }
+        Index layer = 0;
+        std::string axis_key;
+        std::vector<Index> const *sizes = nullptr;
+        if (parse_layer_axis_group_name(ad->name, layer, axis_key))
+        {
+            auto lit = spec.per_layer.find(layer);
+            if (lit != spec.per_layer.end())
+            {
+                auto ait = lit->second.find(axis_key);
+                if (ait != lit->second.end())
+                {
+                    sizes = &ait->second;
+                }
+            }
+            if (sizes == nullptr)
+            {
+                auto dit = spec.defaults.find(axis_key);
+                if (dit != spec.defaults.end())
+                {
+                    sizes = &dit->second;
+                }
+            }
+        }
+        else
+        {
+            auto dit = spec.defaults.find(ad->name);
+            if (dit != spec.defaults.end())
+            {
+                sizes = &dit->second;
+            }
+        }
+        if (sizes == nullptr)
+        {
+            continue;
+        }
+        std::vector<Index> const resolved =
+            tile_sizes_for_axis_extent(*sizes, ad->extent);
+        apply_tiling_to_axis(ad, resolved);
+    }
+}
+
+} // namespace nntile::examples

--- a/nntile/examples/tiling_config_json.hh
+++ b/nntile/examples/tiling_config_json.hh
@@ -16,7 +16,7 @@
 #include <nlohmann/json.hpp>
 #include <nntile/base_types.hh>
 #include <nntile/tensor/axis_descriptor.hh>
-#include <nntile/tensor/graph_decl.hh>
+#include <nntile/tensor/graph.hh>
 
 #include <fstream>
 #include <map>

--- a/nntile/tests/tensor/CMakeLists.txt
+++ b/nntile/tests/tensor/CMakeLists.txt
@@ -87,6 +87,7 @@ set(TESTS_TENSOR_CATCH2
 
 set(TESTS_TENSOR_ROOT_CATCH2
     "axis_descriptor"
+    "tiling_config_json"
 )
 
 # CUDA-only tests (flash_* operations require n_cuda=1)
@@ -126,7 +127,8 @@ foreach(test IN LISTS TESTS_TENSOR_ROOT_CATCH2)
         COV_GLOBAL coverage_graph coverage
     )
     target_include_directories(tests_graph_tensor_${test} PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/..)
+        ${CMAKE_CURRENT_SOURCE_DIR}/..
+        ${CMAKE_SOURCE_DIR}/nntile/examples)
 endforeach()
 
 foreach(test IN LISTS TESTS_TENSOR_CUDA)

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -128,6 +128,31 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "mlp axes split when hidden_size equals intermediate_size",
+    "[tiling][naming]")
+{
+    model::gpt2::Gpt2Config cfg;
+    cfg.hidden_size = 128;
+    cfg.intermediate_size = 128;
+    cfg.num_attention_heads = 4;
+    cfg.num_hidden_layers = 1;
+    cfg.validate();
+
+    TensorGraph tg("naming");
+    auto *fc1 = tg.data({128, 128})
+                    ->set_name("model_transformer_h_0_mlp_fc1_weight");
+    auto *fc2 = tg.data({128, 128})
+                    ->set_name("model_transformer_h_0_mlp_fc2_weight");
+
+    name_gpt2_training_axis_groups(tg, cfg, 8, 4);
+
+    REQUIRE(fc1->axis(0)->name == "hidden_size");
+    REQUIRE(fc1->axis(1)->name == "layer.0.intermediate_size");
+    REQUIRE(fc2->axis(0)->name == "layer.0.intermediate_size");
+    REQUIRE(fc2->axis(1)->name == "hidden_size");
+}
+
+TEST_CASE(
     "seq_len not named hidden_size when extents match",
     "[tiling][naming]")
 {

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -77,7 +77,7 @@ TEST_CASE("apply per-layer override on named axes", "[tiling][json]")
     spec.defaults["intermediate_size"] = {64, 64};
     spec.per_layer[1]["intermediate_size"] = {40, 88};
 
-    apply_flat_tiling_spec(tg, spec, 2);
+    apply_flat_tiling_spec(tg, spec);
 
     REQUIRE(t0->axis(0)->tile_sizes.size() == 2);
     REQUIRE(t0->axis(0)->tile_sizes[0] == 64);

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -128,6 +128,28 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "wpe position axis not named vocab_size when extents match",
+    "[tiling][naming]")
+{
+    model::gpt2::Gpt2Config cfg;
+    cfg.vocab_size = 128;
+    cfg.max_position_embeddings = 128;
+    cfg.hidden_size = 64;
+    cfg.intermediate_size = 256;
+    cfg.num_attention_heads = 4;
+    cfg.num_hidden_layers = 1;
+    cfg.validate();
+
+    TensorGraph tg("naming");
+    auto *wpe = tg.data({128, 64})->set_name("model_transformer_wpe_vocab");
+
+    name_gpt2_training_axis_groups(tg, cfg, 8, 4);
+
+    REQUIRE(wpe->axis(0)->name == "max_position_embeddings");
+    REQUIRE(wpe->axis(1)->name == "hidden_size");
+}
+
+TEST_CASE(
     "wpe axes split when hidden_size equals max_position",
     "[tiling][naming]")
 {

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -128,6 +128,27 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "wpe axes split when hidden_size equals max_position",
+    "[tiling][naming]")
+{
+    model::gpt2::Gpt2Config cfg;
+    cfg.hidden_size = 128;
+    cfg.max_position_embeddings = 128;
+    cfg.intermediate_size = 256;
+    cfg.num_attention_heads = 4;
+    cfg.num_hidden_layers = 1;
+    cfg.validate();
+
+    TensorGraph tg("naming");
+    auto *wpe = tg.data({128, 128})->set_name("model_transformer_wpe_vocab");
+
+    name_gpt2_training_axis_groups(tg, cfg, 8, 4);
+
+    REQUIRE(wpe->axis(0)->name == "max_position_embeddings");
+    REQUIRE(wpe->axis(1)->name == "hidden_size");
+}
+
+TEST_CASE(
     "mlp axes split when hidden_size equals intermediate_size",
     "[tiling][naming]")
 {

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -1,0 +1,85 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file nntile/tests/tensor/tiling_config_json.cc
+ * Tests for examples/tiling_config_json.hh
+ *
+ * @version 1.1.0
+ * */
+
+#include "tiling_config_json.hh"
+
+#include <catch2/catch_test_macros.hpp>
+#include <nntile/tensor.hh>
+
+#include <cstdio>
+#include <fstream>
+
+using namespace nntile;
+using namespace nntile::examples;
+
+TEST_CASE("load tiling.json default + layers", "[tiling][json]")
+{
+    nlohmann::json j = {
+        {"default", {{"hidden_size", 4}, {"intermediate_size", {2, 2}}}},
+        {"layers",
+            {{"h_1", {{"intermediate_size", {1, 1}}}}}}};
+
+    FlatTilingSpec spec = load_tiling_from_json(j, 2);
+    REQUIRE(spec.defaults.at("hidden_size").size() == 1);
+    REQUIRE(spec.defaults.at("hidden_size")[0] == 4);
+    REQUIRE(spec.per_layer.at(1).at("intermediate_size").size() == 2);
+}
+
+TEST_CASE("reject missing default or layers", "[tiling][json]")
+{
+    REQUIRE_THROWS(load_tiling_from_json(nlohmann::json::object(), 2));
+    REQUIRE_THROWS(load_tiling_from_json(
+        nlohmann::json{{"default", nlohmann::json::object()}}, 2));
+}
+
+TEST_CASE("HF alias normalizes hidden_size", "[tiling][json]")
+{
+    nlohmann::json j = {
+        {"default", {{"n_embd", 8}}},
+        {"layers", nlohmann::json::object()}};
+    FlatTilingSpec spec = load_tiling_from_json(j, 1);
+    REQUIRE(spec.defaults.count("hidden_size") == 1);
+}
+
+TEST_CASE("apply per-layer override on named axes", "[tiling][json]")
+{
+    TensorGraph tg("apply");
+    auto *t0 = tg.data({128})->set_name("model_transformer_h_0_mlp_w");
+    auto *t1 = tg.data({128})->set_name("model_transformer_h_1_mlp_w");
+    t0->axis(0)->name = "layer.0.intermediate_size";
+    t1->axis(0)->name = "layer.1.intermediate_size";
+
+    FlatTilingSpec spec;
+    spec.defaults["intermediate_size"] = {64, 64};
+    spec.per_layer[1]["intermediate_size"] = {40, 88};
+
+    apply_flat_tiling_spec(tg, spec, 2);
+
+    REQUIRE(t0->axis(0)->tile_sizes.size() == 2);
+    REQUIRE(t0->axis(0)->tile_sizes[0] == 64);
+    REQUIRE(t1->axis(0)->tile_sizes.size() == 2);
+    REQUIRE(t1->axis(0)->tile_sizes[0] == 40);
+}
+
+TEST_CASE("round-trip save and reload", "[tiling][json]")
+{
+    FlatTilingSpec spec;
+    spec.defaults["batch_size"] = {1};
+    spec.defaults["seq_len"] = {4, 4};
+    spec.per_layer[0]["intermediate_size"] = {32, 32, 32, 32};
+
+    std::string const path = "/tmp/nntile_test_tiling.json";
+    save_tiling_json(spec, path);
+    FlatTilingSpec loaded = load_tiling_json(path, 2);
+    REQUIRE(loaded.defaults.at("batch_size")[0] == 1);
+    REQUIRE(loaded.per_layer.at(0).at("intermediate_size")[0] == 32);
+    std::remove(path.c_str());
+}

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -9,12 +9,12 @@
  * @version 1.1.0
  * */
 
-#include "gpt2_axis_naming.hh"
-#include "tiling_config_json.hh"
-
 #include <catch2/catch_test_macros.hpp>
 #include <nntile/model/gpt2/gpt2_config.hh>
 #include <nntile/tensor.hh>
+
+#include "gpt2_axis_naming.hh"
+#include "tiling_config_json.hh"
 
 #include <cstdio>
 #include <fstream>

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -128,6 +128,26 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "vocab_size not named batch_size when extents match",
+    "[tiling][naming]")
+{
+    model::gpt2::Gpt2Config cfg;
+    cfg.vocab_size = 256;
+    cfg.hidden_size = 64;
+    cfg.intermediate_size = 128;
+    cfg.num_attention_heads = 4;
+    cfg.num_hidden_layers = 1;
+    cfg.validate();
+
+    TensorGraph tg("naming");
+    auto *wte = tg.data({256})->set_name("model_transformer_wte_weight");
+
+    name_gpt2_training_axis_groups(tg, cfg, 8, 256);
+
+    REQUIRE(wte->axis(0)->name == "vocab_size");
+}
+
+TEST_CASE(
     "hidden_size not named seq_len when extents match",
     "[tiling][naming]")
 {

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -9,9 +9,11 @@
  * @version 1.1.0
  * */
 
+#include "gpt2_axis_naming.hh"
 #include "tiling_config_json.hh"
 
 #include <catch2/catch_test_macros.hpp>
+#include <nntile/model/gpt2/gpt2_config.hh>
 #include <nntile/tensor.hh>
 
 #include <cstdio>
@@ -67,6 +69,28 @@ TEST_CASE("apply per-layer override on named axes", "[tiling][json]")
     REQUIRE(t0->axis(0)->tile_sizes[0] == 64);
     REQUIRE(t1->axis(0)->tile_sizes.size() == 2);
     REQUIRE(t1->axis(0)->tile_sizes[0] == 40);
+}
+
+TEST_CASE(
+    "batch_size extent does not name attention head axes",
+    "[tiling][naming]")
+{
+    model::gpt2::Gpt2Config cfg;
+    cfg.hidden_size = 64;
+    cfg.intermediate_size = 128;
+    cfg.num_attention_heads = 4;
+    cfg.num_hidden_layers = 1;
+    cfg.validate();
+
+    TensorGraph tg("naming");
+    auto *heads =
+        tg.data({4, 16, 64})->set_name("model_transformer_h_0_attn_q_weight");
+    auto *batch_in = tg.data({8, 4})->set_name("input_ids");
+
+    name_gpt2_training_axis_groups(tg, cfg, 8, 4);
+
+    REQUIRE(heads->axis(0)->name == "layer.0.num_attention_heads");
+    REQUIRE(batch_in->axis(1)->name == "batch_size");
 }
 
 TEST_CASE("round-trip save and reload", "[tiling][json]")

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -93,6 +93,26 @@ TEST_CASE(
     REQUIRE(batch_in->axis(1)->name == "batch_size");
 }
 
+TEST_CASE(
+    "seq_len and batch_size named when extents match",
+    "[tiling][naming]")
+{
+    model::gpt2::Gpt2Config cfg;
+    cfg.hidden_size = 64;
+    cfg.intermediate_size = 128;
+    cfg.num_attention_heads = 4;
+    cfg.num_hidden_layers = 1;
+    cfg.validate();
+
+    TensorGraph tg("naming");
+    auto *batch_in = tg.data({8, 8})->set_name("input_ids");
+
+    name_gpt2_training_axis_groups(tg, cfg, 8, 8);
+
+    REQUIRE(batch_in->axis(0)->name == "seq_len");
+    REQUIRE(batch_in->axis(1)->name == "batch_size");
+}
+
 TEST_CASE("round-trip save and reload", "[tiling][json]")
 {
     FlatTilingSpec spec;

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -128,6 +128,26 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "seq_len not named hidden_size when extents match",
+    "[tiling][naming]")
+{
+    model::gpt2::Gpt2Config cfg;
+    cfg.hidden_size = 64;
+    cfg.intermediate_size = 128;
+    cfg.num_attention_heads = 4;
+    cfg.num_hidden_layers = 1;
+    cfg.validate();
+
+    TensorGraph tg("naming");
+    auto *batch_in = tg.data({64, 4})->set_name("input_ids");
+
+    name_gpt2_training_axis_groups(tg, cfg, 64, 4);
+
+    REQUIRE(batch_in->axis(0)->name == "seq_len");
+    REQUIRE(batch_in->axis(1)->name == "batch_size");
+}
+
+TEST_CASE(
     "vocab_size not named batch_size when extents match",
     "[tiling][naming]")
 {

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -42,6 +42,20 @@ TEST_CASE("reject missing default or layers", "[tiling][json]")
         nlohmann::json{{"default", nlohmann::json::object()}}, 2));
 }
 
+TEST_CASE("parse tile sizes beyond int32 range", "[tiling][json]")
+{
+    Index const big = static_cast<Index>(3000000000LL);
+    std::vector<Index> scalar =
+        parse_tile_sizes_json(nlohmann::json(big), 0, "test");
+    REQUIRE(scalar.size() == 1);
+    REQUIRE(scalar[0] == big);
+
+    std::vector<Index> array = parse_tile_sizes_json(
+        nlohmann::json::array({big, big}), 0, "test");
+    REQUIRE(array.size() == 2);
+    REQUIRE(array[0] == big);
+}
+
 TEST_CASE("HF alias normalizes hidden_size", "[tiling][json]")
 {
     nlohmann::json j = {

--- a/nntile/tests/tensor/tiling_config_json.cc
+++ b/nntile/tests/tensor/tiling_config_json.cc
@@ -113,6 +113,25 @@ TEST_CASE(
     REQUIRE(batch_in->axis(1)->name == "batch_size");
 }
 
+TEST_CASE(
+    "hidden_size not named seq_len when extents match",
+    "[tiling][naming]")
+{
+    model::gpt2::Gpt2Config cfg;
+    cfg.hidden_size = 64;
+    cfg.intermediate_size = 128;
+    cfg.num_attention_heads = 4;
+    cfg.num_hidden_layers = 1;
+    cfg.validate();
+
+    TensorGraph tg("naming");
+    auto *hidden = tg.data({64})->set_name("model_transformer_h_0_ln_1");
+
+    name_gpt2_training_axis_groups(tg, cfg, 64, 4);
+
+    REQUIRE(hidden->axis(0)->name == "hidden_size");
+}
+
 TEST_CASE("round-trip save and reload", "[tiling][json]")
 {
     FlatTilingSpec spec;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds loading and application of a separate **`tiling.json`** file for GPT-2 graph training, using the agreed **Option 1** schema:

- `"default"`: graph-wide tiling (config-aligned axis names + `seq_len` / `batch_size`)
- `"layers"`: per-block overrides keyed by `h_0`, `h_1`, …

## Changes

- `tiling_config_json.hh` — parse/save/apply tiling spec
- `gpt2_axis_naming.hh` — name `AxisDescriptor` groups for GPT-2 (`hidden_size`, `layer.N.intermediate_size`, …)
- `gpt2_graph_training` — new `--tiling` flag; copies `tiling.json` to `--output-dir` when saving
- Demo configs under `examples/demo_configs/`
- Catch2 tests in `tests/tensor/tiling_config_json.cc`
- README documentation

## Usage

```bash
./build/examples/gpt2_graph_training \
  --train-bin build/examples/demo_data/gpt2/train.bin \
  --config nntile/examples/demo_configs/gpt2_tiny_config.json \
  --tiling nntile/examples/demo_configs/gpt2_tiny_tiling.json \
  --seq 8 --batch 2
```

## Notes

- Tiling is applied once after model + inputs are built, before the training loop (axis merge during forward propagates tiling).
- `config.json` remains model-only; tiling is not embedded in config.
- Build/tests require StarPU in the environment (`tests_graph_tensor_tiling_config_json`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f09a682b-92c8-412a-b0e2-c23e626b81c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f09a682b-92c8-412a-b0e2-c23e626b81c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

