### PR TITLE
Graph API C-order shapes: TileGraph parity, fiber layout, and batch_ndim docs

### DIFF
--- a/.github/scripts/check-nntile-includes.sh
+++ b/.github/scripts/check-nntile-includes.sh
@@ -24,8 +24,10 @@ git grep -E '#include[[:space:]]*[<"]nntile/(core|graph)/' -- \
     ':(exclude)external' \
     ':(exclude)build' \
     ':(exclude).git' \
+    ':(exclude)nntile/' \
     ':(exclude)scripts/' \
     ':(exclude)wrappers/python' \
+    ':(exclude)*.md' \
     >>"$bad" 2>/dev/null || true
 
 legacy='#include[[:space:]]*[<"]nntile/(kernel|starpu|tile|tensor)/'
@@ -36,6 +38,12 @@ git grep -E "$legacy" -- \
     ':(exclude)nntile/' \
     ':(exclude)scripts/' \
     >>"$bad" 2>/dev/null || true
+
+# Documentation may show legacy include examples.
+if [ -s "$bad" ]; then
+    grep -v '\.md:' "$bad" >"${bad}.filtered" || true
+    mv "${bad}.filtered" "$bad"
+fi
 
 if [ -s "$bad" ]; then
     echo "::error::Forbidden include paths (use flat nntile/... layout):"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,6 @@ Uses ruff, isort, and standard pre-commit hooks. Configuration is in
 
 ### Graph API work (`graph_api` branch)
 
-- **Agent checklist (actionable):** [.cursor/plans/graph-static-execution.md](.cursor/plans/graph-static-execution.md)
+- **Agent checklist (actionable):** [docs/dev/graph_static_execution_agentic_plan.md](docs/dev/graph_static_execution_agentic_plan.md)
 - **Roadmap:** [docs/dev/graph_static_execution_plan.md](docs/dev/graph_static_execution_plan.md)
 - **Per-task steps:** [docs/dev/graph_static_execution_agentic_plan.md](docs/dev/graph_static_execution_agentic_plan.md)

--- a/docs/cpp/README.md
+++ b/docs/cpp/README.md
@@ -4,9 +4,9 @@ NNTile is split into two CMake packages:
 
 | Package | Libraries | Umbrella headers |
 |---------|-----------|------------------|
-| **core** | `nntile` | [`include/nntile/core.hh`](../../include/nntile/core.hh) |
-| **graph** | `nntile` (links core) | [`include/nntile/graph.hh`](../../include/nntile/graph.hh) |
-| **full** | both | [`include/nntile.hh`](../../include/nntile.hh) |
+| **core** | `nntile` | [`nntile/include/nntile/core.hh`](../../nntile/include/nntile/core.hh) |
+| **graph** | `nntile` (links core) | [`nntile/include/nntile/graph.hh`](../../nntile/include/nntile/graph.hh) |
+| **full** | both | [`nntile/include/nntile.hh`](../../nntile/include/nntile.hh) |
 
 Core code lives under `nntile/src/` and `include/nntile/` with namespace
 `nntile::{kernel,starpu,tile,tensor,...}`. Graph code lives under

--- a/docs/dev/graph_static_execution_plan.md
+++ b/docs/dev/graph_static_execution_plan.md
@@ -144,10 +144,10 @@ production GPT-2 tooling
 **Generate `execution.json` (first run):**
 
 ```bash
-./build/examples/gpt2_graph_training \
-  --train-bin build/examples/demo_data/gpt2/train.bin \
-  --config examples/demo_configs/gpt2_tiny_config.json \
-  --tiling examples/demo_configs/gpt2_tiny_tiling.json \
+./build/nntile/examples/gpt2_graph_training \
+  --train-bin build/nntile/examples/demo_data/gpt2/train.bin \
+  --config nntile/examples/demo_configs/gpt2_tiny_config.json \
+  --tiling nntile/examples/demo_configs/gpt2_tiny_tiling.json \
   --execution-out /tmp/gpt2_execution.json \
   --seq 8 --batch 2 --epochs 1 --max-batches 1
 ```
@@ -155,10 +155,10 @@ production GPT-2 tooling
 **Train using saved schedule:**
 
 ```bash
-./build/examples/gpt2_graph_training \
-  --train-bin build/examples/demo_data/gpt2/train.bin \
-  --config examples/demo_configs/gpt2_tiny_config.json \
-  --tiling examples/demo_configs/gpt2_tiny_tiling.json \
+./build/nntile/examples/gpt2_graph_training \
+  --train-bin build/nntile/examples/demo_data/gpt2/train.bin \
+  --config nntile/examples/demo_configs/gpt2_tiny_config.json \
+  --tiling nntile/examples/demo_configs/gpt2_tiny_tiling.json \
   --execution /tmp/gpt2_execution.json \
   --seq 8 --batch 2 --epochs 4 --max-batches 32
 ```

--- a/docs/graph-wip.md
+++ b/docs/graph-wip.md
@@ -6,10 +6,10 @@ automatic differentiation. This stack is separate from the classic Python API
 
 ## What exists today
 
-- C++ headers under [`include/nntile/`](../include/nntile/) and sources
+- C++ headers under [`nntile/include/nntile/`](../nntile/include/nntile/) and sources
   under [`nntile/src/`](../nntile/src/)
-- Python bindings: `nntile` (see [`wrappers/python/nntile/nntile.cc`](../wrappers/python/nntile/nntile.cc))
-- C++ examples under [`examples/`](../examples/) (e.g. autograd and MLP demos)
+- Python bindings: `nntile` (see [`python/nntile/`](../python/nntile/))
+- C++ examples under [`nntile/examples/`](../nntile/examples/) (e.g. autograd and MLP demos)
 - Architecture overview: [`graph.md`](../graph.md) at the repository root
 
 ## What to use for production training

--- a/graph.md
+++ b/graph.md
@@ -235,19 +235,22 @@ Shape conversion helpers are re-exported from `include/nntile/tile/shape_layout.
 
 ### Tile op axis conventions
 
-Axis-aware tile ops (`*_fiber*`, `*_slice*`, `softmax`, `maxsumexp`, `transpose`,
-`mask_scalar`) take **graph axis** indices at the tile API. `execute()` converts
-with `graph_axis_to_storage(axis, ndim)` before calling `core::*`, where `ndim`
-is the rank of the tensor the axis refers to (the full tensor for reductions,
-not the reduced output).
+Axis-aware tile ops (`*_fiber*`, `*_slice*`, `softmax`, `maxsumexp`, `transpose`)
+take **graph axis** indices (or graph leading-axis counts for `transpose`) at
+the tile API. `execute()` converts with `graph_axis_to_storage(axis, ndim)`
+before calling `core::*`, where `ndim` is the rank of the tensor the axis
+refers to (the full tensor for reductions, not the reduced output). For
+`transpose`, `ndim` is the number of leading **graph** axes in the cyclic
+shift; execute maps it to storage via `src->ndim() - ndim`.
 
 `TensorGraph` lowering passes graph axes to tile ops for slice/softmax-family ops.
 Fiber and reduction ops also store graph axes; tile calls receive graph axes
 directly.
 
 Layout-parameter ops (`embedding`, `conv2d_*`, `copy_intersection`, `rope`,
-`flash_sdpa`) keep storage-indexed geometry from tensor lowering; no tile-layer
-shape relabeling.
+`flash_sdpa`, `mask_scalar`) keep storage-indexed geometry from tensor lowering;
+`mask_scalar` takes `batch_ndim` (leading graph batch rank), not an axis index.
+No tile-layer shape relabeling beyond execute-time kernel conventions.
 
 ### TileGraph GEMM
 
@@ -324,12 +327,13 @@ Update `src/CMakeLists.txt` and `include/CMakeLists.txt` if adding new files.
 
 ## Minimal example
 
-Using NNGraph with gradients (see `examples/graph_mlp_example.cc` and
-`examples/linear_layer_example.cc` for full examples):
+Using NNGraph with gradients (see `nntile/examples/graph_mlp_example.cc` and
+`nntile/examples/linear_layer_example.cc` for full examples):
 
 ```cpp
 #include <nntile/context.hh>
 #include <nntile/graph.hh>
+#include <nntile/runtime.hh>
 
 using namespace nntile;
 
@@ -337,18 +341,20 @@ nntile::Context context(
     1, 0, 0, "/tmp/nntile_ooc", 16777216, 0, "localhost", 5001, 0);
 
 NNGraph graph("demo");
-auto* a = graph.tensor({2, 3}, "a", DataType::FP32, true);
-auto* b = graph.tensor({4, 3}, "b", DataType::FP32, true);  // out=4, in=3
-auto* y = gemm(a, b, "y");  // shape (2, 4) with trans_b=true in Linear
+auto* x = graph.tensor({2, 3}, "x", DataType::FP32, true);
+auto* w = graph.tensor({4, 3}, "w", DataType::FP32, true);  // out=4, in=3
+auto* y = gemm(x, w, "y");  // shape (2, 4) with trans_b=true in Linear
 
 x->mark_input(true);
 y->mark_output(true);
 y->backward();  // build backward pass
-CompiledGraph compiled(graph.tensor_graph());
-compiled.compile();
-compiled.bind_data("x", input_data);
-compiled.bind_data("w", weight_data);
-compiled.execute();
-compiled.wait();
-auto out = compiled.get_output<float>("y");
+
+TileGraph tile_graph = TileGraph::from_tensor_graph(graph.tensor_graph());
+Runtime runtime(tile_graph);
+runtime.compile();
+runtime.bind_data(x->data(), x_data);
+runtime.bind_data(w->data(), w_data);
+runtime.execute();
+runtime.wait();
+auto out = runtime.get_output<float>(y->data());
 ```

--- a/graph.md
+++ b/graph.md
@@ -172,6 +172,11 @@ TensorGraph / NNGraph API. `TensorGraph` op nodes store graph axes only;
 coordinates (storage-indexed internally). Tile execute converts to storage
 for `core::*`.
 
+**Fiber tensors** (`batch_ndim > 0`): graph shape is
+`[batch_0, …, batch_{batch_ndim-1}, fiber_dim]` (C-order: batch slower,
+fiber faster). The fiber extent matches `tensor.shape[axis]`; leading batch
+axes match `tensor.shape[0:batch_ndim)`.
+
 **Exception — NNGraph `transpose`:** graph model code was written with
 **storage-order** transpose axes (historical `graph_api` convention). The NN
 layer maps model `ndim` to tensor `src->ndim() - ndim` so unchanged model

--- a/graph.md
+++ b/graph.md
@@ -166,8 +166,11 @@ two:
 - `tensor::storage_axis_to_graph(storage_axis, ndim)` — storage axis → graph axis
 
 Most reduction and layout ops take **graph axis indices** at the public
-TensorGraph / NNGraph API and translate to storage axes internally before
-lowering.
+TensorGraph / NNGraph API. `TensorGraph` op nodes store graph axes only;
+`lower_to_tile` uses graph axes for tiling logic and calls
+`layout_axis(graph_axis, ndim)` only when indexing `TensorAxisLayout` grid
+coordinates (storage-indexed internally). Tile execute converts to storage
+for `core::*`.
 
 **Exception — NNGraph `transpose`:** graph model code was written with
 **storage-order** transpose axes (historical `graph_api` convention). The NN
@@ -239,8 +242,8 @@ is the rank of the tensor the axis refers to (the full tensor for reductions,
 not the reduced output).
 
 `TensorGraph` lowering passes graph axes to tile ops for slice/softmax-family ops.
-Ops that store a storage axis internally (e.g. fiber ops after validation) convert
-with `storage_axis_to_graph` at the tile boundary.
+Fiber and reduction ops also store graph axes; tile calls receive graph axes
+directly.
 
 Layout-parameter ops (`embedding`, `conv2d_*`, `copy_intersection`, `rope`,
 `flash_sdpa`) keep storage-indexed geometry from tensor lowering; no tile-layer

--- a/graph.md
+++ b/graph.md
@@ -135,9 +135,10 @@ GEMM shape rules (see `gemm_output_shape` in `tensor/ops/gemm.hh`):
 - **NNGraph** `gemm(a, b, trans_a, trans_b, ndim, batch_ndim)` forwards to
   `tensor::gemm(a, b, trans_a, trans_b, ndim, batch_ndim)` on graph shapes
   (no operand swap at the NN/tensor builder boundary).
-- **Tile lowering** (`TensorGemmOp::lower_to_tile`) maps graph-axis GEMM to
-  Fortran-order tile `tile::gemm` by swapping operands and transpose flags
-  (`tile::gemm(b, a, trans_b, trans_a, …)`).
+- **Tile lowering** (`TensorGemmOp::lower_to_tile`) calls
+  `tile::gemm(a, b, c, trans_a, trans_b, …)` with graph operand order (no swap).
+- **Tile execute** (`TileGemmOp::execute`) maps graph-axis GEMM to Fortran
+  `core::gemm` by swapping operands and transpose flags at the kernel boundary.
 - `trans_a` / `trans_b` transpose the contracted ``ndim`` axes of ``a`` / ``b``
   (see `gemm_output_shape` for the exact index ranges).
 - `ndim` is the number of contraction (K) dimensions.
@@ -211,6 +212,45 @@ With activations `x` shaped `[batch, seq, hidden]` and Q weight
 BERT/RoBERTa embeddings: sum word/position/token-type, then
 `transpose(embed, 2)` (storage-order axis) → `[batch, seq, hidden]` before
 `layer_norm(..., axis=2)` (graph axis).
+
+## TileGraph
+
+`TileGraph` is the tiled execution graph produced by lowering `TensorGraph`.
+It mirrors TensorGraph's C-order shape labels at the public API while
+`core::Tile` allocation and kernels remain Fortran-ordered.
+
+- `TileGraph::TileNode::shape()` — **graph** (C-order) labels, matching the
+  parent `TensorGraph::TensorNode::shape()` for the logical tensor.
+- `TileGraph::TileNode::storage_shape()` — Fortran storage shape passed to
+  `core::Tile` (via `tensor::graph_shape_to_storage`).
+- `TensorDescriptor.tile_shape` in `from_tensor_graph` / append phases uses
+  graph-order labels; `grid_shape` / `tile_coord` stay storage-indexed
+  (`TensorAxisLayout` is unchanged).
+
+Shape conversion helpers are re-exported from `include/nntile/tile/shape_layout.hh`
+(same functions as `tensor::shape_layout.hh`).
+
+### Tile op axis conventions
+
+Axis-aware tile ops (`*_fiber*`, `*_slice*`, `softmax`, `maxsumexp`, `transpose`,
+`mask_scalar`) take **graph axis** indices at the tile API. `execute()` converts
+with `graph_axis_to_storage(axis, ndim)` before calling `core::*`, where `ndim`
+is the rank of the tensor the axis refers to (the full tensor for reductions,
+not the reduced output).
+
+`TensorGraph` lowering passes graph axes to tile ops for slice/softmax-family ops.
+Ops that store a storage axis internally (e.g. fiber ops after validation) convert
+with `storage_axis_to_graph` at the tile boundary.
+
+Layout-parameter ops (`embedding`, `conv2d_*`, `copy_intersection`, `rope`,
+`flash_sdpa`) keep storage-indexed geometry from tensor lowering; no tile-layer
+shape relabeling.
+
+### TileGraph GEMM
+
+- Tensor lowering: `tile::gemm(ta, tb, tc, trans_a, trans_b, ndim, batch_ndim)`
+  (graph operand order).
+- Tile execute: calls `core::gemm` with operand/transpose swap for Fortran kernels.
 
 ## NNGraph
 

--- a/nntile/examples/gpt2_graph_training.cc
+++ b/nntile/examples/gpt2_graph_training.cc
@@ -56,7 +56,7 @@
 #include "gpt2_config_json.hh"
 #include "tiling_config_json.hh"
 #include <nntile.hh>
-#include <nntile/core/execution_schedule.hh>
+#include <nntile/runtime.hh>
 #include <nntile/dataset/causal_lm_mmap.hh>
 #include <nntile/model/gpt2/gpt2_causal.hh>
 #include <nntile/model/gpt2/gpt2_config.hh>

--- a/nntile/include/nntile/nn/ops/gemm.hh
+++ b/nntile/include/nntile/nn/ops/gemm.hh
@@ -27,8 +27,8 @@ namespace nntile
 //! Generic GEMM on graph shapes.
 //!
 //! ``trans_a`` / ``trans_b`` transpose the first ``ndim`` axes of operands
-//! ``a`` / ``b``.  Lowers to ``tensor::gemm(b, a, trans_b, trans_a, ndim,
-//! batch_ndim)`` (operands and transpose flags swapped for graph labels).
+//! ``a`` / ``b``.  Lowers to ``tensor::gemm(a, b, trans_a, trans_b, ndim,
+//! batch_ndim)`` on graph shapes (no operand swap).
 struct NNGemmOp : NNGraph::OpNode
 {
     Scalar alpha;

--- a/nntile/include/nntile/nn/ops/sdpa_eager.hh
+++ b/nntile/include/nntile/nn/ops/sdpa_eager.hh
@@ -12,7 +12,8 @@
  * Forward: attn = softmax(scale * K^T @ Q + mask), out = V @ attn
  * Backward: grad_Q, grad_K, grad_V via chain rule.
  *
- * Layout: [head_size, n_seq, batch...]. Scale = 1/sqrt(head_size).
+ * Graph layout: [batch..., seq, head_size] (C-order).
+ * Scale = 1/sqrt(head_size).
  *
  * @version 1.1.0
  * */
@@ -66,14 +67,13 @@ struct NNSdpaEagerOp : NNGraph::OpNode
 };
 
 //! SDPA eager: out = V @ softmax(scale * K^T @ Q + mask)
-//! @param q Query [head_size, q_seq, batch...]
-//! @param k Key [head_size, k_seq, batch...]
-//! @param v Value [head_size, k_seq, batch...]
-//! @param output_name Name for output tensor
+//! @param q Query [batch..., q_seq, head_size]
+//! @param k Key [batch..., k_seq, head_size]
+//! @param v Value [batch..., k_seq, head_size]
 //! @param mask Optional boolean mask [k_seq, q_seq] (nullptr = no mask)
-//! @param batch_ndim Number of trailing batch dimensions
+//! @param batch_ndim Number of leading batch dimensions (shape[0:batch_ndim))
 //! @param redux Reduction mode for distributed training
-//! @return Output [head_size, q_seq, batch...]
+//! @return Output [batch..., q_seq, head_size]
 NNGraph::TensorNode *sdpa_eager(NNGraph::TensorNode *q,
     NNGraph::TensorNode *k,
     NNGraph::TensorNode *v,

--- a/nntile/include/nntile/tensor/graph_data_node.hh
+++ b/nntile/include/nntile/tensor/graph_data_node.hh
@@ -181,8 +181,8 @@ inline void validate_slice_shape_and_merge(TensorGraph::TensorNode *slice,
 //! Validate fiber shape and merge axes (fiber 1+batch_ndim into tensor).
 //!
 //! ``axis`` is a **graph** axis on ``tensor`` (0 = outermost). Fiber graph shape
-//! is ``[fiber_dim, batch_0, …, batch_{batch_ndim-1}]`` with leading batch
-//! prefix aligned to tensor graph axes ``[0, batch_ndim)``.
+//! is ``[batch_0, …, batch_{batch_ndim-1}, fiber_dim]`` (C-order: batch slower,
+//! fiber faster); leading batch prefix matches tensor graph axes ``[0, batch_ndim)``.
 inline void validate_fiber_shape_and_merge(TensorGraph::TensorNode *fiber,
     TensorGraph::TensorNode *tensor,
     Index axis,
@@ -207,25 +207,27 @@ inline void validate_fiber_shape_and_merge(TensorGraph::TensorNode *fiber,
                                     std::to_string(tensor->ndim()) + " vs " +
                                     std::to_string(batch_ndim) + ")");
     }
-    if (fiber->shape()[0] != tensor->shape()[axis])
+    const Index fiber_ax = batch_ndim;
+    if (fiber->shape()[static_cast<size_t>(fiber_ax)] != tensor->shape()[axis])
     {
         throw std::invalid_argument(
-            op_name + ": fiber dim 0 must match tensor dim " +
-            std::to_string(axis) + " (" + std::to_string(fiber->shape()[0]) +
+            op_name + ": fiber dim " + std::to_string(fiber_ax) +
+            " must match tensor dim " + std::to_string(axis) + " (" +
+            std::to_string(fiber->shape()[static_cast<size_t>(fiber_ax)]) +
             " vs " + std::to_string(tensor->shape()[axis]) + ")");
     }
-    merge_axis(fiber->mutable_axes()[0], tensor->mutable_axes()[axis]);
+    merge_axis(fiber->mutable_axes()[fiber_ax], tensor->mutable_axes()[axis]);
     for (Index i = 0; i < batch_ndim; ++i)
     {
-        if (fiber->shape()[1 + i] != tensor->shape()[i])
+        if (fiber->shape()[static_cast<size_t>(i)] != tensor->shape()[i])
         {
             throw std::invalid_argument(
-                op_name + ": fiber dim " + std::to_string(1 + i) +
+                op_name + ": fiber dim " + std::to_string(i) +
                 " must match tensor dim " + std::to_string(i) + " (" +
-                std::to_string(fiber->shape()[1 + i]) + " vs " +
+                std::to_string(fiber->shape()[static_cast<size_t>(i)]) + " vs " +
                 std::to_string(tensor->shape()[i]) + ")");
         }
-        merge_axis(fiber->mutable_axes()[1 + i], tensor->mutable_axes()[i]);
+        merge_axis(fiber->mutable_axes()[i], tensor->mutable_axes()[i]);
     }
 }
 

--- a/nntile/include/nntile/tensor/graph_data_node.hh
+++ b/nntile/include/nntile/tensor/graph_data_node.hh
@@ -180,15 +180,9 @@ inline void validate_slice_shape_and_merge(TensorGraph::TensorNode *slice,
 
 //! Validate fiber shape and merge axes (fiber 1+batch_ndim into tensor).
 //!
-//! ``axis`` is a **storage** axis index on ``tensor`` (0 = innermost), not a
-//! graph axis. TensorGraph fiber builders that take graph axes must call
-//! ``graph_axis_to_storage`` before invoking this helper.
-//!
-//! Size checks compare ``fiber->storage_shape()`` to ``tensor->storage_shape()``.
-//! ``fiber`` storage layout is ``[fiber_dim, batch_0, …, batch_{batch_ndim-1}]``
-//! aligned with the tensor's trailing ``batch_ndim`` storage dimensions.
-//! ``merge_axis`` updates graph ``AxisDescriptor`` groups using storage indices
-//! mapped back to graph axes via ``storage_axis_to_graph``.
+//! ``axis`` is a **graph** axis on ``tensor`` (0 = outermost). Fiber graph shape
+//! is ``[fiber_dim, batch_0, …, batch_{batch_ndim-1}]`` with leading batch
+//! prefix aligned to tensor graph axes ``[0, batch_ndim)``.
 inline void validate_fiber_shape_and_merge(TensorGraph::TensorNode *fiber,
     TensorGraph::TensorNode *tensor,
     Index axis,
@@ -213,35 +207,25 @@ inline void validate_fiber_shape_and_merge(TensorGraph::TensorNode *fiber,
                                     std::to_string(tensor->ndim()) + " vs " +
                                     std::to_string(batch_ndim) + ")");
     }
-    const std::vector<Index> f_shape = fiber->storage_shape();
-    const std::vector<Index> t_shape = tensor->storage_shape();
-    const Index nd = tensor->ndim();
-    if (f_shape[0] != t_shape[axis])
+    if (fiber->shape()[0] != tensor->shape()[axis])
     {
         throw std::invalid_argument(
             op_name + ": fiber dim 0 must match tensor dim " +
-            std::to_string(axis) + " (" + std::to_string(f_shape[0]) +
-            " vs " + std::to_string(t_shape[axis]) + ")");
+            std::to_string(axis) + " (" + std::to_string(fiber->shape()[0]) +
+            " vs " + std::to_string(tensor->shape()[axis]) + ")");
     }
-    const Index fiber_nd = fiber->ndim();
-    merge_axis(
-        fiber->mutable_axes()[tensor::storage_axis_to_graph(0, fiber_nd)],
-        tensor->mutable_axes()[tensor::storage_axis_to_graph(axis, nd)]);
+    merge_axis(fiber->mutable_axes()[0], tensor->mutable_axes()[axis]);
     for (Index i = 0; i < batch_ndim; ++i)
     {
-        Index ti = nd - batch_ndim + i;
-        if (f_shape[1 + i] != t_shape[ti])
+        if (fiber->shape()[1 + i] != tensor->shape()[i])
         {
             throw std::invalid_argument(
                 op_name + ": fiber dim " + std::to_string(1 + i) +
-                " must match tensor dim " + std::to_string(ti) + " (" +
-                std::to_string(f_shape[1 + i]) + " vs " +
-                std::to_string(t_shape[ti]) + ")");
+                " must match tensor dim " + std::to_string(i) + " (" +
+                std::to_string(fiber->shape()[1 + i]) + " vs " +
+                std::to_string(tensor->shape()[i]) + ")");
         }
-        merge_axis(
-            fiber->mutable_axes()[tensor::storage_axis_to_graph(
-                1 + i, fiber_nd)],
-            tensor->mutable_axes()[tensor::storage_axis_to_graph(ti, nd)]);
+        merge_axis(fiber->mutable_axes()[1 + i], tensor->mutable_axes()[i]);
     }
 }
 

--- a/nntile/include/nntile/tensor/ops/gemm.hh
+++ b/nntile/include/nntile/tensor/ops/gemm.hh
@@ -36,7 +36,7 @@ namespace nntile::tensor
 //! @param trans_a Swap first ndim dimensions in A
 //! @param trans_b Swap first ndim dimensions in B
 //! @param ndim Number of contraction dimensions (default: 1)
-//! @param batch_ndim Number of trailing batch dimensions (default: 0)
+//! @param batch_ndim Leading batch rank shared by A and B (shape[0:batch_ndim))
 //! @return Output shape for the gemm result
 std::vector<Index> gemm_output_shape(const std::vector<Index> &a_shape,
     const std::vector<Index> &b_shape,
@@ -99,7 +99,7 @@ struct TensorGemmOp : TensorGraph::OpNode
 //! @param trans_a Transpose A (default: false)
 //! @param trans_b Transpose B (default: false)
 //! @param ndim Number of contraction dimensions (default: 1)
-//! @param batch_ndim Number of trailing batch dimensions (default: 0)
+//! @param batch_ndim Leading batch rank shared by A and B (shape[0:batch_ndim))
 //! @return Pointer to the output tensor
 TensorGraph::TensorNode *gemm(TensorGraph::TensorNode *a,
     TensorGraph::TensorNode *b,
@@ -118,7 +118,7 @@ TensorGraph::TensorNode *gemm(TensorGraph::TensorNode *a,
 //! @param trans_a Transpose A (default: false)
 //! @param trans_b Transpose B (default: false)
 //! @param ndim Number of contraction dimensions (default: 1)
-//! @param batch_ndim Number of trailing batch dimensions (default: 0)
+//! @param batch_ndim Leading batch rank shared by A and B (shape[0:batch_ndim))
 void gemm(TensorGraph::TensorNode *a,
     TensorGraph::TensorNode *b,
     TensorGraph::TensorNode *c,

--- a/nntile/include/nntile/tensor/shape_layout.hh
+++ b/nntile/include/nntile/tensor/shape_layout.hh
@@ -63,4 +63,38 @@ inline Index layout_axis(Index graph_axis, Index ndim)
     return graph_axis_to_storage(graph_axis, ndim);
 }
 
+//! Graph-order fiber shape: leading batch axes, then fiber axis (C-order).
+inline std::vector<Index> graph_fiber_shape(
+    const std::vector<Index> &tensor_shape,
+    Index graph_axis,
+    Index batch_ndim)
+{
+    std::vector<Index> out;
+    out.reserve(static_cast<size_t>(batch_ndim + 1));
+    for (Index i = 0; i < batch_ndim; ++i)
+    {
+        out.push_back(tensor_shape[static_cast<size_t>(i)]);
+    }
+    out.push_back(tensor_shape[static_cast<size_t>(graph_axis)]);
+    return out;
+}
+
+//! Map tensor grid coord to fiber grid coord (graph-axis semantics).
+inline void fiber_layout_coord_from_tensor(
+    const std::vector<Index> &tensor_coord,
+    Index graph_axis,
+    Index batch_ndim,
+    Index fiber_ndim,
+    Index tensor_ndim,
+    std::vector<Index> &fiber_coord)
+{
+    fiber_coord[static_cast<size_t>(layout_axis(batch_ndim, fiber_ndim))] =
+        tensor_coord[static_cast<size_t>(layout_axis(graph_axis, tensor_ndim))];
+    for (Index b = 0; b < batch_ndim; ++b)
+    {
+        fiber_coord[static_cast<size_t>(layout_axis(b, fiber_ndim))] =
+            tensor_coord[static_cast<size_t>(layout_axis(b, tensor_ndim))];
+    }
+}
+
 } // namespace nntile::tensor

--- a/nntile/include/nntile/tensor/shape_layout.hh
+++ b/nntile/include/nntile/tensor/shape_layout.hh
@@ -57,4 +57,10 @@ inline std::vector<Index> storage_shape_to_graph(
     return reverse_shape(storage_shape);
 }
 
+//! TensorAxisLayout grid_coord / grid_shape index for a graph axis.
+inline Index layout_axis(Index graph_axis, Index ndim)
+{
+    return graph_axis_to_storage(graph_axis, ndim);
+}
+
 } // namespace nntile::tensor

--- a/nntile/include/nntile/tile/graph_data_node.hh
+++ b/nntile/include/nntile/tile/graph_data_node.hh
@@ -26,6 +26,7 @@
 // NNTile headers
 #include <nntile/base_types.hh>
 #include <nntile/dtype.hh>
+#include <nntile/tensor/shape_layout.hh>
 
 namespace nntile
 {
@@ -48,7 +49,13 @@ class TileGraph::TileNode
     NodeId id() const { return id_; }
     const std::string &name() const { return name_; }
     DataType dtype() const { return dtype_; }
+    //! Graph-order shape (0 = outermost / slowest).
     const std::vector<Index> &shape() const { return shape_; }
+    //! Storage-order shape for core tile memory and kernels.
+    std::vector<Index> storage_shape() const
+    {
+        return tensor::graph_shape_to_storage(shape_);
+    }
     Index ndim() const { return static_cast<Index>(shape_.size()); }
     Index dim(int idx) const;
     Index nelems() const;

--- a/nntile/include/nntile/tile/ops/add_fiber.hh
+++ b/nntile/include/nntile/tile/ops/add_fiber.hh
@@ -26,6 +26,7 @@ struct TileAddFiberOp : TileGraph::OpNode
 {
     Scalar alpha = 0.0;
     Scalar beta = 0.0;
+//! axis: graph axis index (0 = outermost); execute converts for core kernels.
     Index axis = 0;
     Index batch_ndim = 0;
     TileGraph::TileNode* s1 = nullptr;
@@ -46,6 +47,7 @@ struct TileAddFiberOp : TileGraph::OpNode
         return std::make_shared<TileAddFiberOp>(*this);
     }
 };
-//! Add along fibers: output = alpha * fiber + beta * tensor (uses existing output)
+//! Add along fibers: output = alpha * fiber + beta * tensor (uses existing output).
+//! @param axis graph axis index (0 = outermost); converted at execute.
 void add_fiber(Scalar a, TileGraph::TileNode* s1, Scalar b, TileGraph::TileNode* s2, TileGraph::TileNode* dst, Index axis, Index batch_ndim);
 } // namespace nntile::tile

--- a/nntile/include/nntile/tile/ops/add_slice.hh
+++ b/nntile/include/nntile/tile/ops/add_slice.hh
@@ -25,6 +25,7 @@ namespace nntile::tile
 struct TileAddSliceOp : TileGraph::OpNode
 {
     Scalar alpha = 0, beta = 0;
+//! axis: graph axis index (0 = outermost); execute converts for core kernels.
     Index axis = 0;
     TileGraph::TileNode *s1 = nullptr, *s2 = nullptr, *dst = nullptr;
     TileAddSliceOp() = default;
@@ -40,6 +41,6 @@ struct TileAddSliceOp : TileGraph::OpNode
         return std::make_shared<TileAddSliceOp>(*this);
     }
 };
-//! Add slice: dst = alpha * src1 + beta * src2 (uses existing output)
+//! @param axis graph axis index (0 = outermost); converted at execute.
 void add_slice(Scalar a, TileGraph::TileNode* t1, Scalar b, TileGraph::TileNode* t2, TileGraph::TileNode* dst, Index axis);
 } // namespace nntile::tile

--- a/nntile/include/nntile/tile/ops/mask_scalar.hh
+++ b/nntile/include/nntile/tile/ops/mask_scalar.hh
@@ -25,6 +25,7 @@ namespace nntile::tile
 struct TileMaskScalarOp : TileGraph::OpNode
 {
     Scalar val = 0.0;
+//! batch_ndim: leading graph batch rank (not an axis index).
     Index batch_ndim = 0;
     TileGraph::TileNode* mask = nullptr;
     TileGraph::TileNode* a = nullptr;
@@ -42,7 +43,7 @@ struct TileMaskScalarOp : TileGraph::OpNode
         return std::make_shared<TileMaskScalarOp>(*this);
     }
 };
-//! Mask scalar: A[mask] = val
+//! @param batch_ndim leading graph batch dimensions (not an axis index).
 void mask_scalar(
     TileGraph::TileNode* mask, Scalar val, TileGraph::TileNode* a, Index batch_ndim = 0);
 } // namespace nntile::tile

--- a/nntile/include/nntile/tile/ops/maxsumexp.hh
+++ b/nntile/include/nntile/tile/ops/maxsumexp.hh
@@ -24,6 +24,7 @@ namespace nntile::tile
 //! MaxSumExp operation: dst = maxsumexp(src, axis)
 struct TileMaxsumexpOp : TileGraph::OpNode
 {
+//! axis: graph axis index (0 = outermost); execute converts for core kernels.
     Index axis = 0;
     int redux = 0;
     TileGraph::TileNode* src = nullptr;
@@ -41,5 +42,6 @@ struct TileMaxsumexpOp : TileGraph::OpNode
         return std::make_shared<TileMaxsumexpOp>(*this);
     }
 };
+//! @param axis graph axis index on src (0 = outermost); converted at execute.
 void maxsumexp(TileGraph::TileNode* src, TileGraph::TileNode* dst, Index axis, int redux = 0);
 } // namespace nntile::tile

--- a/nntile/include/nntile/tile/ops/softmax.hh
+++ b/nntile/include/nntile/tile/ops/softmax.hh
@@ -25,6 +25,7 @@ namespace nntile::tile
 struct TileSoftmaxOp : TileGraph::OpNode
 {
     Scalar alpha = 0.0;
+//! axis: graph axis index (0 = outermost); execute converts for core kernels.
     Index axis = 0;
     TileGraph::TileNode* maxsumexp = nullptr;
     TileGraph::TileNode* src = nullptr;
@@ -44,6 +45,7 @@ struct TileSoftmaxOp : TileGraph::OpNode
         return std::make_shared<TileSoftmaxOp>(*this);
     }
 };
+//! @param axis graph axis index (0 = outermost); converted at execute.
 void softmax(
     TileGraph::TileNode* maxsumexp_n,
     TileGraph::TileNode* src,

--- a/nntile/include/nntile/tile/ops/transpose.hh
+++ b/nntile/include/nntile/tile/ops/transpose.hh
@@ -25,6 +25,7 @@ namespace nntile::tile
 struct TileTransposeOp : TileGraph::OpNode
 {
     Scalar alpha = 0.0;
+//! ndim: number of leading graph axes in the cyclic transpose; converted at execute.
     Index ndim = 0;
     TileGraph::TileNode* src = nullptr;
     TileGraph::TileNode* dst = nullptr;
@@ -48,7 +49,7 @@ struct TileTransposeOp : TileGraph::OpNode
     }
 };
 
-//! Transpose: dst = alpha * transpose(src) (uses existing output)
+//! Cyclic transpose of leading graph axes; execute maps ndim to storage layout.
 void transpose(Scalar alpha, TileGraph::TileNode* src, TileGraph::TileNode* dst, Index ndim);
 
 } // namespace nntile::tile

--- a/nntile/include/nntile/tile/shape_layout.hh
+++ b/nntile/include/nntile/tile/shape_layout.hh
@@ -1,0 +1,17 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * NNTile is software framework for fast training of big neural networks on
+ * distributed-memory heterogeneous systems based on StarPU runtime system.
+ *
+ * @file include/nntile/tile/shape_layout.hh
+ * TileGraph shape labels vs core tile storage (re-export).
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include <nntile/tensor/shape_layout.hh>

--- a/nntile/src/nn/ops/norm_fiber.cc
+++ b/nntile/src/nn/ops/norm_fiber.cc
@@ -33,17 +33,7 @@ namespace
 std::vector<Index> norm_fiber_output_shape(
     const std::vector<Index> &x_shape, Index graph_axis, Index batch_ndim)
 {
-    const std::vector<Index> xs = tensor::graph_shape_to_storage(x_shape);
-    const Index nd = static_cast<Index>(xs.size());
-    const Index s_axis = tensor::graph_axis_to_storage(graph_axis, nd);
-    std::vector<Index> out_s;
-    out_s.reserve(batch_ndim + 1);
-    out_s.push_back(xs[s_axis]);
-    for (Index i = 0; i < batch_ndim; ++i)
-    {
-        out_s.push_back(xs[nd - batch_ndim + i]);
-    }
-    return tensor::storage_shape_to_graph(out_s);
+    return tensor::graph_fiber_shape(x_shape, graph_axis, batch_ndim);
 }
 
 } // anonymous namespace

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -496,7 +496,7 @@ void Runtime::allocate_missing_tiles()
             continue;
         }
         DataType dtype = node->dtype();
-        std::vector<Index> shape = node->shape();
+        std::vector<Index> shape = node->storage_shape();
 
         switch (dtype)
         {

--- a/nntile/src/tensor/ops/add_fiber.cc
+++ b/nntile/src/tensor/ops/add_fiber.cc
@@ -126,20 +126,16 @@ void TensorAddFiberOp::lower_to_tile(const LoweringContext &ctx) const
     const auto &tiles_o = tile_lower::tiles_of(ctx.tile_map, output);
 
     const Index out_nd = output->ndim();
-    const Index lay_ax = layout_axis(axis, out_nd);
+    const Index fiber_nd = fiber->ndim();
 
     std::vector<Index> dst_coord;
-    std::vector<Index> fiber_coord(static_cast<size_t>(fiber->ndim()));
+    std::vector<Index> fiber_coord(static_cast<size_t>(fiber_nd));
 
     for (Index lin_d = 0; lin_d < lay_d->grid_volume(); ++lin_d)
     {
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
-        fiber_coord[0] = dst_coord[static_cast<size_t>(lay_ax)];
-        for (Index b = 0; b < batch_ndim; ++b)
-        {
-            fiber_coord[static_cast<size_t>(b + 1)] =
-                dst_coord[static_cast<size_t>(layout_axis(b, out_nd))];
-        }
+        fiber_layout_coord_from_tensor(
+            dst_coord, axis, batch_ndim, fiber_nd, out_nd, fiber_coord);
         const Index lin_f = lay_f->grid_linear(fiber_coord);
         tile::add_fiber(alpha,
             tiles_f[static_cast<size_t>(lin_f)],

--- a/nntile/src/tensor/ops/add_fiber.cc
+++ b/nntile/src/tensor/ops/add_fiber.cc
@@ -112,6 +112,9 @@ void add_fiber(Scalar alpha,
 
 void TensorAddFiberOp::lower_to_tile(const LoweringContext &ctx) const
 {
+    const Index g_axis =
+        storage_axis_to_graph(axis, output->ndim());
+
     // Match nntile::tensor::add_fiber_async (src/tensor/add_fiber.cc).
     const TensorAxisLayout *lay_d = ctx.tiling.find(output);
     const TensorAxisLayout *lay_f = ctx.tiling.find(fiber);
@@ -148,7 +151,7 @@ void TensorAddFiberOp::lower_to_tile(const LoweringContext &ctx) const
             beta,
             tiles_t[static_cast<size_t>(lin_d)],
             tiles_o[static_cast<size_t>(lin_d)],
-            axis,
+            g_axis,
             batch_ndim);
     }
 }

--- a/nntile/src/tensor/ops/add_fiber.cc
+++ b/nntile/src/tensor/ops/add_fiber.cc
@@ -53,10 +53,8 @@ TensorGraph::TensorNode *add_fiber(Scalar alpha,
             "add_fiber: input tensors must have the same dtype");
     }
 
-    const Index s_axis = graph_axis_to_storage(axis, tensor->ndim());
-
     validate_fiber_shape_and_merge(
-        fiber, tensor, s_axis, batch_ndim, "add_fiber");
+        fiber, tensor, axis, batch_ndim, "add_fiber");
 
     // Output shape matches tensor (fiber is broadcast)
     std::vector<Index> output_shape = tensor->shape();
@@ -65,7 +63,7 @@ TensorGraph::TensorNode *add_fiber(Scalar alpha,
     output->set_axes(tensor->axes());
 
     auto op = std::make_shared<TensorAddFiberOp>(
-        fiber, tensor, output, alpha, beta, s_axis, batch_ndim);
+        fiber, tensor, output, alpha, beta, axis, batch_ndim);
     fiber->graph()->add_op(op);
 
     return output;
@@ -99,22 +97,18 @@ void add_fiber(Scalar alpha,
         throw std::invalid_argument(
             "add_fiber: fiber, tensor, and output must be distinct tensors");
     }
-    const Index s_axis = graph_axis_to_storage(axis, tensor->ndim());
 
     validate_fiber_shape_and_merge(
-        fiber, tensor, s_axis, batch_ndim, "add_fiber");
+        fiber, tensor, axis, batch_ndim, "add_fiber");
     validate_same_shape_and_merge(tensor, output, "add_fiber");
 
     auto op = std::make_shared<TensorAddFiberOp>(
-        fiber, tensor, output, alpha, beta, s_axis, batch_ndim);
+        fiber, tensor, output, alpha, beta, axis, batch_ndim);
     fiber->graph()->add_op(op);
 }
 
 void TensorAddFiberOp::lower_to_tile(const LoweringContext &ctx) const
 {
-    const Index g_axis =
-        storage_axis_to_graph(axis, output->ndim());
-
     // Match nntile::tensor::add_fiber_async (src/tensor/add_fiber.cc).
     const TensorAxisLayout *lay_d = ctx.tiling.find(output);
     const TensorAxisLayout *lay_f = ctx.tiling.find(fiber);
@@ -131,19 +125,20 @@ void TensorAddFiberOp::lower_to_tile(const LoweringContext &ctx) const
     const auto &tiles_t = tile_lower::tiles_of(ctx.tile_map, tensor);
     const auto &tiles_o = tile_lower::tiles_of(ctx.tile_map, output);
 
+    const Index out_nd = output->ndim();
+    const Index lay_ax = layout_axis(axis, out_nd);
+
     std::vector<Index> dst_coord;
     std::vector<Index> fiber_coord(static_cast<size_t>(fiber->ndim()));
 
     for (Index lin_d = 0; lin_d < lay_d->grid_volume(); ++lin_d)
     {
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
-        const Index j = dst_coord[static_cast<size_t>(axis)];
-        fiber_coord[0] = j;
+        fiber_coord[0] = dst_coord[static_cast<size_t>(lay_ax)];
         for (Index b = 0; b < batch_ndim; ++b)
         {
             fiber_coord[static_cast<size_t>(b + 1)] =
-                dst_coord[static_cast<size_t>(
-                    output->ndim() - batch_ndim + b)];
+                dst_coord[static_cast<size_t>(layout_axis(b, out_nd))];
         }
         const Index lin_f = lay_f->grid_linear(fiber_coord);
         tile::add_fiber(alpha,
@@ -151,7 +146,7 @@ void TensorAddFiberOp::lower_to_tile(const LoweringContext &ctx) const
             beta,
             tiles_t[static_cast<size_t>(lin_d)],
             tiles_o[static_cast<size_t>(lin_d)],
-            g_axis,
+            axis,
             batch_ndim);
     }
 }

--- a/nntile/src/tensor/ops/add_fiber_inplace.cc
+++ b/nntile/src/tensor/ops/add_fiber_inplace.cc
@@ -30,8 +30,6 @@
 namespace nntile::tensor
 {
 
-
-
 void add_fiber_inplace(
     Scalar alpha,
     TensorGraph::TensorNode* fiber,
@@ -60,20 +58,16 @@ void add_fiber_inplace(
         throw std::invalid_argument(
             "add_fiber_inplace: fiber and tensor must be distinct tensors");
     }
-    const Index s_axis = graph_axis_to_storage(axis, tensor->ndim());
-    validate_fiber_shape_and_merge(fiber, tensor, s_axis, batch_ndim,
+    validate_fiber_shape_and_merge(fiber, tensor, axis, batch_ndim,
                                    "add_fiber_inplace");
 
     auto op = std::make_shared<TensorAddFiberInplaceOp>(
-        fiber, tensor, alpha, beta, s_axis, batch_ndim);
+        fiber, tensor, alpha, beta, axis, batch_ndim);
     tensor->graph()->add_op(op);
 }
 
 void TensorAddFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
 {
-    const Index g_axis =
-        storage_axis_to_graph(axis, tensor->ndim());
-
     // Match nntile::tensor::add_fiber_inplace_async (src/tensor/add_fiber_inplace.cc).
     if(alpha == 0.0)
     {
@@ -92,19 +86,20 @@ void TensorAddFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
     const auto& tiles_f = tile_lower::tiles_of(ctx.tile_map, fiber);
     const auto& tiles_t = tile_lower::tiles_of(ctx.tile_map, tensor);
 
+    const Index ten_nd = tensor->ndim();
+    const Index lay_ax = layout_axis(axis, ten_nd);
+
     std::vector<Index> dst_coord;
     std::vector<Index> fiber_coord(static_cast<size_t>(fiber->ndim()));
 
     for(Index lin_d = 0; lin_d < lay_d->grid_volume(); ++lin_d)
     {
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
-        const Index j = dst_coord[static_cast<size_t>(axis)];
-        fiber_coord[0] = j;
+        fiber_coord[0] = dst_coord[static_cast<size_t>(lay_ax)];
         for(Index b = 0; b < batch_ndim; ++b)
         {
             fiber_coord[static_cast<size_t>(b + 1)] =
-                dst_coord[static_cast<size_t>(
-                    tensor->ndim() - batch_ndim + b)];
+                dst_coord[static_cast<size_t>(layout_axis(b, ten_nd))];
         }
         const Index lin_f = lay_f->grid_linear(fiber_coord);
         tile::add_fiber_inplace(
@@ -112,7 +107,7 @@ void TensorAddFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
             tiles_f[static_cast<size_t>(lin_f)],
             beta,
             tiles_t[static_cast<size_t>(lin_d)],
-            g_axis,
+            axis,
             batch_ndim);
     }
 }

--- a/nntile/src/tensor/ops/add_fiber_inplace.cc
+++ b/nntile/src/tensor/ops/add_fiber_inplace.cc
@@ -87,20 +87,16 @@ void TensorAddFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
     const auto& tiles_t = tile_lower::tiles_of(ctx.tile_map, tensor);
 
     const Index ten_nd = tensor->ndim();
-    const Index lay_ax = layout_axis(axis, ten_nd);
+    const Index fiber_nd = fiber->ndim();
 
     std::vector<Index> dst_coord;
-    std::vector<Index> fiber_coord(static_cast<size_t>(fiber->ndim()));
+    std::vector<Index> fiber_coord(static_cast<size_t>(fiber_nd));
 
     for(Index lin_d = 0; lin_d < lay_d->grid_volume(); ++lin_d)
     {
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
-        fiber_coord[0] = dst_coord[static_cast<size_t>(lay_ax)];
-        for(Index b = 0; b < batch_ndim; ++b)
-        {
-            fiber_coord[static_cast<size_t>(b + 1)] =
-                dst_coord[static_cast<size_t>(layout_axis(b, ten_nd))];
-        }
+        fiber_layout_coord_from_tensor(
+            dst_coord, axis, batch_ndim, fiber_nd, ten_nd, fiber_coord);
         const Index lin_f = lay_f->grid_linear(fiber_coord);
         tile::add_fiber_inplace(
             alpha,

--- a/nntile/src/tensor/ops/add_fiber_inplace.cc
+++ b/nntile/src/tensor/ops/add_fiber_inplace.cc
@@ -72,7 +72,7 @@ void add_fiber_inplace(
 void TensorAddFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
 {
     const Index g_axis =
-        storage_axis_to_graph(axis, dst->ndim());
+        storage_axis_to_graph(axis, tensor->ndim());
 
     // Match nntile::tensor::add_fiber_inplace_async (src/tensor/add_fiber_inplace.cc).
     if(alpha == 0.0)

--- a/nntile/src/tensor/ops/add_fiber_inplace.cc
+++ b/nntile/src/tensor/ops/add_fiber_inplace.cc
@@ -71,6 +71,9 @@ void add_fiber_inplace(
 
 void TensorAddFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
 {
+    const Index g_axis =
+        storage_axis_to_graph(axis, dst->ndim());
+
     // Match nntile::tensor::add_fiber_inplace_async (src/tensor/add_fiber_inplace.cc).
     if(alpha == 0.0)
     {
@@ -109,7 +112,7 @@ void TensorAddFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
             tiles_f[static_cast<size_t>(lin_f)],
             beta,
             tiles_t[static_cast<size_t>(lin_d)],
-            axis,
+            g_axis,
             batch_ndim);
     }
 }

--- a/nntile/src/tensor/ops/add_slice.cc
+++ b/nntile/src/tensor/ops/add_slice.cc
@@ -168,7 +168,7 @@ void TensorAddSliceOp::lower_to_tile(const LoweringContext &ctx) const
                 beta,
                 tiles_s2[static_cast<size_t>(lin_d)],
                 tiles_d[static_cast<size_t>(lin_d)],
-                s_axis);
+                axis);
         }
     }
 }

--- a/nntile/src/tensor/ops/add_slice.cc
+++ b/nntile/src/tensor/ops/add_slice.cc
@@ -122,7 +122,7 @@ void TensorAddSliceOp::lower_to_tile(const LoweringContext &ctx) const
 
     const Index nd = dst->ndim();
     const Index s1_nd = src1->ndim();
-    const Index s_axis = graph_axis_to_storage(axis, nd);
+    const Index lay_ax = layout_axis(axis, nd);
 
     std::vector<Index> s1_coord;
     std::vector<Index> dst_coord(static_cast<size_t>(nd));
@@ -132,13 +132,12 @@ void TensorAddSliceOp::lower_to_tile(const LoweringContext &ctx) const
         lay_s1->grid_coord_from_linear(lin_s1, s1_coord);
         TileGraph::TileNode *s1_tile = tiles_s1[static_cast<size_t>(lin_s1)];
 
-        for (Index s = 0; s < nd; ++s)
+        for (Index g = 0; g < nd; ++g)
         {
-            if (s == s_axis)
+            if (g == axis)
             {
                 continue;
             }
-            const Index g = storage_axis_to_graph(s, nd);
             Index g1 = 0;
             for (Index g2 = 0; g2 < nd; ++g2)
             {
@@ -152,16 +151,15 @@ void TensorAddSliceOp::lower_to_tile(const LoweringContext &ctx) const
                 }
                 ++g1;
             }
-            dst_coord[static_cast<size_t>(s)] =
-                s1_coord[static_cast<size_t>(
-                    graph_axis_to_storage(g1, s1_nd))];
+            dst_coord[static_cast<size_t>(layout_axis(g, nd))] =
+                s1_coord[static_cast<size_t>(layout_axis(g1, s1_nd))];
         }
 
         const Index nseg_along_axis =
-            lay_d->grid_shape()[static_cast<size_t>(s_axis)];
+            lay_d->grid_shape()[static_cast<size_t>(lay_ax)];
         for (Index jj = 0; jj < nseg_along_axis; ++jj)
         {
-            dst_coord[static_cast<size_t>(s_axis)] = jj;
+            dst_coord[static_cast<size_t>(lay_ax)] = jj;
             const Index lin_d = lay_d->grid_linear(dst_coord);
             tile::add_slice(alpha,
                 s1_tile,

--- a/nntile/src/tensor/ops/add_slice_inplace.cc
+++ b/nntile/src/tensor/ops/add_slice_inplace.cc
@@ -127,7 +127,7 @@ void TensorAddSliceInplaceOp::lower_to_tile(const LoweringContext& ctx) const
                 tiles_s[static_cast<size_t>(lin_s)],
                 beta,
                 tiles_d[static_cast<size_t>(lin_d)],
-                s_axis);
+                axis);
         }
     }
 }

--- a/nntile/src/tensor/ops/add_slice_inplace.cc
+++ b/nntile/src/tensor/ops/add_slice_inplace.cc
@@ -83,7 +83,7 @@ void TensorAddSliceInplaceOp::lower_to_tile(const LoweringContext& ctx) const
 
     const Index nd = dst->ndim();
     const Index s_nd = src->ndim();
-    const Index s_axis = graph_axis_to_storage(axis, nd);
+    const Index lay_ax = layout_axis(axis, nd);
 
     std::vector<Index> s_coord;
     std::vector<Index> d_coord(static_cast<size_t>(nd));
@@ -91,13 +91,12 @@ void TensorAddSliceInplaceOp::lower_to_tile(const LoweringContext& ctx) const
     for(Index lin_s = 0; lin_s < lay_s->grid_volume(); ++lin_s)
     {
         lay_s->grid_coord_from_linear(lin_s, s_coord);
-        for(Index s = 0; s < nd; ++s)
+        for(Index g = 0; g < nd; ++g)
         {
-            if(s == s_axis)
+            if(g == axis)
             {
                 continue;
             }
-            const Index g = storage_axis_to_graph(s, nd);
             Index g1 = 0;
             for(Index g2 = 0; g2 < nd; ++g2)
             {
@@ -111,16 +110,15 @@ void TensorAddSliceInplaceOp::lower_to_tile(const LoweringContext& ctx) const
                 }
                 ++g1;
             }
-            d_coord[static_cast<size_t>(s)] =
-                s_coord[static_cast<size_t>(
-                    graph_axis_to_storage(g1, s_nd))];
+            d_coord[static_cast<size_t>(layout_axis(g, nd))] =
+                s_coord[static_cast<size_t>(layout_axis(g1, s_nd))];
         }
 
         const Index nseg_along_axis =
-            lay_d->grid_shape()[static_cast<size_t>(s_axis)];
+            lay_d->grid_shape()[static_cast<size_t>(lay_ax)];
         for(Index jj = 0; jj < nseg_along_axis; ++jj)
         {
-            d_coord[static_cast<size_t>(s_axis)] = jj;
+            d_coord[static_cast<size_t>(lay_ax)] = jj;
             const Index lin_d = lay_d->grid_linear(d_coord);
             tile::add_slice_inplace(
                 alpha,

--- a/nntile/src/tensor/ops/gemm.cc
+++ b/nntile/src/tensor/ops/gemm.cc
@@ -564,13 +564,13 @@ void TensorGemmOp::lower_to_tile(const LoweringContext &ctx) const
             const bool first_k = (kk == 0);
             const Scalar beta_use = (first_k ? beta : Scalar(1.0));
 
-            tile::gemm(tb,
-                ta,
+            tile::gemm(ta,
+                tb,
                 tc,
                 alpha,
                 beta_use,
-                trans_b,
                 trans_a,
+                trans_b,
                 ndim,
                 batch_ndim);
         }

--- a/nntile/src/tensor/ops/maxsumexp.cc
+++ b/nntile/src/tensor/ops/maxsumexp.cc
@@ -35,24 +35,23 @@ namespace nntile::tensor
 namespace
 {
 
-//! Map maxsumexp tile storage coord to src storage coord (omit pair axis).
-void maxsumexp_to_src_storage_coord(const std::vector<Index> &m_storage,
+//! Map maxsumexp grid coord to src grid coord (omit pair axis).
+void maxsumexp_to_src_grid_coord(const std::vector<Index> &m_coord,
     Index axis,
     Index src_ndim,
-    std::vector<Index> &src_storage)
+    std::vector<Index> &src_coord)
 {
-    src_storage.resize(static_cast<size_t>(src_ndim));
-    for (Index s = 0; s < src_ndim; ++s)
+    src_coord.resize(static_cast<size_t>(src_ndim));
+    for (Index g = 0; g < src_ndim; ++g)
     {
-        const Index g = storage_axis_to_graph(s, src_ndim);
         if (g == axis)
         {
             continue;
         }
         const Index m_g = (g < axis) ? g : (g - 1);
-        const Index dst_ndim = static_cast<Index>(m_storage.size());
-        const Index m_s = graph_axis_to_storage(m_g, dst_ndim);
-        src_storage[static_cast<size_t>(s)] = m_storage[static_cast<size_t>(m_s)];
+        const Index m_ndim = static_cast<Index>(m_coord.size());
+        src_coord[static_cast<size_t>(layout_axis(g, src_ndim))] =
+            m_coord[static_cast<size_t>(layout_axis(m_g, m_ndim))];
     }
 }
 
@@ -130,7 +129,7 @@ void TensorMaxsumexpOp::lower_to_tile(const LoweringContext &ctx) const
     const auto &tiles_dst = tile_lower::tiles_of(ctx.tile_map, dst);
 
     const Index src_nd = src->ndim();
-    const Index s_axis = graph_axis_to_storage(axis, src_nd);
+    const Index lay_ax = layout_axis(axis, src_nd);
 
     std::vector<Index> dst_coord;
     std::vector<Index> src_coord(static_cast<size_t>(src_nd));
@@ -141,15 +140,15 @@ void TensorMaxsumexpOp::lower_to_tile(const LoweringContext &ctx) const
         TileGraph::TileNode *dst_tile =
             tiles_dst[static_cast<size_t>(lin_dst)];
 
-        maxsumexp_to_src_storage_coord(dst_coord, axis, src_nd, src_coord);
+        maxsumexp_to_src_grid_coord(dst_coord, axis, src_nd, src_coord);
 
         tile::clear(dst_tile);
 
         const Index nseg_along_axis =
-            lay_src->grid_shape()[static_cast<size_t>(s_axis)];
+            lay_src->grid_shape()[static_cast<size_t>(lay_ax)];
         for (Index j = 0; j < nseg_along_axis; ++j)
         {
-            src_coord[static_cast<size_t>(s_axis)] = j;
+            src_coord[static_cast<size_t>(lay_ax)] = j;
             const Index lin_src = lay_src->grid_linear(src_coord);
             TileGraph::TileNode *src_tile =
                 tiles_src[static_cast<size_t>(lin_src)];

--- a/nntile/src/tensor/ops/maxsumexp.cc
+++ b/nntile/src/tensor/ops/maxsumexp.cc
@@ -153,7 +153,7 @@ void TensorMaxsumexpOp::lower_to_tile(const LoweringContext &ctx) const
             const Index lin_src = lay_src->grid_linear(src_coord);
             TileGraph::TileNode *src_tile =
                 tiles_src[static_cast<size_t>(lin_src)];
-            tile::maxsumexp(src_tile, dst_tile, s_axis, redux);
+            tile::maxsumexp(src_tile, dst_tile, axis, redux);
         }
     }
 }

--- a/nntile/src/tensor/ops/multiply_fiber.cc
+++ b/nntile/src/tensor/ops/multiply_fiber.cc
@@ -123,6 +123,9 @@ void multiply_fiber(Scalar alpha,
 
 void TensorMultiplyFiberOp::lower_to_tile(const LoweringContext &ctx) const
 {
+    const Index g_axis =
+        storage_axis_to_graph(axis, dst->ndim());
+
     // Match nntile::tensor::multiply_fiber_async
     // (src/tensor/multiply_fiber.cc).
     const TensorAxisLayout *lay_d = ctx.tiling.find(dst);
@@ -149,7 +152,7 @@ void TensorMultiplyFiberOp::lower_to_tile(const LoweringContext &ctx) const
             tiles_s1[static_cast<size_t>(j)],
             tiles_s2[static_cast<size_t>(lin_d)],
             tiles_d[static_cast<size_t>(lin_d)],
-            axis);
+            g_axis);
     }
 }
 

--- a/nntile/src/tensor/ops/multiply_fiber.cc
+++ b/nntile/src/tensor/ops/multiply_fiber.cc
@@ -60,9 +60,7 @@ TensorGraph::TensorNode *multiply_fiber(Scalar alpha,
         throw std::invalid_argument("multiply_fiber: axis out of range");
     }
 
-    const Index s_axis = graph_axis_to_storage(axis, src2->ndim());
-
-    validate_fiber_shape_and_merge(src1, src2, s_axis, 0, "multiply_fiber");
+    validate_fiber_shape_and_merge(src1, src2, axis, 0, "multiply_fiber");
 
     std::vector<Index> output_shape = src2->shape();
     TensorGraph::TensorNode *dst =
@@ -70,7 +68,7 @@ TensorGraph::TensorNode *multiply_fiber(Scalar alpha,
     dst->set_axes(src2->axes());
 
     auto op = std::make_shared<TensorMultiplyFiberOp>(
-        alpha, src1, src2, dst, s_axis);
+        alpha, src1, src2, dst, axis);
     src1->graph()->add_op(op);
 
     return dst;
@@ -111,21 +109,16 @@ void multiply_fiber(Scalar alpha,
             "multiply_fiber: src1, src2, and dst must be distinct tensors");
     }
 
-    const Index s_axis = graph_axis_to_storage(axis, src2->ndim());
-
-    validate_fiber_shape_and_merge(src1, src2, s_axis, 0, "multiply_fiber");
+    validate_fiber_shape_and_merge(src1, src2, axis, 0, "multiply_fiber");
     validate_same_shape_and_merge(src2, dst, "multiply_fiber");
 
     auto op = std::make_shared<TensorMultiplyFiberOp>(
-        alpha, src1, src2, dst, s_axis);
+        alpha, src1, src2, dst, axis);
     src1->graph()->add_op(op);
 }
 
 void TensorMultiplyFiberOp::lower_to_tile(const LoweringContext &ctx) const
 {
-    const Index g_axis =
-        storage_axis_to_graph(axis, dst->ndim());
-
     // Match nntile::tensor::multiply_fiber_async
     // (src/tensor/multiply_fiber.cc).
     const TensorAxisLayout *lay_d = ctx.tiling.find(dst);
@@ -142,17 +135,20 @@ void TensorMultiplyFiberOp::lower_to_tile(const LoweringContext &ctx) const
     const auto &tiles_s2 = tile_lower::tiles_of(ctx.tile_map, src2);
     const auto &tiles_d = tile_lower::tiles_of(ctx.tile_map, dst);
 
+    const Index dst_nd = dst->ndim();
+    const Index lay_ax = layout_axis(axis, dst_nd);
+
     std::vector<Index> dst_coord;
 
     for (Index lin_d = 0; lin_d < lay_d->grid_volume(); ++lin_d)
     {
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
-        const Index j = dst_coord[static_cast<size_t>(axis)];
+        const Index j = dst_coord[static_cast<size_t>(lay_ax)];
         tile::multiply_fiber(alpha,
             tiles_s1[static_cast<size_t>(j)],
             tiles_s2[static_cast<size_t>(lin_d)],
             tiles_d[static_cast<size_t>(lin_d)],
-            g_axis);
+            axis);
     }
 }
 

--- a/nntile/src/tensor/ops/multiply_fiber_inplace.cc
+++ b/nntile/src/tensor/ops/multiply_fiber_inplace.cc
@@ -32,6 +32,9 @@ namespace nntile::tensor
 
 void TensorMultiplyFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
 {
+    const Index g_axis =
+        storage_axis_to_graph(axis, dst->ndim());
+
     // Match nntile::tensor::multiply_fiber_inplace_async
     // (src/tensor/multiply_fiber_inplace.cc).
     const TensorAxisLayout* lay_d = ctx.tiling.find(dst);
@@ -49,7 +52,7 @@ void TensorMultiplyFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) con
         const Index j = dst_coord[static_cast<size_t>(axis)];
         tile::multiply_fiber_inplace(
             alpha, ts[static_cast<size_t>(j)], td[static_cast<size_t>(lin_d)],
-            axis);
+            g_axis);
     }
 }
 

--- a/nntile/src/tensor/ops/multiply_fiber_inplace.cc
+++ b/nntile/src/tensor/ops/multiply_fiber_inplace.cc
@@ -32,9 +32,6 @@ namespace nntile::tensor
 
 void TensorMultiplyFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
 {
-    const Index g_axis =
-        storage_axis_to_graph(axis, dst->ndim());
-
     // Match nntile::tensor::multiply_fiber_inplace_async
     // (src/tensor/multiply_fiber_inplace.cc).
     const TensorAxisLayout* lay_d = ctx.tiling.find(dst);
@@ -45,14 +42,16 @@ void TensorMultiplyFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) con
     }
     const auto& ts = tile_lower::tiles_of(ctx.tile_map, src);
     const auto& td = tile_lower::tiles_of(ctx.tile_map, dst);
+    const Index dst_nd = dst->ndim();
+    const Index lay_ax = layout_axis(axis, dst_nd);
     std::vector<Index> dst_coord;
     for(Index lin_d = 0; lin_d < lay_d->grid_volume(); ++lin_d)
     {
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
-        const Index j = dst_coord[static_cast<size_t>(axis)];
+        const Index j = dst_coord[static_cast<size_t>(lay_ax)];
         tile::multiply_fiber_inplace(
             alpha, ts[static_cast<size_t>(j)], td[static_cast<size_t>(lin_d)],
-            g_axis);
+            axis);
     }
 }
 
@@ -82,12 +81,11 @@ void multiply_fiber_inplace(
         throw std::invalid_argument(
             "multiply_fiber_inplace: input tensors must have the same dtype");
     }
-    const Index s_axis = graph_axis_to_storage(axis, dst->ndim());
-    validate_fiber_shape_and_merge(src, dst, s_axis, 0,
+    validate_fiber_shape_and_merge(src, dst, axis, 0,
         "multiply_fiber_inplace");
 
     auto op = std::make_shared<TensorMultiplyFiberInplaceOp>(
-        alpha, src, dst, s_axis);
+        alpha, src, dst, axis);
     src->graph()->add_op(op);
 }
 

--- a/nntile/src/tensor/ops/multiply_slice.cc
+++ b/nntile/src/tensor/ops/multiply_slice.cc
@@ -126,7 +126,7 @@ void TensorMultiplySliceOp::lower_to_tile(const LoweringContext& ctx) const
                 alpha,
                 s_tile,
                 tiles_d[static_cast<size_t>(lin_d)],
-                s_axis);
+                axis);
         }
     }
 }

--- a/nntile/src/tensor/ops/multiply_slice.cc
+++ b/nntile/src/tensor/ops/multiply_slice.cc
@@ -81,7 +81,7 @@ void TensorMultiplySliceOp::lower_to_tile(const LoweringContext& ctx) const
 
     const Index nd = dst->ndim();
     const Index s_nd = src->ndim();
-    const Index s_axis = graph_axis_to_storage(axis, nd);
+    const Index lay_ax = layout_axis(axis, nd);
 
     std::vector<Index> s_coord;
     std::vector<Index> d_coord(static_cast<size_t>(nd));
@@ -91,13 +91,12 @@ void TensorMultiplySliceOp::lower_to_tile(const LoweringContext& ctx) const
         lay_s->grid_coord_from_linear(lin_s, s_coord);
         TileGraph::TileNode* s_tile = tiles_s[static_cast<size_t>(lin_s)];
 
-        for(Index s = 0; s < nd; ++s)
+        for(Index g = 0; g < nd; ++g)
         {
-            if(s == s_axis)
+            if(g == axis)
             {
                 continue;
             }
-            const Index g = storage_axis_to_graph(s, nd);
             Index g1 = 0;
             for(Index g2 = 0; g2 < nd; ++g2)
             {
@@ -111,16 +110,15 @@ void TensorMultiplySliceOp::lower_to_tile(const LoweringContext& ctx) const
                 }
                 ++g1;
             }
-            d_coord[static_cast<size_t>(s)] =
-                s_coord[static_cast<size_t>(
-                    graph_axis_to_storage(g1, s_nd))];
+            d_coord[static_cast<size_t>(layout_axis(g, nd))] =
+                s_coord[static_cast<size_t>(layout_axis(g1, s_nd))];
         }
 
         const Index nseg_along_axis =
-            lay_d->grid_shape()[static_cast<size_t>(s_axis)];
+            lay_d->grid_shape()[static_cast<size_t>(lay_ax)];
         for(Index jj = 0; jj < nseg_along_axis; ++jj)
         {
-            d_coord[static_cast<size_t>(s_axis)] = jj;
+            d_coord[static_cast<size_t>(lay_ax)] = jj;
             const Index lin_d = lay_d->grid_linear(d_coord);
             tile::multiply_slice(
                 alpha,

--- a/nntile/src/tensor/ops/norm_fiber.cc
+++ b/nntile/src/tensor/ops/norm_fiber.cc
@@ -136,10 +136,10 @@ void TensorNormFiberOp::lower_to_tile(const LoweringContext &ctx) const
 
     constexpr Scalar one = 1.0;
     const Index src_nd = src1->ndim();
-    const Index lay_ax = layout_axis(axis, src_nd);
+    const Index dst_nd = dst->ndim();
 
     std::vector<Index> s1_coord;
-    std::vector<Index> dst_coord(static_cast<size_t>(dst->ndim()));
+    std::vector<Index> dst_coord(static_cast<size_t>(dst_nd));
 
     for (Index lin1 = 0; lin1 < lay1->grid_volume(); ++lin1)
     {
@@ -155,12 +155,8 @@ void TensorNormFiberOp::lower_to_tile(const LoweringContext &ctx) const
             }
         }
 
-        dst_coord[0] = s1_coord[static_cast<size_t>(lay_ax)];
-        for (Index b = 0; b < batch_ndim; ++b)
-        {
-            dst_coord[static_cast<size_t>(b + 1)] =
-                s1_coord[static_cast<size_t>(layout_axis(b, src_nd))];
-        }
+        fiber_layout_coord_from_tensor(
+            s1_coord, axis, batch_ndim, dst_nd, src_nd, dst_coord);
         const Index lin_d = lay_d->grid_linear(dst_coord);
 
         if (init_first)

--- a/nntile/src/tensor/ops/norm_fiber.cc
+++ b/nntile/src/tensor/ops/norm_fiber.cc
@@ -116,6 +116,9 @@ void norm_fiber(Scalar alpha,
 
 void TensorNormFiberOp::lower_to_tile(const LoweringContext &ctx) const
 {
+    const Index g_axis =
+        storage_axis_to_graph(axis, dst->ndim());
+
     // Match nntile::tensor::norm_fiber_async (src/tensor/norm_fiber.cc).
     const TensorAxisLayout *lay1 = ctx.tiling.find(src1);
     if (lay1 == nullptr)
@@ -170,7 +173,7 @@ void TensorNormFiberOp::lower_to_tile(const LoweringContext &ctx) const
                 beta,
                 tiles_s2[static_cast<size_t>(lin_d)],
                 tiles_d[static_cast<size_t>(lin_d)],
-                axis,
+                g_axis,
                 batch_ndim,
                 redux);
         }
@@ -180,7 +183,7 @@ void TensorNormFiberOp::lower_to_tile(const LoweringContext &ctx) const
                 tiles_s1[static_cast<size_t>(lin1)],
                 one,
                 tiles_d[static_cast<size_t>(lin_d)],
-                axis,
+                g_axis,
                 batch_ndim,
                 redux);
         }

--- a/nntile/src/tensor/ops/norm_fiber.cc
+++ b/nntile/src/tensor/ops/norm_fiber.cc
@@ -117,7 +117,7 @@ void norm_fiber(Scalar alpha,
 void TensorNormFiberOp::lower_to_tile(const LoweringContext &ctx) const
 {
     const Index g_axis =
-        storage_axis_to_graph(axis, dst->ndim());
+        storage_axis_to_graph(axis, src1->ndim());
 
     // Match nntile::tensor::norm_fiber_async (src/tensor/norm_fiber.cc).
     const TensorAxisLayout *lay1 = ctx.tiling.find(src1);

--- a/nntile/src/tensor/ops/norm_fiber.cc
+++ b/nntile/src/tensor/ops/norm_fiber.cc
@@ -60,14 +60,12 @@ TensorGraph::TensorNode *norm_fiber(Scalar alpha,
     TensorGraph::TensorNode *dst =
         src1->graph()->data(std::move(output_shape), src1->dtype());
 
-    const Index s_axis = graph_axis_to_storage(axis, src1->ndim());
-
     validate_fiber_shape_and_merge(
-        dst, src1, s_axis, batch_ndim, "norm_fiber");
+        dst, src1, axis, batch_ndim, "norm_fiber");
     validate_same_shape_and_merge(src2, dst, "norm_fiber");
 
     auto op = std::make_shared<TensorNormFiberOp>(
-        alpha, beta, src1, src2, dst, s_axis, batch_ndim, redux);
+        alpha, beta, src1, src2, dst, axis, batch_ndim, redux);
     src1->graph()->add_op(op);
 
     return dst;
@@ -103,22 +101,17 @@ void norm_fiber(Scalar alpha,
             "norm_fiber: src1, src2, and dst must be distinct tensors");
     }
 
-    const Index s_axis = graph_axis_to_storage(axis, src1->ndim());
-
     validate_fiber_shape_and_merge(
-        dst, src1, s_axis, batch_ndim, "norm_fiber");
+        dst, src1, axis, batch_ndim, "norm_fiber");
     validate_same_shape_and_merge(src2, dst, "norm_fiber");
 
     auto op = std::make_shared<TensorNormFiberOp>(
-        alpha, beta, src1, src2, dst, s_axis, batch_ndim, redux);
+        alpha, beta, src1, src2, dst, axis, batch_ndim, redux);
     src1->graph()->add_op(op);
 }
 
 void TensorNormFiberOp::lower_to_tile(const LoweringContext &ctx) const
 {
-    const Index g_axis =
-        storage_axis_to_graph(axis, src1->ndim());
-
     // Match nntile::tensor::norm_fiber_async (src/tensor/norm_fiber.cc).
     const TensorAxisLayout *lay1 = ctx.tiling.find(src1);
     if (lay1 == nullptr)
@@ -142,6 +135,9 @@ void TensorNormFiberOp::lower_to_tile(const LoweringContext &ctx) const
     const auto &tiles_d = tile_lower::tiles_of(ctx.tile_map, dst);
 
     constexpr Scalar one = 1.0;
+    const Index src_nd = src1->ndim();
+    const Index lay_ax = layout_axis(axis, src_nd);
+
     std::vector<Index> s1_coord;
     std::vector<Index> dst_coord(static_cast<size_t>(dst->ndim()));
 
@@ -149,20 +145,21 @@ void TensorNormFiberOp::lower_to_tile(const LoweringContext &ctx) const
     {
         lay1->grid_coord_from_linear(lin1, s1_coord);
         bool init_first = true;
-        for (Index j = 0; j < src1->ndim() - batch_ndim; ++j)
+        for (Index g = batch_ndim; g < src_nd; ++g)
         {
-            if (j != axis && s1_coord[static_cast<size_t>(j)] != 0)
+            if (g != axis
+                && s1_coord[static_cast<size_t>(layout_axis(g, src_nd))] != 0)
             {
                 init_first = false;
                 break;
             }
         }
 
-        dst_coord[0] = s1_coord[static_cast<size_t>(axis)];
+        dst_coord[0] = s1_coord[static_cast<size_t>(lay_ax)];
         for (Index b = 0; b < batch_ndim; ++b)
         {
             dst_coord[static_cast<size_t>(b + 1)] =
-                s1_coord[static_cast<size_t>(src1->ndim() - batch_ndim + b)];
+                s1_coord[static_cast<size_t>(layout_axis(b, src_nd))];
         }
         const Index lin_d = lay_d->grid_linear(dst_coord);
 
@@ -173,7 +170,7 @@ void TensorNormFiberOp::lower_to_tile(const LoweringContext &ctx) const
                 beta,
                 tiles_s2[static_cast<size_t>(lin_d)],
                 tiles_d[static_cast<size_t>(lin_d)],
-                g_axis,
+                axis,
                 batch_ndim,
                 redux);
         }
@@ -183,7 +180,7 @@ void TensorNormFiberOp::lower_to_tile(const LoweringContext &ctx) const
                 tiles_s1[static_cast<size_t>(lin1)],
                 one,
                 tiles_d[static_cast<size_t>(lin_d)],
-                g_axis,
+                axis,
                 batch_ndim,
                 redux);
         }

--- a/nntile/src/tensor/ops/norm_fiber_inplace.cc
+++ b/nntile/src/tensor/ops/norm_fiber_inplace.cc
@@ -32,9 +32,6 @@ namespace nntile::tensor
 
 void TensorNormFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
 {
-    const Index g_axis =
-        storage_axis_to_graph(axis, src->ndim());
-
     // Match nntile::tensor::norm_fiber_inplace_async (src/tensor/norm_fiber_inplace.cc).
     const TensorAxisLayout* lay1 = ctx.tiling.find(src);
     const TensorAxisLayout* lay_d = ctx.tiling.find(dst);
@@ -47,27 +44,29 @@ void TensorNormFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
     const auto& tiles_s = tile_lower::tiles_of(ctx.tile_map, src);
     const auto& tiles_d = tile_lower::tiles_of(ctx.tile_map, dst);
     constexpr Scalar one = 1.0;
+    const Index src_nd = src->ndim();
+    const Index lay_ax = layout_axis(axis, src_nd);
     std::vector<Index> s1_coord;
     std::vector<Index> dst_coord(static_cast<size_t>(dst->ndim()));
-    const Index fiber_prefix = src->ndim() - batch_ndim;
 
     for(Index lin1 = 0; lin1 < lay1->grid_volume(); ++lin1)
     {
         lay1->grid_coord_from_linear(lin1, s1_coord);
         bool init_first = true;
-        for(Index j = 0; j < fiber_prefix; ++j)
+        for(Index g = batch_ndim; g < src_nd; ++g)
         {
-            if(j != axis && s1_coord[static_cast<size_t>(j)] != 0)
+            if(g != axis
+                && s1_coord[static_cast<size_t>(layout_axis(g, src_nd))] != 0)
             {
                 init_first = false;
                 break;
             }
         }
-        dst_coord[0] = s1_coord[static_cast<size_t>(axis)];
+        dst_coord[0] = s1_coord[static_cast<size_t>(lay_ax)];
         for(Index b = 0; b < batch_ndim; ++b)
         {
             dst_coord[static_cast<size_t>(b + 1)] =
-                s1_coord[static_cast<size_t>(src->ndim() - batch_ndim + b)];
+                s1_coord[static_cast<size_t>(layout_axis(b, src_nd))];
         }
         const Index lin_d = lay_d->grid_linear(dst_coord);
         if(init_first)
@@ -77,7 +76,7 @@ void TensorNormFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
                 tiles_s[static_cast<size_t>(lin1)],
                 beta,
                 tiles_d[static_cast<size_t>(lin_d)],
-                g_axis,
+                axis,
                 batch_ndim,
                 redux);
         }
@@ -88,7 +87,7 @@ void TensorNormFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
                 tiles_s[static_cast<size_t>(lin1)],
                 one,
                 tiles_d[static_cast<size_t>(lin_d)],
-                g_axis,
+                axis,
                 batch_ndim,
                 redux);
         }
@@ -124,12 +123,11 @@ void norm_fiber_inplace(
         throw std::invalid_argument(
             "norm_fiber_inplace: src and dst must be distinct tensors");
     }
-    const Index s_axis = graph_axis_to_storage(axis, src->ndim());
-    validate_fiber_shape_and_merge(dst, src, s_axis, batch_ndim,
+    validate_fiber_shape_and_merge(dst, src, axis, batch_ndim,
         "norm_fiber_inplace");
 
     auto op = std::make_shared<TensorNormFiberInplaceOp>(
-        alpha, beta, src, dst, s_axis, batch_ndim, redux);
+        alpha, beta, src, dst, axis, batch_ndim, redux);
     src->graph()->add_op(op);
 }
 

--- a/nntile/src/tensor/ops/norm_fiber_inplace.cc
+++ b/nntile/src/tensor/ops/norm_fiber_inplace.cc
@@ -45,9 +45,9 @@ void TensorNormFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
     const auto& tiles_d = tile_lower::tiles_of(ctx.tile_map, dst);
     constexpr Scalar one = 1.0;
     const Index src_nd = src->ndim();
-    const Index lay_ax = layout_axis(axis, src_nd);
+    const Index dst_nd = dst->ndim();
     std::vector<Index> s1_coord;
-    std::vector<Index> dst_coord(static_cast<size_t>(dst->ndim()));
+    std::vector<Index> dst_coord(static_cast<size_t>(dst_nd));
 
     for(Index lin1 = 0; lin1 < lay1->grid_volume(); ++lin1)
     {
@@ -62,12 +62,8 @@ void TensorNormFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
                 break;
             }
         }
-        dst_coord[0] = s1_coord[static_cast<size_t>(lay_ax)];
-        for(Index b = 0; b < batch_ndim; ++b)
-        {
-            dst_coord[static_cast<size_t>(b + 1)] =
-                s1_coord[static_cast<size_t>(layout_axis(b, src_nd))];
-        }
+        fiber_layout_coord_from_tensor(
+            s1_coord, axis, batch_ndim, dst_nd, src_nd, dst_coord);
         const Index lin_d = lay_d->grid_linear(dst_coord);
         if(init_first)
         {

--- a/nntile/src/tensor/ops/norm_fiber_inplace.cc
+++ b/nntile/src/tensor/ops/norm_fiber_inplace.cc
@@ -33,7 +33,7 @@ namespace nntile::tensor
 void TensorNormFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
 {
     const Index g_axis =
-        storage_axis_to_graph(axis, dst->ndim());
+        storage_axis_to_graph(axis, src->ndim());
 
     // Match nntile::tensor::norm_fiber_inplace_async (src/tensor/norm_fiber_inplace.cc).
     const TensorAxisLayout* lay1 = ctx.tiling.find(src);

--- a/nntile/src/tensor/ops/norm_fiber_inplace.cc
+++ b/nntile/src/tensor/ops/norm_fiber_inplace.cc
@@ -32,6 +32,9 @@ namespace nntile::tensor
 
 void TensorNormFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
 {
+    const Index g_axis =
+        storage_axis_to_graph(axis, dst->ndim());
+
     // Match nntile::tensor::norm_fiber_inplace_async (src/tensor/norm_fiber_inplace.cc).
     const TensorAxisLayout* lay1 = ctx.tiling.find(src);
     const TensorAxisLayout* lay_d = ctx.tiling.find(dst);
@@ -74,7 +77,7 @@ void TensorNormFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
                 tiles_s[static_cast<size_t>(lin1)],
                 beta,
                 tiles_d[static_cast<size_t>(lin_d)],
-                axis,
+                g_axis,
                 batch_ndim,
                 redux);
         }
@@ -85,7 +88,7 @@ void TensorNormFiberInplaceOp::lower_to_tile(const LoweringContext& ctx) const
                 tiles_s[static_cast<size_t>(lin1)],
                 one,
                 tiles_d[static_cast<size_t>(lin_d)],
-                axis,
+                g_axis,
                 batch_ndim,
                 redux);
         }

--- a/nntile/src/tensor/ops/norm_slice.cc
+++ b/nntile/src/tensor/ops/norm_slice.cc
@@ -170,7 +170,7 @@ void TensorNormSliceOp::lower_to_tile(const LoweringContext &ctx) const
                     beta,
                     tiles_s2[static_cast<size_t>(lin_d)],
                     tiles_d[static_cast<size_t>(lin_d)],
-                    s_axis,
+                    axis,
                     redux);
             }
             else
@@ -179,7 +179,7 @@ void TensorNormSliceOp::lower_to_tile(const LoweringContext &ctx) const
                     tiles_s1[static_cast<size_t>(lin_s1)],
                     one,
                     tiles_d[static_cast<size_t>(lin_d)],
-                    s_axis,
+                    axis,
                     redux);
             }
         }

--- a/nntile/src/tensor/ops/norm_slice.cc
+++ b/nntile/src/tensor/ops/norm_slice.cc
@@ -129,39 +129,27 @@ void TensorNormSliceOp::lower_to_tile(const LoweringContext &ctx) const
 
     const Index src_nd = src1->ndim();
     const Index dst_nd = dst->ndim();
-    const Index s_axis = graph_axis_to_storage(axis, src_nd);
+    const Index lay_ax = layout_axis(axis, src_nd);
 
     for (Index lin_d = 0; lin_d < lay_d->grid_volume(); ++lin_d)
     {
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
-        for (Index sd = 0; sd < dst_nd; ++sd)
+        for (Index g_src = 0; g_src < src_nd; ++g_src)
         {
-            const Index g_dst = storage_axis_to_graph(sd, dst_nd);
-            Index g_src = 0;
-            Index k = 0;
-            for (Index g2 = 0; g2 < src_nd; ++g2)
+            if (g_src == axis)
             {
-                if (g2 == axis)
-                {
-                    continue;
-                }
-                if (k == g_dst)
-                {
-                    g_src = g2;
-                    break;
-                }
-                ++k;
+                continue;
             }
-            s1_coord[static_cast<size_t>(
-                graph_axis_to_storage(g_src, src_nd))] =
-                dst_coord[static_cast<size_t>(sd)];
+            const Index g_dst = (g_src < axis) ? g_src : (g_src - 1);
+            s1_coord[static_cast<size_t>(layout_axis(g_src, src_nd))] =
+                dst_coord[static_cast<size_t>(layout_axis(g_dst, dst_nd))];
         }
 
         const Index nseg_along_axis =
-            lay_s1->grid_shape()[static_cast<size_t>(s_axis)];
+            lay_s1->grid_shape()[static_cast<size_t>(lay_ax)];
         for (Index jj = 0; jj < nseg_along_axis; ++jj)
         {
-            s1_coord[static_cast<size_t>(s_axis)] = jj;
+            s1_coord[static_cast<size_t>(lay_ax)] = jj;
             const Index lin_s1 = lay_s1->grid_linear(s1_coord);
             if (jj == 0)
             {

--- a/nntile/src/tensor/ops/norm_slice_inplace.cc
+++ b/nntile/src/tensor/ops/norm_slice_inplace.cc
@@ -87,7 +87,7 @@ void TensorNormSliceInplaceOp::lower_to_tile(const LoweringContext& ctx) const
                     tiles_s[static_cast<size_t>(lin_s)],
                     beta,
                     tiles_d[static_cast<size_t>(lin_d)],
-                    s_axis,
+                    axis,
                     redux);
             }
             else
@@ -97,7 +97,7 @@ void TensorNormSliceInplaceOp::lower_to_tile(const LoweringContext& ctx) const
                     tiles_s[static_cast<size_t>(lin_s)],
                     one,
                     tiles_d[static_cast<size_t>(lin_d)],
-                    s_axis,
+                    axis,
                     redux);
             }
         }

--- a/nntile/src/tensor/ops/norm_slice_inplace.cc
+++ b/nntile/src/tensor/ops/norm_slice_inplace.cc
@@ -48,37 +48,25 @@ void TensorNormSliceInplaceOp::lower_to_tile(const LoweringContext& ctx) const
     std::vector<Index> s_coord(static_cast<size_t>(src->ndim()));
     const Index src_nd = src->ndim();
     const Index dst_nd = dst->ndim();
-    const Index s_axis = graph_axis_to_storage(axis, src_nd);
+    const Index lay_ax = layout_axis(axis, src_nd);
     for(Index lin_d = 0; lin_d < lay_d->grid_volume(); ++lin_d)
     {
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
-        for(Index sd = 0; sd < dst_nd; ++sd)
+        for(Index g_src = 0; g_src < src_nd; ++g_src)
         {
-            const Index g_dst = storage_axis_to_graph(sd, dst_nd);
-            Index g_src = 0;
-            Index k = 0;
-            for(Index g2 = 0; g2 < src_nd; ++g2)
+            if(g_src == axis)
             {
-                if(g2 == axis)
-                {
-                    continue;
-                }
-                if(k == g_dst)
-                {
-                    g_src = g2;
-                    break;
-                }
-                ++k;
+                continue;
             }
-            s_coord[static_cast<size_t>(
-                graph_axis_to_storage(g_src, src_nd))] =
-                dst_coord[static_cast<size_t>(sd)];
+            const Index g_dst = (g_src < axis) ? g_src : (g_src - 1);
+            s_coord[static_cast<size_t>(layout_axis(g_src, src_nd))] =
+                dst_coord[static_cast<size_t>(layout_axis(g_dst, dst_nd))];
         }
         const Index nseg_along_axis =
-            lay_s->grid_shape()[static_cast<size_t>(s_axis)];
+            lay_s->grid_shape()[static_cast<size_t>(lay_ax)];
         for(Index jj = 0; jj < nseg_along_axis; ++jj)
         {
-            s_coord[static_cast<size_t>(s_axis)] = jj;
+            s_coord[static_cast<size_t>(lay_ax)] = jj;
             const Index lin_s = lay_s->grid_linear(s_coord);
             if(jj == 0)
             {

--- a/nntile/src/tensor/ops/scale_fiber.cc
+++ b/nntile/src/tensor/ops/scale_fiber.cc
@@ -114,20 +114,16 @@ void TensorScaleFiberOp::lower_to_tile(const LoweringContext &ctx) const
     }
 
     const Index dst_nd = dst->ndim();
-    const Index lay_ax = layout_axis(axis, dst_nd);
+    const Index src_nd = src->ndim();
 
     std::vector<Index> dst_coord;
-    std::vector<Index> src_coord(static_cast<size_t>(src->ndim()));
+    std::vector<Index> src_coord(static_cast<size_t>(src_nd));
 
     for (Index lin_d = 0; lin_d < lay_d->grid_volume(); ++lin_d)
     {
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
-        src_coord[0] = dst_coord[static_cast<size_t>(lay_ax)];
-        for (Index b = 0; b < batch_ndim; ++b)
-        {
-            src_coord[static_cast<size_t>(b + 1)] =
-                dst_coord[static_cast<size_t>(layout_axis(b, dst_nd))];
-        }
+        fiber_layout_coord_from_tensor(
+            dst_coord, axis, batch_ndim, src_nd, dst_nd, src_coord);
         const Index lin_s = lay_s->grid_linear(src_coord);
         tile::scale_fiber(alpha,
             tiles_s[static_cast<size_t>(lin_s)],

--- a/nntile/src/tensor/ops/scale_fiber.cc
+++ b/nntile/src/tensor/ops/scale_fiber.cc
@@ -87,6 +87,9 @@ void scale_fiber(Scalar alpha,
 
 void TensorScaleFiberOp::lower_to_tile(const LoweringContext &ctx) const
 {
+    const Index g_axis =
+        storage_axis_to_graph(axis, dst->ndim());
+
     // Match nntile::tensor::scale_fiber_async (src/tensor/scale_fiber.cc).
     const TensorAxisLayout *lay_d = ctx.tiling.find(dst);
     if (lay_d == nullptr)
@@ -130,7 +133,7 @@ void TensorScaleFiberOp::lower_to_tile(const LoweringContext &ctx) const
         tile::scale_fiber(alpha,
             tiles_s[static_cast<size_t>(lin_s)],
             tiles_d[static_cast<size_t>(lin_d)],
-            axis,
+            g_axis,
             batch_ndim);
     }
 }

--- a/nntile/src/tensor/ops/scale_fiber.cc
+++ b/nntile/src/tensor/ops/scale_fiber.cc
@@ -77,19 +77,15 @@ void scale_fiber(Scalar alpha,
         throw std::invalid_argument(
             "scale_fiber: input tensors must have the same dtype");
     }
-    const Index s_axis = graph_axis_to_storage(axis, dst->ndim());
-    validate_fiber_shape_and_merge(src, dst, s_axis, batch_ndim, "scale_fiber");
+    validate_fiber_shape_and_merge(src, dst, axis, batch_ndim, "scale_fiber");
 
     auto op = std::make_shared<TensorScaleFiberOp>(
-        alpha, src, dst, s_axis, batch_ndim);
+        alpha, src, dst, axis, batch_ndim);
     src->graph()->add_op(op);
 }
 
 void TensorScaleFiberOp::lower_to_tile(const LoweringContext &ctx) const
 {
-    const Index g_axis =
-        storage_axis_to_graph(axis, dst->ndim());
-
     // Match nntile::tensor::scale_fiber_async (src/tensor/scale_fiber.cc).
     const TensorAxisLayout *lay_d = ctx.tiling.find(dst);
     if (lay_d == nullptr)
@@ -117,23 +113,26 @@ void TensorScaleFiberOp::lower_to_tile(const LoweringContext &ctx) const
             "lower_to_tile SCALE_FIBER: missing tiling for src");
     }
 
+    const Index dst_nd = dst->ndim();
+    const Index lay_ax = layout_axis(axis, dst_nd);
+
     std::vector<Index> dst_coord;
     std::vector<Index> src_coord(static_cast<size_t>(src->ndim()));
 
     for (Index lin_d = 0; lin_d < lay_d->grid_volume(); ++lin_d)
     {
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
-        src_coord[0] = dst_coord[static_cast<size_t>(axis)];
+        src_coord[0] = dst_coord[static_cast<size_t>(lay_ax)];
         for (Index b = 0; b < batch_ndim; ++b)
         {
             src_coord[static_cast<size_t>(b + 1)] =
-                dst_coord[static_cast<size_t>(dst->ndim() - batch_ndim + b)];
+                dst_coord[static_cast<size_t>(layout_axis(b, dst_nd))];
         }
         const Index lin_s = lay_s->grid_linear(src_coord);
         tile::scale_fiber(alpha,
             tiles_s[static_cast<size_t>(lin_s)],
             tiles_d[static_cast<size_t>(lin_d)],
-            g_axis,
+            axis,
             batch_ndim);
     }
 }

--- a/nntile/src/tensor/ops/scale_slice.cc
+++ b/nntile/src/tensor/ops/scale_slice.cc
@@ -153,7 +153,7 @@ void TensorScaleSliceOp::lower_to_tile(const LoweringContext &ctx) const
             tile::scale_slice(alpha,
                 tiles_s[static_cast<size_t>(lin_s)],
                 tiles_d[static_cast<size_t>(lin_d)],
-                s_axis);
+                axis);
         }
     }
 }

--- a/nntile/src/tensor/ops/scale_slice.cc
+++ b/nntile/src/tensor/ops/scale_slice.cc
@@ -111,7 +111,7 @@ void TensorScaleSliceOp::lower_to_tile(const LoweringContext &ctx) const
 
     const Index nd = dst->ndim();
     const Index s_nd = src->ndim();
-    const Index s_axis = graph_axis_to_storage(axis, nd);
+    const Index lay_ax = layout_axis(axis, nd);
 
     std::vector<Index> s_coord;
     std::vector<Index> d_coord(static_cast<size_t>(nd));
@@ -119,13 +119,12 @@ void TensorScaleSliceOp::lower_to_tile(const LoweringContext &ctx) const
     for (Index lin_s = 0; lin_s < lay_s->grid_volume(); ++lin_s)
     {
         lay_s->grid_coord_from_linear(lin_s, s_coord);
-        for (Index s = 0; s < nd; ++s)
+        for (Index g = 0; g < nd; ++g)
         {
-            if (s == s_axis)
+            if (g == axis)
             {
                 continue;
             }
-            const Index g = storage_axis_to_graph(s, nd);
             Index g1 = 0;
             for (Index g2 = 0; g2 < nd; ++g2)
             {
@@ -139,16 +138,15 @@ void TensorScaleSliceOp::lower_to_tile(const LoweringContext &ctx) const
                 }
                 ++g1;
             }
-            d_coord[static_cast<size_t>(s)] =
-                s_coord[static_cast<size_t>(
-                    graph_axis_to_storage(g1, s_nd))];
+            d_coord[static_cast<size_t>(layout_axis(g, nd))] =
+                s_coord[static_cast<size_t>(layout_axis(g1, s_nd))];
         }
 
         const Index nseg_along_axis =
-            lay_d->grid_shape()[static_cast<size_t>(s_axis)];
+            lay_d->grid_shape()[static_cast<size_t>(lay_ax)];
         for (Index jj = 0; jj < nseg_along_axis; ++jj)
         {
-            d_coord[static_cast<size_t>(s_axis)] = jj;
+            d_coord[static_cast<size_t>(lay_ax)] = jj;
             const Index lin_d = lay_d->grid_linear(d_coord);
             tile::scale_slice(alpha,
                 tiles_s[static_cast<size_t>(lin_s)],

--- a/nntile/src/tensor/ops/softmax.cc
+++ b/nntile/src/tensor/ops/softmax.cc
@@ -34,23 +34,23 @@ namespace nntile::tensor
 namespace
 {
 
-void maxsumexp_to_src_storage_coord(const std::vector<Index> &m_storage,
+//! Map maxsumexp grid coord to src grid coord (omit pair axis).
+void maxsumexp_to_src_grid_coord(const std::vector<Index> &m_coord,
     Index axis,
     Index ndim,
-    std::vector<Index> &src_storage)
+    std::vector<Index> &src_coord)
 {
-    src_storage.resize(static_cast<size_t>(ndim));
-    for (Index s = 0; s < ndim; ++s)
+    src_coord.resize(static_cast<size_t>(ndim));
+    for (Index g = 0; g < ndim; ++g)
     {
-        const Index g = storage_axis_to_graph(s, ndim);
         if (g == axis)
         {
             continue;
         }
         const Index m_g = (g < axis) ? g : (g - 1);
-        const Index dst_ndim = static_cast<Index>(m_storage.size());
-        const Index m_s = graph_axis_to_storage(m_g, dst_ndim);
-        src_storage[static_cast<size_t>(s)] = m_storage[static_cast<size_t>(m_s)];
+        const Index m_ndim = static_cast<Index>(m_coord.size());
+        src_coord[static_cast<size_t>(layout_axis(g, ndim))] =
+            m_coord[static_cast<size_t>(layout_axis(m_g, m_ndim))];
     }
 }
 
@@ -73,7 +73,7 @@ void TensorSoftmaxOp::lower_to_tile(const LoweringContext &ctx) const
     const auto &tiles_d = tile_lower::tiles_of(ctx.tile_map, dst);
 
     const Index nd = dst->ndim();
-    const Index s_axis = graph_axis_to_storage(axis, nd);
+    const Index lay_ax = layout_axis(axis, nd);
 
     std::vector<Index> m_coord;
     std::vector<Index> coord(static_cast<size_t>(nd));
@@ -83,13 +83,13 @@ void TensorSoftmaxOp::lower_to_tile(const LoweringContext &ctx) const
         lay_m->grid_coord_from_linear(lin_m, m_coord);
         TileGraph::TileNode *m_tile = tiles_m[static_cast<size_t>(lin_m)];
 
-        maxsumexp_to_src_storage_coord(m_coord, axis, nd, coord);
+        maxsumexp_to_src_grid_coord(m_coord, axis, nd, coord);
 
         const Index nseg_along_axis =
-            lay_d->grid_shape()[static_cast<size_t>(s_axis)];
+            lay_d->grid_shape()[static_cast<size_t>(lay_ax)];
         for (Index j = 0; j < nseg_along_axis; ++j)
         {
-            coord[static_cast<size_t>(s_axis)] = j;
+            coord[static_cast<size_t>(lay_ax)] = j;
             const Index lin = lay_d->grid_linear(coord);
             TileGraph::TileNode *s_tile = tiles_s[static_cast<size_t>(lin)];
             TileGraph::TileNode *d_tile = tiles_d[static_cast<size_t>(lin)];

--- a/nntile/src/tensor/ops/softmax.cc
+++ b/nntile/src/tensor/ops/softmax.cc
@@ -93,7 +93,7 @@ void TensorSoftmaxOp::lower_to_tile(const LoweringContext &ctx) const
             const Index lin = lay_d->grid_linear(coord);
             TileGraph::TileNode *s_tile = tiles_s[static_cast<size_t>(lin)];
             TileGraph::TileNode *d_tile = tiles_d[static_cast<size_t>(lin)];
-            tile::softmax(m_tile, s_tile, alpha, d_tile, s_axis);
+            tile::softmax(m_tile, s_tile, alpha, d_tile, axis);
         }
     }
 }

--- a/nntile/src/tensor/ops/softmax_inplace.cc
+++ b/nntile/src/tensor/ops/softmax_inplace.cc
@@ -32,23 +32,23 @@ namespace nntile::tensor
 namespace
 {
 
-void maxsumexp_to_src_storage_coord(const std::vector<Index> &m_storage,
+//! Map maxsumexp grid coord to dst grid coord (omit pair axis).
+void maxsumexp_to_dst_grid_coord(const std::vector<Index> &m_coord,
     Index axis,
-    Index src_ndim,
-    std::vector<Index> &src_storage)
+    Index dst_ndim,
+    std::vector<Index> &dst_coord)
 {
-    src_storage.resize(static_cast<size_t>(src_ndim));
-    for (Index s = 0; s < src_ndim; ++s)
+    dst_coord.resize(static_cast<size_t>(dst_ndim));
+    for (Index g = 0; g < dst_ndim; ++g)
     {
-        const Index g = storage_axis_to_graph(s, src_ndim);
         if (g == axis)
         {
             continue;
         }
         const Index m_g = (g < axis) ? g : (g - 1);
-        const Index dst_ndim = static_cast<Index>(m_storage.size());
-        const Index m_s = graph_axis_to_storage(m_g, dst_ndim);
-        src_storage[static_cast<size_t>(s)] = m_storage[static_cast<size_t>(m_s)];
+        const Index m_ndim = static_cast<Index>(m_coord.size());
+        dst_coord[static_cast<size_t>(layout_axis(g, dst_ndim))] =
+            m_coord[static_cast<size_t>(layout_axis(m_g, m_ndim))];
     }
 }
 
@@ -100,7 +100,7 @@ void TensorSoftmaxInplaceOp::lower_to_tile(const LoweringContext& ctx) const
     const auto& tiles_d = tile_lower::tiles_of(ctx.tile_map, dst);
 
     const Index nd = dst->ndim();
-    const Index s_axis = graph_axis_to_storage(axis, nd);
+    const Index lay_ax = layout_axis(axis, nd);
 
     std::vector<Index> m_coord;
     std::vector<Index> dst_coord(static_cast<size_t>(nd));
@@ -110,13 +110,13 @@ void TensorSoftmaxInplaceOp::lower_to_tile(const LoweringContext& ctx) const
         lay_m->grid_coord_from_linear(lin_m, m_coord);
         TileGraph::TileNode* m_tile = tiles_m[static_cast<size_t>(lin_m)];
 
-        maxsumexp_to_src_storage_coord(m_coord, axis, nd, dst_coord);
+        maxsumexp_to_dst_grid_coord(m_coord, axis, nd, dst_coord);
 
         const Index nseg_along_axis =
-            lay_d->grid_shape()[static_cast<size_t>(s_axis)];
+            lay_d->grid_shape()[static_cast<size_t>(lay_ax)];
         for(Index j = 0; j < nseg_along_axis; ++j)
         {
-            dst_coord[static_cast<size_t>(s_axis)] = j;
+            dst_coord[static_cast<size_t>(lay_ax)] = j;
             const Index lin_d = lay_d->grid_linear(dst_coord);
             TileGraph::TileNode* d_tile =
                 tiles_d[static_cast<size_t>(lin_d)];

--- a/nntile/src/tensor/ops/softmax_inplace.cc
+++ b/nntile/src/tensor/ops/softmax_inplace.cc
@@ -120,7 +120,7 @@ void TensorSoftmaxInplaceOp::lower_to_tile(const LoweringContext& ctx) const
             const Index lin_d = lay_d->grid_linear(dst_coord);
             TileGraph::TileNode* d_tile =
                 tiles_d[static_cast<size_t>(lin_d)];
-            tile::softmax_inplace(m_tile, alpha, d_tile, s_axis);
+            tile::softmax_inplace(m_tile, alpha, d_tile, axis);
         }
     }
 }

--- a/nntile/src/tensor/ops/sum_fiber.cc
+++ b/nntile/src/tensor/ops/sum_fiber.cc
@@ -37,14 +37,7 @@ namespace
 std::vector<Index> sum_fiber_output_shape(
     const std::vector<Index> &x_shape, Index graph_axis, Index batch_ndim)
 {
-    std::vector<Index> out;
-    out.reserve(batch_ndim + 1);
-    out.push_back(x_shape[graph_axis]);
-    for (Index i = 0; i < batch_ndim; ++i)
-    {
-        out.push_back(x_shape[i]);
-    }
-    return out;
+    return graph_fiber_shape(x_shape, graph_axis, batch_ndim);
 }
 
 } // namespace
@@ -68,11 +61,11 @@ TensorGraph::TensorNode *sum_fiber(TensorGraph::TensorNode *x,
         x->graph()->data(std::move(output_shape), x->dtype());
 
     // Merge output fiber axes with x axes
-    merge_axis(output->mutable_axes()[0], x->mutable_axes()[axis]);
     for (Index i = 0; i < batch_ndim; ++i)
     {
-        merge_axis(output->mutable_axes()[1 + i], x->mutable_axes()[i]);
+        merge_axis(output->mutable_axes()[i], x->mutable_axes()[i]);
     }
+    merge_axis(output->mutable_axes()[batch_ndim], x->mutable_axes()[axis]);
 
     auto op = std::make_shared<TensorSumFiberOp>(
         x, output, axis, batch_ndim, redux, alpha, beta);
@@ -132,22 +125,18 @@ void TensorSumFiberOp::lower_to_tile(const LoweringContext &ctx) const
     const auto &tiles_y = tile_lower::tiles_of(ctx.tile_map, y);
 
     const Index x_nd = x->ndim();
-    const Index lay_ax = layout_axis(axis, x_nd);
+    const Index y_nd = y->ndim();
 
     std::vector<Index> x_coord;
-    std::vector<Index> y_coord(static_cast<size_t>(y->ndim()));
+    std::vector<Index> y_coord(static_cast<size_t>(y_nd));
 
     for (Index lin_x = 0; lin_x < lay_x->grid_volume(); ++lin_x)
     {
         lay_x->grid_coord_from_linear(lin_x, x_coord);
         TileGraph::TileNode *x_tile = tiles_x[static_cast<size_t>(lin_x)];
 
-        y_coord[0] = x_coord[static_cast<size_t>(lay_ax)];
-        for (Index b = 0; b < batch_ndim; ++b)
-        {
-            y_coord[static_cast<size_t>(b + 1)] =
-                x_coord[static_cast<size_t>(layout_axis(b, x_nd))];
-        }
+        fiber_layout_coord_from_tensor(
+            x_coord, axis, batch_ndim, y_nd, x_nd, y_coord);
         const Index lin_y = lay_y->grid_linear(y_coord);
         TileGraph::TileNode *y_tile = tiles_y[static_cast<size_t>(lin_y)];
 

--- a/nntile/src/tensor/ops/sum_fiber.cc
+++ b/nntile/src/tensor/ops/sum_fiber.cc
@@ -37,17 +37,14 @@ namespace
 std::vector<Index> sum_fiber_output_shape(
     const std::vector<Index> &x_shape, Index graph_axis, Index batch_ndim)
 {
-    const std::vector<Index> xs = graph_shape_to_storage(x_shape);
-    const Index nd = static_cast<Index>(xs.size());
-    const Index s_axis = graph_axis_to_storage(graph_axis, nd);
-    std::vector<Index> out_s;
-    out_s.reserve(batch_ndim + 1);
-    out_s.push_back(xs[s_axis]);
+    std::vector<Index> out;
+    out.reserve(batch_ndim + 1);
+    out.push_back(x_shape[graph_axis]);
     for (Index i = 0; i < batch_ndim; ++i)
     {
-        out_s.push_back(xs[nd - batch_ndim + i]);
+        out.push_back(x_shape[i]);
     }
-    return storage_shape_to_graph(out_s);
+    return out;
 }
 
 } // namespace
@@ -74,14 +71,11 @@ TensorGraph::TensorNode *sum_fiber(TensorGraph::TensorNode *x,
     merge_axis(output->mutable_axes()[0], x->mutable_axes()[axis]);
     for (Index i = 0; i < batch_ndim; ++i)
     {
-        const Index g_batch = storage_axis_to_graph(
-            x->ndim() - batch_ndim + i, x->ndim());
-        merge_axis(output->mutable_axes()[1 + i], x->mutable_axes()[g_batch]);
+        merge_axis(output->mutable_axes()[1 + i], x->mutable_axes()[i]);
     }
 
-    const Index s_axis = graph_axis_to_storage(axis, x->ndim());
     auto op = std::make_shared<TensorSumFiberOp>(
-        x, output, s_axis, batch_ndim, redux, alpha, beta);
+        x, output, axis, batch_ndim, redux, alpha, beta);
     x->graph()->add_op(op);
 
     return output;
@@ -115,20 +109,16 @@ void sum_fiber(TensorGraph::TensorNode *x,
         throw std::invalid_argument(
             "sum_fiber: x and y must be distinct tensors");
     }
-    const Index s_axis = graph_axis_to_storage(axis, x->ndim());
-    validate_fiber_shape_and_merge(y, x, s_axis, batch_ndim, "sum_fiber");
+    validate_fiber_shape_and_merge(y, x, axis, batch_ndim, "sum_fiber");
 
     auto op = std::make_shared<TensorSumFiberOp>(
-        x, y, s_axis, batch_ndim, redux, alpha, beta);
+        x, y, axis, batch_ndim, redux, alpha, beta);
 
     x->graph()->add_op(op);
 }
 
 void TensorSumFiberOp::lower_to_tile(const LoweringContext &ctx) const
 {
-    const Index g_axis =
-        storage_axis_to_graph(axis, x->ndim());
-
     // Match nntile::tensor::sum_fiber_async (src/tensor/sum_fiber.cc).
     const TensorAxisLayout *lay_x = ctx.tiling.find(x);
     const TensorAxisLayout *lay_y = ctx.tiling.find(y);
@@ -141,29 +131,31 @@ void TensorSumFiberOp::lower_to_tile(const LoweringContext &ctx) const
     const auto &tiles_x = tile_lower::tiles_of(ctx.tile_map, x);
     const auto &tiles_y = tile_lower::tiles_of(ctx.tile_map, y);
 
+    const Index x_nd = x->ndim();
+    const Index lay_ax = layout_axis(axis, x_nd);
+
     std::vector<Index> x_coord;
     std::vector<Index> y_coord(static_cast<size_t>(y->ndim()));
-
-    const Index fiber_prefix = x->ndim() - batch_ndim;
 
     for (Index lin_x = 0; lin_x < lay_x->grid_volume(); ++lin_x)
     {
         lay_x->grid_coord_from_linear(lin_x, x_coord);
         TileGraph::TileNode *x_tile = tiles_x[static_cast<size_t>(lin_x)];
 
-        y_coord[0] = x_coord[static_cast<size_t>(axis)];
-        for (Index j = 0; j < batch_ndim; ++j)
+        y_coord[0] = x_coord[static_cast<size_t>(lay_ax)];
+        for (Index b = 0; b < batch_ndim; ++b)
         {
-            y_coord[static_cast<size_t>(j + 1)] =
-                x_coord[static_cast<size_t>(x->ndim() - batch_ndim + j)];
+            y_coord[static_cast<size_t>(b + 1)] =
+                x_coord[static_cast<size_t>(layout_axis(b, x_nd))];
         }
         const Index lin_y = lay_y->grid_linear(y_coord);
         TileGraph::TileNode *y_tile = tiles_y[static_cast<size_t>(lin_y)];
 
         bool init_first = true;
-        for (Index j = 0; j < fiber_prefix; ++j)
+        for (Index g = batch_ndim; g < x_nd; ++g)
         {
-            if (j != axis && x_coord[static_cast<size_t>(j)] != 0)
+            if (g != axis
+                && x_coord[static_cast<size_t>(layout_axis(g, x_nd))] != 0)
             {
                 init_first = false;
                 break;
@@ -173,12 +165,12 @@ void TensorSumFiberOp::lower_to_tile(const LoweringContext &ctx) const
         if (init_first)
         {
             tile::sum_fiber(
-                alpha, x_tile, beta, y_tile, g_axis, batch_ndim, redux);
+                alpha, x_tile, beta, y_tile, axis, batch_ndim, redux);
         }
         else
         {
             tile::sum_fiber(
-                alpha, x_tile, Scalar(1.0), y_tile, g_axis, batch_ndim, redux);
+                alpha, x_tile, Scalar(1.0), y_tile, axis, batch_ndim, redux);
         }
     }
 }

--- a/nntile/src/tensor/ops/sum_fiber.cc
+++ b/nntile/src/tensor/ops/sum_fiber.cc
@@ -126,6 +126,9 @@ void sum_fiber(TensorGraph::TensorNode *x,
 
 void TensorSumFiberOp::lower_to_tile(const LoweringContext &ctx) const
 {
+    const Index g_axis =
+        storage_axis_to_graph(axis, x->ndim());
+
     // Match nntile::tensor::sum_fiber_async (src/tensor/sum_fiber.cc).
     const TensorAxisLayout *lay_x = ctx.tiling.find(x);
     const TensorAxisLayout *lay_y = ctx.tiling.find(y);
@@ -170,12 +173,12 @@ void TensorSumFiberOp::lower_to_tile(const LoweringContext &ctx) const
         if (init_first)
         {
             tile::sum_fiber(
-                alpha, x_tile, beta, y_tile, axis, batch_ndim, redux);
+                alpha, x_tile, beta, y_tile, g_axis, batch_ndim, redux);
         }
         else
         {
             tile::sum_fiber(
-                alpha, x_tile, Scalar(1.0), y_tile, axis, batch_ndim, redux);
+                alpha, x_tile, Scalar(1.0), y_tile, g_axis, batch_ndim, redux);
         }
     }
 }

--- a/nntile/src/tensor/ops/sum_slice.cc
+++ b/nntile/src/tensor/ops/sum_slice.cc
@@ -135,7 +135,7 @@ void TensorSumSliceOp::lower_to_tile(const LoweringContext &ctx) const
 
     const Index src_nd = src->ndim();
     const Index dst_nd = dst->ndim();
-    const Index s_axis = graph_axis_to_storage(axis, src_nd);
+    const Index lay_ax = layout_axis(axis, src_nd);
 
     std::vector<Index> dst_coord;
     std::vector<Index> s_coord(static_cast<size_t>(src_nd));
@@ -145,33 +145,21 @@ void TensorSumSliceOp::lower_to_tile(const LoweringContext &ctx) const
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
         TileGraph::TileNode *dst_tile = tiles_d[static_cast<size_t>(lin_d)];
 
-        for (Index sd = 0; sd < dst_nd; ++sd)
+        for (Index g_src = 0; g_src < src_nd; ++g_src)
         {
-            const Index g_dst = storage_axis_to_graph(sd, dst_nd);
-            Index g_src = 0;
-            Index k = 0;
-            for (Index g2 = 0; g2 < src_nd; ++g2)
+            if (g_src == axis)
             {
-                if (g2 == axis)
-                {
-                    continue;
-                }
-                if (k == g_dst)
-                {
-                    g_src = g2;
-                    break;
-                }
-                ++k;
+                continue;
             }
-            s_coord[static_cast<size_t>(
-                graph_axis_to_storage(g_src, src_nd))] =
-                dst_coord[static_cast<size_t>(sd)];
+            const Index g_dst = (g_src < axis) ? g_src : (g_src - 1);
+            s_coord[static_cast<size_t>(layout_axis(g_src, src_nd))] =
+                dst_coord[static_cast<size_t>(layout_axis(g_dst, dst_nd))];
         }
 
         const Index nseg_along_axis =
-            lay_s->grid_shape()[static_cast<size_t>(s_axis)];
+            lay_s->grid_shape()[static_cast<size_t>(lay_ax)];
 
-        s_coord[static_cast<size_t>(s_axis)] = 0;
+        s_coord[static_cast<size_t>(lay_ax)] = 0;
         Index lin_s0 = lay_s->grid_linear(s_coord);
         tile::sum_slice(alpha,
             tiles_s[static_cast<size_t>(lin_s0)],
@@ -182,7 +170,7 @@ void TensorSumSliceOp::lower_to_tile(const LoweringContext &ctx) const
 
         for (Index jj = 1; jj < nseg_along_axis; ++jj)
         {
-            s_coord[static_cast<size_t>(s_axis)] = jj;
+            s_coord[static_cast<size_t>(lay_ax)] = jj;
             const Index lin_s = lay_s->grid_linear(s_coord);
             tile::sum_slice(alpha,
                 tiles_s[static_cast<size_t>(lin_s)],

--- a/nntile/src/tensor/ops/sum_slice.cc
+++ b/nntile/src/tensor/ops/sum_slice.cc
@@ -177,7 +177,7 @@ void TensorSumSliceOp::lower_to_tile(const LoweringContext &ctx) const
             tiles_s[static_cast<size_t>(lin_s0)],
             beta,
             dst_tile,
-            s_axis,
+            axis,
             redux);
 
         for (Index jj = 1; jj < nseg_along_axis; ++jj)
@@ -188,7 +188,7 @@ void TensorSumSliceOp::lower_to_tile(const LoweringContext &ctx) const
                 tiles_s[static_cast<size_t>(lin_s)],
                 Scalar(1.0),
                 dst_tile,
-                s_axis,
+                axis,
                 redux);
         }
     }

--- a/nntile/src/tensor/ops/sumprod_fiber.cc
+++ b/nntile/src/tensor/ops/sumprod_fiber.cc
@@ -32,7 +32,7 @@ namespace nntile::tensor
 void TensorSumprodFiberOp::lower_to_tile(const LoweringContext& ctx) const
 {
     const Index g_axis =
-        storage_axis_to_graph(axis, dst->ndim());
+        storage_axis_to_graph(axis, src1->ndim());
 
     // Match nntile::tensor::sumprod_fiber_async (src/tensor/sumprod_fiber.cc).
     const TensorAxisLayout* lay1 = ctx.tiling.find(src1);

--- a/nntile/src/tensor/ops/sumprod_fiber.cc
+++ b/nntile/src/tensor/ops/sumprod_fiber.cc
@@ -31,6 +31,9 @@ namespace nntile::tensor
 
 void TensorSumprodFiberOp::lower_to_tile(const LoweringContext& ctx) const
 {
+    const Index g_axis =
+        storage_axis_to_graph(axis, dst->ndim());
+
     // Match nntile::tensor::sumprod_fiber_async (src/tensor/sumprod_fiber.cc).
     const TensorAxisLayout* lay1 = ctx.tiling.find(src1);
     if(lay1 == nullptr)
@@ -64,7 +67,7 @@ void TensorSumprodFiberOp::lower_to_tile(const LoweringContext& ctx) const
                 t2[static_cast<size_t>(lin1)],
                 beta,
                 td[static_cast<size_t>(j_dst)],
-                axis,
+                g_axis,
                 redux);
         }
         else
@@ -75,7 +78,7 @@ void TensorSumprodFiberOp::lower_to_tile(const LoweringContext& ctx) const
                 t2[static_cast<size_t>(lin1)],
                 one,
                 td[static_cast<size_t>(j_dst)],
-                axis,
+                g_axis,
                 redux);
         }
     }

--- a/nntile/src/tensor/ops/sumprod_fiber.cc
+++ b/nntile/src/tensor/ops/sumprod_fiber.cc
@@ -31,9 +31,6 @@ namespace nntile::tensor
 
 void TensorSumprodFiberOp::lower_to_tile(const LoweringContext& ctx) const
 {
-    const Index g_axis =
-        storage_axis_to_graph(axis, src1->ndim());
-
     // Match nntile::tensor::sumprod_fiber_async (src/tensor/sumprod_fiber.cc).
     const TensorAxisLayout* lay1 = ctx.tiling.find(src1);
     if(lay1 == nullptr)
@@ -45,15 +42,18 @@ void TensorSumprodFiberOp::lower_to_tile(const LoweringContext& ctx) const
     const auto& t2 = tile_lower::tiles_of(ctx.tile_map, src2);
     const auto& td = tile_lower::tiles_of(ctx.tile_map, dst);
     constexpr Scalar one = 1.0;
+    const Index src_nd = src1->ndim();
+    const Index lay_ax = layout_axis(axis, src_nd);
     std::vector<Index> c1;
     for(Index lin1 = 0; lin1 < lay1->grid_volume(); ++lin1)
     {
         lay1->grid_coord_from_linear(lin1, c1);
-        const Index j_dst = c1[static_cast<size_t>(axis)];
+        const Index j_dst = c1[static_cast<size_t>(lay_ax)];
         bool init_first = true;
-        for(Index j = 0; j < src1->ndim(); ++j)
+        for(Index g = 0; g < src_nd; ++g)
         {
-            if(j != axis && c1[static_cast<size_t>(j)] != 0)
+            if(g != axis
+                && c1[static_cast<size_t>(layout_axis(g, src_nd))] != 0)
             {
                 init_first = false;
                 break;
@@ -67,7 +67,7 @@ void TensorSumprodFiberOp::lower_to_tile(const LoweringContext& ctx) const
                 t2[static_cast<size_t>(lin1)],
                 beta,
                 td[static_cast<size_t>(j_dst)],
-                g_axis,
+                axis,
                 redux);
         }
         else
@@ -78,7 +78,7 @@ void TensorSumprodFiberOp::lower_to_tile(const LoweringContext& ctx) const
                 t2[static_cast<size_t>(lin1)],
                 one,
                 td[static_cast<size_t>(j_dst)],
-                g_axis,
+                axis,
                 redux);
         }
     }
@@ -125,12 +125,10 @@ void sumprod_fiber(
     }
 
     validate_same_shape_and_merge(src1, src2, "sumprod_fiber");
-    const Index s_axis = graph_axis_to_storage(axis, src1->ndim());
-    // Merge dst (reduced fiber) axis with src1 axis
     merge_axis(dst->mutable_axes()[0], src1->mutable_axes()[axis]);
 
     auto op = std::make_shared<TensorSumprodFiberOp>(
-        src1, src2, dst, s_axis, redux, alpha, beta);
+        src1, src2, dst, axis, redux, alpha, beta);
     src1->graph()->add_op(op);
 }
 

--- a/nntile/src/tensor/ops/sumprod_slice.cc
+++ b/nntile/src/tensor/ops/sumprod_slice.cc
@@ -94,7 +94,7 @@ void TensorSumprodSliceOp::lower_to_tile(const LoweringContext& ctx) const
 
     const Index src_nd = src1->ndim();
     const Index dst_nd = dst->ndim();
-    const Index s_axis = graph_axis_to_storage(axis, src_nd);
+    const Index lay_ax = layout_axis(axis, src_nd);
 
     std::vector<Index> dst_coord;
     std::vector<Index> s1_coord(static_cast<size_t>(src_nd));
@@ -104,33 +104,21 @@ void TensorSumprodSliceOp::lower_to_tile(const LoweringContext& ctx) const
         lay_d->grid_coord_from_linear(lin_d, dst_coord);
         TileGraph::TileNode* dst_tile = tiles_d[static_cast<size_t>(lin_d)];
 
-        for(Index sd = 0; sd < dst_nd; ++sd)
+        for(Index g_src = 0; g_src < src_nd; ++g_src)
         {
-            const Index g_dst = storage_axis_to_graph(sd, dst_nd);
-            Index g_src = 0;
-            Index k = 0;
-            for(Index g2 = 0; g2 < src_nd; ++g2)
+            if(g_src == axis)
             {
-                if(g2 == axis)
-                {
-                    continue;
-                }
-                if(k == g_dst)
-                {
-                    g_src = g2;
-                    break;
-                }
-                ++k;
+                continue;
             }
-            s1_coord[static_cast<size_t>(
-                graph_axis_to_storage(g_src, src_nd))] =
-                dst_coord[static_cast<size_t>(sd)];
+            const Index g_dst = (g_src < axis) ? g_src : (g_src - 1);
+            s1_coord[static_cast<size_t>(layout_axis(g_src, src_nd))] =
+                dst_coord[static_cast<size_t>(layout_axis(g_dst, dst_nd))];
         }
 
         const Index nseg_along_axis =
-            lay_s1->grid_shape()[static_cast<size_t>(s_axis)];
+            lay_s1->grid_shape()[static_cast<size_t>(lay_ax)];
 
-        s1_coord[static_cast<size_t>(s_axis)] = 0;
+        s1_coord[static_cast<size_t>(lay_ax)] = 0;
         Index lin_s0 = lay_s1->grid_linear(s1_coord);
         tile::sumprod_slice(
             alpha,
@@ -143,7 +131,7 @@ void TensorSumprodSliceOp::lower_to_tile(const LoweringContext& ctx) const
 
         for(Index jj = 1; jj < nseg_along_axis; ++jj)
         {
-            s1_coord[static_cast<size_t>(s_axis)] = jj;
+            s1_coord[static_cast<size_t>(lay_ax)] = jj;
             const Index lin_s = lay_s1->grid_linear(s1_coord);
             tile::sumprod_slice(
                 alpha,

--- a/nntile/src/tensor/ops/sumprod_slice.cc
+++ b/nntile/src/tensor/ops/sumprod_slice.cc
@@ -138,7 +138,7 @@ void TensorSumprodSliceOp::lower_to_tile(const LoweringContext& ctx) const
             tiles_s2[static_cast<size_t>(lin_s0)],
             beta,
             dst_tile,
-            s_axis,
+            axis,
             redux);
 
         for(Index jj = 1; jj < nseg_along_axis; ++jj)
@@ -151,7 +151,7 @@ void TensorSumprodSliceOp::lower_to_tile(const LoweringContext& ctx) const
                 tiles_s2[static_cast<size_t>(lin_s)],
                 Scalar(1.0),
                 dst_tile,
-                s_axis,
+                axis,
                 redux);
         }
     }

--- a/nntile/src/tensor/ops/transpose.cc
+++ b/nntile/src/tensor/ops/transpose.cc
@@ -87,7 +87,7 @@ void TensorTransposeOp::lower_to_tile(const LoweringContext &ctx) const
             tile::transpose(alpha,
                 tiles_s[static_cast<size_t>(lin_s)],
                 tiles_d[static_cast<size_t>(lin_d)],
-                storage_ndim);
+                ndim);
         }
     }
 }

--- a/nntile/src/tile/append_tensor_graph_phase.cc
+++ b/nntile/src/tile/append_tensor_graph_phase.cc
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include "nntile/tensor/graph.hh"
+#include "nntile/tensor/shape_layout.hh"
 #include "nntile/tile/graph.hh"
 #include <nntile/runtime.hh>
 #include "nntile/tile/lower_from_tensor.hh"
@@ -83,8 +84,10 @@ std::vector<TileGraph::TileNode*> create_tile_nodes_only(
     for(Index lin = 0; lin < vol; ++lin)
     {
         lay.grid_coord_from_linear(lin, grid_coord);
-        const std::vector<Index> tile_shape =
+        const std::vector<Index> storage_tile_shape =
             lay.tile_shape_at(grid_coord);
+        const std::vector<Index> tile_shape =
+            tensor::storage_shape_to_graph(storage_tile_shape);
         const std::string tname =
             tile_node_name(tensor_node->name(), group_id, lin, vol);
         TileGraph::TileNode* tile_node_ptr = tile_graph.data(
@@ -113,7 +116,8 @@ void attach_new_descriptor(
     TileGraph::TensorDescriptor desc;
     desc.tensor_name = tensor_node->name();
     desc.tensor_shape = tensor_node->shape();
-    desc.tile_shape = lay.max_tile_extents();
+    desc.tile_shape =
+        tensor::storage_shape_to_graph(lay.max_tile_extents());
     desc.grid_shape = lay.grid_shape();
     desc.dtype = tensor_node->dtype();
     desc.tiles = tiles;

--- a/nntile/src/tile/from_tensor_graph.cc
+++ b/nntile/src/tile/from_tensor_graph.cc
@@ -19,6 +19,7 @@
 #include <stdexcept>
 
 #include "nntile/tensor/graph.hh"
+#include "nntile/tensor/shape_layout.hh"
 #include "nntile/tensor/tensor_graph_tiling.hh"
 #include "nntile/tile/lower_from_tensor.hh"
 
@@ -73,7 +74,10 @@ TileGraph TileGraph::from_tensor_graph(
         for(Index lin = 0; lin < vol; ++lin)
         {
             lay->grid_coord_from_linear(lin, grid_coord);
-            const std::vector<Index> tile_shape = lay->tile_shape_at(grid_coord);
+            const std::vector<Index> storage_tile_shape =
+                lay->tile_shape_at(grid_coord);
+            const std::vector<Index> tile_shape =
+                tensor::storage_shape_to_graph(storage_tile_shape);
             const std::string tname =
                 internal_tile_name(tensor_node->name(), lin, vol);
 
@@ -97,7 +101,8 @@ TileGraph TileGraph::from_tensor_graph(
         TileGraph::TensorDescriptor desc;
         desc.tensor_name = tensor_node->name();
         desc.tensor_shape = tensor_node->shape();
-        desc.tile_shape = lay->max_tile_extents();
+        desc.tile_shape =
+            tensor::storage_shape_to_graph(lay->max_tile_extents());
         desc.grid_shape = lay->grid_shape();
         desc.dtype = tensor_node->dtype();
         desc.tiles = tiles;

--- a/nntile/src/tile/ops/add_fiber.cc
+++ b/nntile/src/tile/ops/add_fiber.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/add_fiber.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -54,28 +55,30 @@ void add_fiber(
 }
 void TileAddFiberOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim);
+            run<nntile::fp32_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim);
+            run<nntile::fp64_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim);
             break;
         case DataType::FP16:
             throw std::runtime_error("FP16 not supported for add_fiber in this build");
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim);
+            run<nntile::bf16_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/add_fiber.cc
+++ b/nntile/src/tile/ops/add_fiber.cc
@@ -37,7 +37,7 @@ void run(
     Index ax,
     Index bd)
 {
-    nntile::core::add_fiber<T>(runtime.starpu_worker_hint(), 
+    nntile::core::add_fiber<T>(runtime.starpu_worker_hint(),
         a, runtime.get_tile<T>(t1), b, runtime.get_tile<T>(t2), runtime.get_tile<T>(d), ax, bd);
 }
 } // namespace
@@ -56,7 +56,7 @@ void add_fiber(
 void TileAddFiberOp::execute(Runtime& runtime) const
 {
     const Index s_axis =
-        tensor::graph_axis_to_storage(axis, dst->ndim());
+        tensor::graph_axis_to_storage(axis, s2->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {

--- a/nntile/src/tile/ops/add_fiber_inplace.cc
+++ b/nntile/src/tile/ops/add_fiber_inplace.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/add_fiber_inplace.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -42,29 +43,31 @@ void add_fiber_inplace(Scalar a, TileGraph::TileNode* s, Scalar b, TileGraph::Ti
 }
 void TileAddFiberInplaceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, src, beta, dst, axis, batch_ndim);
+            run<nntile::fp32_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, beta, dst, axis, batch_ndim);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, beta, dst, axis, batch_ndim);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, beta, dst, axis, batch_ndim);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, src, beta, dst, axis, batch_ndim);
+            run<nntile::fp64_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, src, beta, dst, axis, batch_ndim);
+            run<nntile::fp16_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, src, beta, dst, axis, batch_ndim);
+            run<nntile::bf16_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/add_slice.cc
+++ b/nntile/src/tile/ops/add_slice.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/add_slice.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -44,29 +45,31 @@ void add_slice(Scalar a, TileGraph::TileNode* t1, Scalar b, TileGraph::TileNode*
 }
 void TileAddSliceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, t2->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, s1, beta, s2, dst, axis);
+            run<nntile::fp32_t>(runtime, alpha, s1, beta, s2, dst, s_axis);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, beta, s2, dst, axis);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, beta, s2, dst, s_axis);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, beta, s2, dst, axis);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, beta, s2, dst, s_axis);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, beta, s2, dst, axis);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, beta, s2, dst, s_axis);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, s1, beta, s2, dst, axis);
+            run<nntile::fp64_t>(runtime, alpha, s1, beta, s2, dst, s_axis);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, s1, beta, s2, dst, axis);
+            run<nntile::fp16_t>(runtime, alpha, s1, beta, s2, dst, s_axis);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, s1, beta, s2, dst, axis);
+            run<nntile::bf16_t>(runtime, alpha, s1, beta, s2, dst, s_axis);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/add_slice.cc
+++ b/nntile/src/tile/ops/add_slice.cc
@@ -46,7 +46,7 @@ void add_slice(Scalar a, TileGraph::TileNode* t1, Scalar b, TileGraph::TileNode*
 void TileAddSliceOp::execute(Runtime& runtime) const
 {
     const Index s_axis =
-        tensor::graph_axis_to_storage(axis, t2->ndim());
+        tensor::graph_axis_to_storage(axis, s2->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {

--- a/nntile/src/tile/ops/add_slice_inplace.cc
+++ b/nntile/src/tile/ops/add_slice_inplace.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/add_slice_inplace.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -42,29 +43,31 @@ void add_slice_inplace(Scalar a, TileGraph::TileNode* s, Scalar b, TileGraph::Ti
 }
 void TileAddSliceInplaceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, src, beta, dst, axis);
+            run<nntile::fp32_t>(runtime, alpha, src, beta, dst, s_axis);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, beta, dst, axis);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, beta, dst, s_axis);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, beta, dst, axis);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, beta, dst, s_axis);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, beta, dst, axis);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, beta, dst, s_axis);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, src, beta, dst, axis);
+            run<nntile::fp64_t>(runtime, alpha, src, beta, dst, s_axis);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, src, beta, dst, axis);
+            run<nntile::fp16_t>(runtime, alpha, src, beta, dst, s_axis);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, src, beta, dst, axis);
+            run<nntile::bf16_t>(runtime, alpha, src, beta, dst, s_axis);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/gemm.cc
+++ b/nntile/src/tile/ops/gemm.cc
@@ -31,6 +31,8 @@ namespace nntile::tile
 namespace
 {
 
+//! Graph-order GEMM (C = alpha * op(A) @ op(B) + beta * C); core uses
+//! Fortran layout via operand/transpose swap at execute.
 template<typename T>
 void run_gemm(
     Runtime& runtime,
@@ -53,8 +55,8 @@ void run_gemm(
     const auto trans_b_op = trans_b ? nntile::TransOp(nntile::TransOp::Trans)
                                     : nntile::TransOp(nntile::TransOp::NoTrans);
 
-    nntile::core::gemm<T>(runtime.starpu_worker_hint(), 
-        alpha, trans_a_op, a_t, trans_b_op, b_t, beta, c_t, ndim, batch_ndim,
+    nntile::core::gemm<T>(runtime.starpu_worker_hint(),
+        alpha, trans_b_op, b_t, trans_a_op, a_t, beta, c_t, ndim, batch_ndim,
         0);
 }
 

--- a/nntile/src/tile/ops/maxsumexp.cc
+++ b/nntile/src/tile/ops/maxsumexp.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/maxsumexp.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -46,29 +47,31 @@ void maxsumexp(TileGraph::TileNode* src, TileGraph::TileNode* dst, Index axis, i
 }
 void TileMaxsumexpOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run_me<nntile::fp32_t>(runtime, src, dst, axis, redux);
+            run_me<nntile::fp32_t>(runtime, src, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_TF32:
-            run_me<nntile::fp32_fast_tf32_t>(runtime, src, dst, axis, redux);
+            run_me<nntile::fp32_fast_tf32_t>(runtime, src, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_FP16:
-            run_me<nntile::fp32_fast_fp16_t>(runtime, src, dst, axis, redux);
+            run_me<nntile::fp32_fast_fp16_t>(runtime, src, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_BF16:
-            run_me<nntile::fp32_fast_bf16_t>(runtime, src, dst, axis, redux);
+            run_me<nntile::fp32_fast_bf16_t>(runtime, src, dst, s_axis, redux);
             break;
         case DataType::FP64:
-            run_me<nntile::fp64_t>(runtime, src, dst, axis, redux);
+            run_me<nntile::fp64_t>(runtime, src, dst, s_axis, redux);
             break;
         case DataType::FP16:
-            run_me<nntile::fp16_t>(runtime, src, dst, axis, redux);
+            run_me<nntile::fp16_t>(runtime, src, dst, s_axis, redux);
             break;
         case DataType::BF16:
-            run_me<nntile::bf16_t>(runtime, src, dst, axis, redux);
+            run_me<nntile::bf16_t>(runtime, src, dst, s_axis, redux);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/maxsumexp.cc
+++ b/nntile/src/tile/ops/maxsumexp.cc
@@ -47,6 +47,7 @@ void maxsumexp(TileGraph::TileNode* src, TileGraph::TileNode* dst, Index axis, i
 }
 void TileMaxsumexpOp::execute(Runtime& runtime) const
 {
+    // axis is graph-indexed on src; convert for core Fortran kernel.
     const Index s_axis =
         tensor::graph_axis_to_storage(axis, src->ndim());
     DataType dtype = runtime.get_dtype(src);

--- a/nntile/src/tile/ops/maxsumexp.cc
+++ b/nntile/src/tile/ops/maxsumexp.cc
@@ -48,7 +48,7 @@ void maxsumexp(TileGraph::TileNode* src, TileGraph::TileNode* dst, Index axis, i
 void TileMaxsumexpOp::execute(Runtime& runtime) const
 {
     const Index s_axis =
-        tensor::graph_axis_to_storage(axis, dst->ndim());
+        tensor::graph_axis_to_storage(axis, src->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {

--- a/nntile/src/tile/ops/multiply_fiber.cc
+++ b/nntile/src/tile/ops/multiply_fiber.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/multiply_fiber.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -44,29 +45,31 @@ void multiply_fiber(Scalar a, TileGraph::TileNode* t1, TileGraph::TileNode* t2, 
 }
 void TileMultiplyFiberOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, s1, s2, dst, axis);
+            run<nntile::fp32_t>(runtime, alpha, s1, s2, dst, s_axis);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, s2, dst, axis);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, s2, dst, s_axis);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, s2, dst, axis);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, s2, dst, s_axis);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, s2, dst, axis);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, s2, dst, s_axis);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, s1, s2, dst, axis);
+            run<nntile::fp64_t>(runtime, alpha, s1, s2, dst, s_axis);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, s1, s2, dst, axis);
+            run<nntile::fp16_t>(runtime, alpha, s1, s2, dst, s_axis);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, s1, s2, dst, axis);
+            run<nntile::bf16_t>(runtime, alpha, s1, s2, dst, s_axis);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/multiply_fiber.cc
+++ b/nntile/src/tile/ops/multiply_fiber.cc
@@ -46,7 +46,7 @@ void multiply_fiber(Scalar a, TileGraph::TileNode* t1, TileGraph::TileNode* t2, 
 void TileMultiplyFiberOp::execute(Runtime& runtime) const
 {
     const Index s_axis =
-        tensor::graph_axis_to_storage(axis, dst->ndim());
+        tensor::graph_axis_to_storage(axis, s2->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {

--- a/nntile/src/tile/ops/multiply_fiber_inplace.cc
+++ b/nntile/src/tile/ops/multiply_fiber_inplace.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/multiply_fiber_inplace.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -41,29 +42,31 @@ void multiply_fiber_inplace(Scalar a, TileGraph::TileNode* s, TileGraph::TileNod
 }
 void TileMultiplyFiberInplaceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp64_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::bf16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/multiply_slice.cc
+++ b/nntile/src/tile/ops/multiply_slice.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/multiply_slice.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -41,29 +42,31 @@ void multiply_slice(Scalar a, TileGraph::TileNode* s, TileGraph::TileNode* d, In
 }
 void TileMultiplySliceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp64_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::bf16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/norm_fiber.cc
+++ b/nntile/src/tile/ops/norm_fiber.cc
@@ -47,7 +47,7 @@ void norm_fiber(
 void TileNormFiberOp::execute(Runtime& runtime) const
 {
     const Index s_axis =
-        tensor::graph_axis_to_storage(axis, dst->ndim());
+        tensor::graph_axis_to_storage(axis, s1->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {

--- a/nntile/src/tile/ops/norm_fiber.cc
+++ b/nntile/src/tile/ops/norm_fiber.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/norm_fiber.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -45,28 +46,30 @@ void norm_fiber(
 }
 void TileNormFiberOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim, redux);
+            run<nntile::fp64_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP16:
             throw std::runtime_error("FP16 not supported for tile norm_fiber in this build");
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, s1, beta, s2, dst, axis, batch_ndim, redux);
+            run<nntile::bf16_t>(runtime, alpha, s1, beta, s2, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/norm_fiber_inplace.cc
+++ b/nntile/src/tile/ops/norm_fiber_inplace.cc
@@ -44,7 +44,7 @@ void norm_fiber_inplace(Scalar a, TileGraph::TileNode* s, Scalar b, TileGraph::T
 void TileNormFiberInplaceOp::execute(Runtime& runtime) const
 {
     const Index s_axis =
-        tensor::graph_axis_to_storage(axis, dst->ndim());
+        tensor::graph_axis_to_storage(axis, src->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {

--- a/nntile/src/tile/ops/norm_fiber_inplace.cc
+++ b/nntile/src/tile/ops/norm_fiber_inplace.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/norm_fiber_inplace.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -42,28 +43,30 @@ void norm_fiber_inplace(Scalar a, TileGraph::TileNode* s, Scalar b, TileGraph::T
 }
 void TileNormFiberInplaceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::fp64_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP16:
             throw std::runtime_error("FP16 not supported for tile norm_fiber_inplace in this build");
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::bf16_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/norm_slice.cc
+++ b/nntile/src/tile/ops/norm_slice.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/norm_slice.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -44,29 +45,31 @@ void norm_slice(Scalar a, TileGraph::TileNode* t1, Scalar b, TileGraph::TileNode
 }
 void TileNormSliceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, s1, beta, s2, dst, axis, redux);
+            run<nntile::fp32_t>(runtime, alpha, s1, beta, s2, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, beta, s2, dst, axis, redux);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, beta, s2, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, beta, s2, dst, axis, redux);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, beta, s2, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, beta, s2, dst, axis, redux);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, beta, s2, dst, s_axis, redux);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, s1, beta, s2, dst, axis, redux);
+            run<nntile::fp64_t>(runtime, alpha, s1, beta, s2, dst, s_axis, redux);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, s1, beta, s2, dst, axis, redux);
+            run<nntile::fp16_t>(runtime, alpha, s1, beta, s2, dst, s_axis, redux);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, s1, beta, s2, dst, axis, redux);
+            run<nntile::bf16_t>(runtime, alpha, s1, beta, s2, dst, s_axis, redux);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/norm_slice.cc
+++ b/nntile/src/tile/ops/norm_slice.cc
@@ -46,7 +46,7 @@ void norm_slice(Scalar a, TileGraph::TileNode* t1, Scalar b, TileGraph::TileNode
 void TileNormSliceOp::execute(Runtime& runtime) const
 {
     const Index s_axis =
-        tensor::graph_axis_to_storage(axis, dst->ndim());
+        tensor::graph_axis_to_storage(axis, s1->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {

--- a/nntile/src/tile/ops/norm_slice_inplace.cc
+++ b/nntile/src/tile/ops/norm_slice_inplace.cc
@@ -44,7 +44,7 @@ void norm_slice_inplace(Scalar a, TileGraph::TileNode* s, Scalar b, TileGraph::T
 void TileNormSliceInplaceOp::execute(Runtime& runtime) const
 {
     const Index s_axis =
-        tensor::graph_axis_to_storage(axis, dst->ndim());
+        tensor::graph_axis_to_storage(axis, src->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {

--- a/nntile/src/tile/ops/norm_slice_inplace.cc
+++ b/nntile/src/tile/ops/norm_slice_inplace.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/norm_slice_inplace.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -42,29 +43,31 @@ void norm_slice_inplace(Scalar a, TileGraph::TileNode* s, Scalar b, TileGraph::T
 }
 void TileNormSliceInplaceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, src, beta, dst, axis, redux);
+            run<nntile::fp32_t>(runtime, alpha, src, beta, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, beta, dst, axis, redux);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, beta, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, beta, dst, axis, redux);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, beta, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, beta, dst, axis, redux);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, beta, dst, s_axis, redux);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, src, beta, dst, axis, redux);
+            run<nntile::fp64_t>(runtime, alpha, src, beta, dst, s_axis, redux);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, src, beta, dst, axis, redux);
+            run<nntile::fp16_t>(runtime, alpha, src, beta, dst, s_axis, redux);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, src, beta, dst, axis, redux);
+            run<nntile::bf16_t>(runtime, alpha, src, beta, dst, s_axis, redux);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/scale_fiber.cc
+++ b/nntile/src/tile/ops/scale_fiber.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/scale_fiber.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -41,29 +42,31 @@ void scale_fiber(Scalar a, TileGraph::TileNode* s, TileGraph::TileNode* d, Index
 }
 void TileScaleFiberOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, src, dst, axis, batch_ndim);
+            run<nntile::fp32_t>(runtime, alpha, src, dst, s_axis, batch_ndim);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, dst, axis, batch_ndim);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, dst, s_axis, batch_ndim);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, dst, axis, batch_ndim);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, dst, s_axis, batch_ndim);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, dst, axis, batch_ndim);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, dst, s_axis, batch_ndim);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, src, dst, axis, batch_ndim);
+            run<nntile::fp64_t>(runtime, alpha, src, dst, s_axis, batch_ndim);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, src, dst, axis, batch_ndim);
+            run<nntile::fp16_t>(runtime, alpha, src, dst, s_axis, batch_ndim);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, src, dst, axis, batch_ndim);
+            run<nntile::bf16_t>(runtime, alpha, src, dst, s_axis, batch_ndim);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/scale_slice.cc
+++ b/nntile/src/tile/ops/scale_slice.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/scale_slice.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -41,29 +42,31 @@ void scale_slice(Scalar a, TileGraph::TileNode* s, TileGraph::TileNode* d, Index
 }
 void TileScaleSliceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp64_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::fp16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, src, dst, axis);
+            run<nntile::bf16_t>(runtime, alpha, src, dst, s_axis);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/softmax.cc
+++ b/nntile/src/tile/ops/softmax.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/softmax.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -52,29 +53,31 @@ void softmax(
 }
 void TileSoftmaxOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run_sm<nntile::fp32_t>(runtime, maxsumexp, src, alpha, dst, axis);
+            run_sm<nntile::fp32_t>(runtime, maxsumexp, src, alpha, dst, s_axis);
             break;
         case DataType::FP32_FAST_TF32:
-            run_sm<nntile::fp32_fast_tf32_t>(runtime, maxsumexp, src, alpha, dst, axis);
+            run_sm<nntile::fp32_fast_tf32_t>(runtime, maxsumexp, src, alpha, dst, s_axis);
             break;
         case DataType::FP32_FAST_FP16:
-            run_sm<nntile::fp32_fast_fp16_t>(runtime, maxsumexp, src, alpha, dst, axis);
+            run_sm<nntile::fp32_fast_fp16_t>(runtime, maxsumexp, src, alpha, dst, s_axis);
             break;
         case DataType::FP32_FAST_BF16:
-            run_sm<nntile::fp32_fast_bf16_t>(runtime, maxsumexp, src, alpha, dst, axis);
+            run_sm<nntile::fp32_fast_bf16_t>(runtime, maxsumexp, src, alpha, dst, s_axis);
             break;
         case DataType::FP64:
-            run_sm<nntile::fp64_t>(runtime, maxsumexp, src, alpha, dst, axis);
+            run_sm<nntile::fp64_t>(runtime, maxsumexp, src, alpha, dst, s_axis);
             break;
         case DataType::FP16:
-            run_sm<nntile::fp16_t>(runtime, maxsumexp, src, alpha, dst, axis);
+            run_sm<nntile::fp16_t>(runtime, maxsumexp, src, alpha, dst, s_axis);
             break;
         case DataType::BF16:
-            run_sm<nntile::bf16_t>(runtime, maxsumexp, src, alpha, dst, axis);
+            run_sm<nntile::bf16_t>(runtime, maxsumexp, src, alpha, dst, s_axis);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/softmax_inplace.cc
+++ b/nntile/src/tile/ops/softmax_inplace.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/softmax_inplace.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -47,29 +48,31 @@ void softmax_inplace(TileGraph::TileNode* mse, Scalar alpha, TileGraph::TileNode
 }
 void TileSoftmaxInplaceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(dst);
     switch(dtype)
     {
         case DataType::FP32:
-            run_smi<nntile::fp32_t>(runtime, maxsumexp_n, alpha, dst, axis);
+            run_smi<nntile::fp32_t>(runtime, maxsumexp_n, alpha, dst, s_axis);
             break;
         case DataType::FP32_FAST_TF32:
-            run_smi<nntile::fp32_fast_tf32_t>(runtime, maxsumexp_n, alpha, dst, axis);
+            run_smi<nntile::fp32_fast_tf32_t>(runtime, maxsumexp_n, alpha, dst, s_axis);
             break;
         case DataType::FP32_FAST_FP16:
-            run_smi<nntile::fp32_fast_fp16_t>(runtime, maxsumexp_n, alpha, dst, axis);
+            run_smi<nntile::fp32_fast_fp16_t>(runtime, maxsumexp_n, alpha, dst, s_axis);
             break;
         case DataType::FP32_FAST_BF16:
-            run_smi<nntile::fp32_fast_bf16_t>(runtime, maxsumexp_n, alpha, dst, axis);
+            run_smi<nntile::fp32_fast_bf16_t>(runtime, maxsumexp_n, alpha, dst, s_axis);
             break;
         case DataType::FP64:
-            run_smi<nntile::fp64_t>(runtime, maxsumexp_n, alpha, dst, axis);
+            run_smi<nntile::fp64_t>(runtime, maxsumexp_n, alpha, dst, s_axis);
             break;
         case DataType::FP16:
-            run_smi<nntile::fp16_t>(runtime, maxsumexp_n, alpha, dst, axis);
+            run_smi<nntile::fp16_t>(runtime, maxsumexp_n, alpha, dst, s_axis);
             break;
         case DataType::BF16:
-            run_smi<nntile::bf16_t>(runtime, maxsumexp_n, alpha, dst, axis);
+            run_smi<nntile::bf16_t>(runtime, maxsumexp_n, alpha, dst, s_axis);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/sum_fiber.cc
+++ b/nntile/src/tile/ops/sum_fiber.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/sum_fiber.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -44,29 +45,31 @@ void sum_fiber(
 }
 void TileSumFiberOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::fp64_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::fp16_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, src, beta, dst, axis, batch_ndim, redux);
+            run<nntile::bf16_t>(runtime, alpha, src, beta, dst, s_axis, batch_ndim, redux);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/sum_fiber.cc
+++ b/nntile/src/tile/ops/sum_fiber.cc
@@ -46,7 +46,7 @@ void sum_fiber(
 void TileSumFiberOp::execute(Runtime& runtime) const
 {
     const Index s_axis =
-        tensor::graph_axis_to_storage(axis, dst->ndim());
+        tensor::graph_axis_to_storage(axis, src->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {

--- a/nntile/src/tile/ops/sum_slice.cc
+++ b/nntile/src/tile/ops/sum_slice.cc
@@ -21,6 +21,7 @@
 #include <nntile/core/sum_slice.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -44,29 +45,31 @@ void sum_slice(
 }
 void TileSumSliceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, src->ndim());
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, src, dst, alpha, beta, axis, redux);
+            run<nntile::fp32_t>(runtime, src, dst, alpha, beta, s_axis, redux);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, src, dst, alpha, beta, axis, redux);
+            run<nntile::fp32_fast_tf32_t>(runtime, src, dst, alpha, beta, s_axis, redux);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, src, dst, alpha, beta, axis, redux);
+            run<nntile::fp32_fast_fp16_t>(runtime, src, dst, alpha, beta, s_axis, redux);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, src, dst, alpha, beta, axis, redux);
+            run<nntile::fp32_fast_bf16_t>(runtime, src, dst, alpha, beta, s_axis, redux);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, src, dst, alpha, beta, axis, redux);
+            run<nntile::fp64_t>(runtime, src, dst, alpha, beta, s_axis, redux);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, src, dst, alpha, beta, axis, redux);
+            run<nntile::fp16_t>(runtime, src, dst, alpha, beta, s_axis, redux);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, src, dst, alpha, beta, axis, redux);
+            run<nntile::bf16_t>(runtime, src, dst, alpha, beta, s_axis, redux);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/sumprod_fiber.cc
+++ b/nntile/src/tile/ops/sumprod_fiber.cc
@@ -45,7 +45,7 @@ void sumprod_fiber(Scalar a, TileGraph::TileNode* t1, TileGraph::TileNode* t2, S
 void TileSumprodFiberOp::execute(Runtime& runtime) const
 {
     const Index s_axis =
-        tensor::graph_axis_to_storage(axis, dst->ndim());
+        tensor::graph_axis_to_storage(axis, s1->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {

--- a/nntile/src/tile/ops/sumprod_fiber.cc
+++ b/nntile/src/tile/ops/sumprod_fiber.cc
@@ -20,6 +20,7 @@
 #include <nntile/core/sumprod_fiber.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -43,29 +44,31 @@ void sumprod_fiber(Scalar a, TileGraph::TileNode* t1, TileGraph::TileNode* t2, S
 }
 void TileSumprodFiberOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp32_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp64_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp16_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::bf16_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/sumprod_slice.cc
+++ b/nntile/src/tile/ops/sumprod_slice.cc
@@ -45,7 +45,7 @@ void sumprod_slice(Scalar a, TileGraph::TileNode* t1, TileGraph::TileNode* t2, S
 void TileSumprodSliceOp::execute(Runtime& runtime) const
 {
     const Index s_axis =
-        tensor::graph_axis_to_storage(axis, dst->ndim());
+        tensor::graph_axis_to_storage(axis, s1->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {

--- a/nntile/src/tile/ops/sumprod_slice.cc
+++ b/nntile/src/tile/ops/sumprod_slice.cc
@@ -20,6 +20,7 @@
 #include <nntile/core/sumprod_slice.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 namespace nntile::tile
 {
 namespace
@@ -43,29 +44,31 @@ void sumprod_slice(Scalar a, TileGraph::TileNode* t1, TileGraph::TileNode* t2, S
 }
 void TileSumprodSliceOp::execute(Runtime& runtime) const
 {
+    const Index s_axis =
+        tensor::graph_axis_to_storage(axis, dst->ndim());
     DataType dtype = runtime.get_dtype(s1);
     switch(dtype)
     {
         case DataType::FP32:
-            run<nntile::fp32_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp32_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_TF32:
-            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp32_fast_tf32_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_FP16:
-            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp32_fast_fp16_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::FP32_FAST_BF16:
-            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp32_fast_bf16_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::FP64:
-            run<nntile::fp64_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp64_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::FP16:
-            run<nntile::fp16_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::fp16_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::BF16:
-            run<nntile::bf16_t>(runtime, alpha, s1, s2, beta, dst, axis, redux);
+            run<nntile::bf16_t>(runtime, alpha, s1, s2, beta, dst, s_axis, redux);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/src/tile/ops/transpose.cc
+++ b/nntile/src/tile/ops/transpose.cc
@@ -23,6 +23,7 @@
 #include <nntile/core/transpose.hh>
 
 #include <nntile/runtime.hh>
+#include <nntile/tile/shape_layout.hh>
 
 namespace nntile::tile
 {
@@ -65,29 +66,30 @@ void transpose(Scalar alpha, TileGraph::TileNode* src, TileGraph::TileNode* dst,
 
 void TileTransposeOp::execute(Runtime& runtime) const
 {
+    const Index storage_ndim = src->ndim() - ndim;
     DataType dtype = runtime.get_dtype(src);
     switch(dtype)
     {
         case DataType::FP32:
-            run_transpose<nntile::fp32_t>(runtime, alpha, ndim, src, dst);
+            run_transpose<nntile::fp32_t>(runtime, alpha, storage_ndim, src, dst);
             break;
         case DataType::FP32_FAST_TF32:
-            run_transpose<nntile::fp32_fast_tf32_t>(runtime, alpha, ndim, src, dst);
+            run_transpose<nntile::fp32_fast_tf32_t>(runtime, alpha, storage_ndim, src, dst);
             break;
         case DataType::FP32_FAST_FP16:
-            run_transpose<nntile::fp32_fast_fp16_t>(runtime, alpha, ndim, src, dst);
+            run_transpose<nntile::fp32_fast_fp16_t>(runtime, alpha, storage_ndim, src, dst);
             break;
         case DataType::FP32_FAST_BF16:
-            run_transpose<nntile::fp32_fast_bf16_t>(runtime, alpha, ndim, src, dst);
+            run_transpose<nntile::fp32_fast_bf16_t>(runtime, alpha, storage_ndim, src, dst);
             break;
         case DataType::FP64:
-            run_transpose<nntile::fp64_t>(runtime, alpha, ndim, src, dst);
+            run_transpose<nntile::fp64_t>(runtime, alpha, storage_ndim, src, dst);
             break;
         case DataType::FP16:
-            run_transpose<nntile::fp16_t>(runtime, alpha, ndim, src, dst);
+            run_transpose<nntile::fp16_t>(runtime, alpha, storage_ndim, src, dst);
             break;
         case DataType::BF16:
-            run_transpose<nntile::bf16_t>(runtime, alpha, ndim, src, dst);
+            run_transpose<nntile::bf16_t>(runtime, alpha, storage_ndim, src, dst);
             break;
         case DataType::INT64:
         case DataType::BOOL:

--- a/nntile/tests/tensor/ops/add_fiber.cc
+++ b/nntile/tests/tensor/ops/add_fiber.cc
@@ -16,7 +16,7 @@
 
 #include "context_fixture.hh"
 #include "nntile/tensor.hh"
-#include "nntile/tensor/axis_descriptor.hh"
+#include "nntile/tensor/shape_layout.hh"
 #include "nntile/tile.hh"
 #include "nntile/tensor/ops/add_fiber.hh"
 #include "nntile/tensor.hh"
@@ -47,18 +47,11 @@ constexpr Index dim_5 = 5;
 
 } // anonymous namespace
 
-//! Fiber shape for add_fiber: {tensor_shape[axis]} for batch_ndim=0
+//! Fiber graph shape: leading batch axes, then fiber axis (C-order).
 static std::vector<Index> fiber_shape(
     const std::vector<Index> &tensor_shape, Index axis, Index batch_ndim)
 {
-    std::vector<Index> out;
-    out.reserve(batch_ndim + 1);
-    out.push_back(tensor_shape[axis]);
-    for (Index i = 0; i < batch_ndim; ++i)
-    {
-        out.push_back(tensor_shape[tensor_shape.size() - batch_ndim + i]);
-    }
-    return out;
+    return nntile::tensor::graph_fiber_shape(tensor_shape, axis, batch_ndim);
 }
 
 TEST_CASE("TensorGraph add_fiber structure", "[graph][tensor]")

--- a/nntile/tests/tensor/ops/add_fiber_inplace.cc
+++ b/nntile/tests/tensor/ops/add_fiber_inplace.cc
@@ -16,7 +16,7 @@
 
 #include "context_fixture.hh"
 #include "nntile/tensor.hh"
-#include "nntile/tensor/axis_descriptor.hh"
+#include "nntile/tensor/shape_layout.hh"
 #include "nntile/tile.hh"
 #include "nntile/tensor/ops/add_fiber_inplace.hh"
 #include "nntile/tensor.hh"
@@ -47,18 +47,10 @@ constexpr Index dim_5 = 5;
 
 } // anonymous namespace
 
-//! Fiber shape: {tensor_shape[axis]} for batch_ndim=0
 static std::vector<Index> fiber_shape(
     const std::vector<Index> &tensor_shape, Index axis, Index batch_ndim)
 {
-    std::vector<Index> out;
-    out.reserve(batch_ndim + 1);
-    out.push_back(tensor_shape[axis]);
-    for (Index i = 0; i < batch_ndim; ++i)
-    {
-        out.push_back(tensor_shape[tensor_shape.size() - batch_ndim + i]);
-    }
-    return out;
+    return nntile::tensor::graph_fiber_shape(tensor_shape, axis, batch_ndim);
 }
 
 TEST_CASE("TensorGraph add_fiber_inplace structure", "[graph][tensor]")

--- a/nntile/tests/tensor/ops/mask_scalar.cc
+++ b/nntile/tests/tensor/ops/mask_scalar.cc
@@ -110,11 +110,11 @@ TEST_CASE_METHOD(nntile::test::ContextFixture,
     const auto [A_shape, batch_ndim] =
         GENERATE(std::make_pair(std::vector<Index>{6, 4}, Index(0)),
             std::make_pair(std::vector<Index>{6}, Index(0)),
-            std::make_pair(std::vector<Index>{4, 2}, Index(0)));
+            std::make_pair(std::vector<Index>{4, 2}, Index(0)),
+            std::make_pair(std::vector<Index>{2, 6, 4}, Index(1)));
 
-    const Index A_data_ndim = static_cast<Index>(A_shape.size()) - batch_ndim;
     std::vector<Index> mask_shape(
-        A_shape.begin(), A_shape.begin() + A_data_ndim);
+        A_shape.begin() + static_cast<ptrdiff_t>(batch_ndim), A_shape.end());
     const Index mask_nelems = std::accumulate(
         mask_shape.begin(), mask_shape.end(), Index(1), std::multiplies<>());
     const Index A_nelems = std::accumulate(

--- a/nntile/tests/tensor/ops/norm_fiber.cc
+++ b/nntile/tests/tensor/ops/norm_fiber.cc
@@ -16,7 +16,7 @@
 
 #include "context_fixture.hh"
 #include "nntile/tensor.hh"
-#include "nntile/tensor/axis_descriptor.hh"
+#include "nntile/tensor/shape_layout.hh"
 #include "nntile/tile.hh"
 #include "nntile/tensor/ops/norm_fiber.hh"
 #include "nntile/tensor.hh"
@@ -55,18 +55,10 @@ constexpr Index dim_6 = 6;
 
 } // anonymous namespace
 
-//! Output shape for norm_fiber: {x_shape[axis]} for batch_ndim=0
 static std::vector<Index> norm_fiber_output_shape(
     const std::vector<Index> &x_shape, Index axis, Index batch_ndim)
 {
-    std::vector<Index> out_shape;
-    out_shape.reserve(batch_ndim + 1);
-    out_shape.push_back(x_shape[axis]);
-    for (Index i = 0; i < batch_ndim; ++i)
-    {
-        out_shape.push_back(x_shape[x_shape.size() - batch_ndim + i]);
-    }
-    return out_shape;
+    return nntile::tensor::graph_fiber_shape(x_shape, axis, batch_ndim);
 }
 
 TEST_CASE("TensorGraph norm_fiber structure", "[graph][tensor]")

--- a/nntile/tests/tensor/ops/norm_fiber_inplace.cc
+++ b/nntile/tests/tensor/ops/norm_fiber_inplace.cc
@@ -16,7 +16,7 @@
 
 #include "context_fixture.hh"
 #include "nntile/tensor.hh"
-#include "nntile/tensor/axis_descriptor.hh"
+#include "nntile/tensor/shape_layout.hh"
 #include "nntile/tile.hh"
 #include "nntile/tensor/ops/norm_fiber_inplace.hh"
 #include "nntile/tensor.hh"
@@ -54,18 +54,10 @@ constexpr Index dim_6 = 6;
 
 } // anonymous namespace
 
-//! Fiber shape: {tensor_shape[axis]} for batch_ndim=0
 static std::vector<Index> fiber_shape(
     const std::vector<Index> &tensor_shape, Index axis, Index batch_ndim)
 {
-    std::vector<Index> out;
-    out.reserve(batch_ndim + 1);
-    out.push_back(tensor_shape[axis]);
-    for (Index i = 0; i < batch_ndim; ++i)
-    {
-        out.push_back(tensor_shape[tensor_shape.size() - batch_ndim + i]);
-    }
-    return out;
+    return nntile::tensor::graph_fiber_shape(tensor_shape, axis, batch_ndim);
 }
 
 TEST_CASE("TensorGraph norm_fiber_inplace structure", "[graph][tensor]")

--- a/nntile/tests/tensor/ops/scale_fiber.cc
+++ b/nntile/tests/tensor/ops/scale_fiber.cc
@@ -16,7 +16,7 @@
 
 #include "context_fixture.hh"
 #include "nntile/tensor.hh"
-#include "nntile/tensor/axis_descriptor.hh"
+#include "nntile/tensor/shape_layout.hh"
 #include "nntile/tile.hh"
 #include "nntile/tensor/ops/scale_fiber.hh"
 #include "nntile/tensor.hh"
@@ -46,18 +46,10 @@ constexpr Index dim_5 = 5;
 
 } // anonymous namespace
 
-//! Fiber shape: {dst_shape[axis]} for batch_ndim=0
 static std::vector<Index> fiber_shape(
     const std::vector<Index> &dst_shape, Index axis, Index batch_ndim)
 {
-    std::vector<Index> out;
-    out.reserve(batch_ndim + 1);
-    out.push_back(dst_shape[axis]);
-    for (Index i = 0; i < batch_ndim; ++i)
-    {
-        out.push_back(dst_shape[dst_shape.size() - batch_ndim + i]);
-    }
-    return out;
+    return nntile::tensor::graph_fiber_shape(dst_shape, axis, batch_ndim);
 }
 
 TEST_CASE("TensorGraph scale_fiber structure", "[graph][tensor]")

--- a/nntile/tests/tensor/ops/sum_fiber.cc
+++ b/nntile/tests/tensor/ops/sum_fiber.cc
@@ -16,7 +16,7 @@
 
 #include "context_fixture.hh"
 #include "nntile/tensor.hh"
-#include "nntile/tensor/axis_descriptor.hh"
+#include "nntile/tensor/shape_layout.hh"
 #include "nntile/tile.hh"
 #include "nntile/tensor/ops/sum_fiber.hh"
 #include "nntile/tensor.hh"
@@ -55,19 +55,10 @@ constexpr Index dim_6 = 6;
 
 } // anonymous namespace
 
-//! Compute output shape for sum_fiber: y has shape {x_shape[axis]} for
-//! batch_ndim=0
 static std::vector<Index> sum_fiber_output_shape(
     const std::vector<Index> &x_shape, Index axis, Index batch_ndim)
 {
-    std::vector<Index> out_shape;
-    out_shape.reserve(batch_ndim + 1);
-    out_shape.push_back(x_shape[axis]);
-    for (Index i = 0; i < batch_ndim; ++i)
-    {
-        out_shape.push_back(x_shape[x_shape.size() - batch_ndim + i]);
-    }
-    return out_shape;
+    return nntile::tensor::graph_fiber_shape(x_shape, axis, batch_ndim);
 }
 
 TEST_CASE("TensorGraph sum_fiber structure", "[graph][tensor]")

--- a/nntile/tests/tile/ops/adam_step.cc
+++ b/nntile/tests/tile/ops/adam_step.cc
@@ -13,6 +13,7 @@
  * */
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "mixed_tile_common.hh"
 
 #include <catch2/catch_test_macros.hpp>

--- a/nntile/tests/tile/ops/adamw_step.cc
+++ b/nntile/tests/tile/ops/adamw_step.cc
@@ -13,6 +13,7 @@
  * */
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "mixed_tile_common.hh"
 
 #include <catch2/catch_test_macros.hpp>

--- a/nntile/tests/tile/ops/add.cc
+++ b/nntile/tests/tile/ops/add.cc
@@ -15,6 +15,7 @@
 #include "nntile/tile/ops/add.hh"
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/add.hh"
@@ -27,6 +28,7 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 
 //! Run add via TileGraph (compile + execute) and via tile API, compare
 template <typename T>

--- a/nntile/tests/tile/ops/add_fiber.cc
+++ b/nntile/tests/tile/ops/add_fiber.cc
@@ -153,6 +153,6 @@ TEST_CASE_METHOD(nntile::test::ContextFixture,
     }
     for(size_t i = 0; i < tref.size(); ++i)
     {
-        REQUIRE(std::abs(gout[i] - tref[i]) < 1e-3f);
+        REQUIRE(std::abs(gout[i] - tref[i]) < 1e-6f);
     }
 }

--- a/nntile/tests/tile/ops/add_fiber.cc
+++ b/nntile/tests/tile/ops/add_fiber.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/add_fiber.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,23 +24,27 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_fiber matches tile", "[graph][tile]")
 {
-    const std::vector<Index> full = {3, 4, 5};
-    const std::vector<Index> fib = {5};
+    const std::vector<Index> stor_full = {3, 4, 5};
+    const std::vector<Index> graph_full = graph_shape(stor_full);
+    const std::vector<Index> stor_fib = {5};
+    const std::vector<Index> graph_fib = graph_shape(stor_fib);
     const Index nfull = 3 * 4 * 5;
     const Index nfib = 5;
-    const Index axis = 2;
+    const Index stor_axis = 2;
+    const Index g_axis = graph_axis(stor_axis, static_cast<Index>(stor_full.size()));
     const Index batch = 0;
     const Scalar alpha = 1.0, beta = 1.0;
     TileGraph g("g");
-    auto* s1 = g.data(fib, "s1", DataType::FP32);
-    auto* s2 = g.data(full, "s2", DataType::FP32);
-    auto* d = g.data(full, "d", DataType::FP32);
+    auto* s1 = g.data(graph_fib, "s1", DataType::FP32);
+    auto* s2 = g.data(graph_full, "s2", DataType::FP32);
+    auto* d = g.data(graph_full, "d", DataType::FP32);
     s1->mark_input(true);
     s2->mark_input(true);
     d->mark_output(true);
-    tg::add_fiber(alpha, s1, beta, s2, d, axis, batch);
+    tg::add_fiber(alpha, s1, beta, s2, d, g_axis, batch);
     Runtime runtime(g);
     runtime.compile();
     std::vector<float> f1(nfib), f2(nfull), f3(nfull, 0.f);
@@ -51,7 +56,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_fiber matches tile
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> t1(fib), t2(full), dst(full);
+    nntile::core::Tile<fp32_t> t1(stor_fib), t2(stor_full), dst(stor_full);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto a = t1.acquire(STARPU_W);
@@ -67,7 +72,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_fiber matches tile
         b.release();
         c.release();
     }
-    nntile::core::add_fiber<fp32_t>(-1, alpha, t1, beta, t2, dst, axis, batch);
+    nntile::core::add_fiber<fp32_t>(-1, alpha, t1, beta, t2, dst, stor_axis, batch);
     starpu_task_wait_for_all();
     std::vector<float> tref(nfull);
     {

--- a/nntile/tests/tile/ops/add_fiber.cc
+++ b/nntile/tests/tile/ops/add_fiber.cc
@@ -83,3 +83,76 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_fiber matches tile
     constexpr float tol = 1e-3f;
     for(size_t i = 0; i < tref.size(); ++i) { REQUIRE(std::abs(gout[i] - tref[i]) < tol); }
 }
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "TileGraph add_fiber batch_ndim=1",
+    "[graph][tile]")
+{
+    const std::vector<Index> stor_full = {4, 3, 2};
+    const std::vector<Index> graph_full = graph_shape(stor_full);
+    const std::vector<Index> stor_fib = {3, 2};
+    const std::vector<Index> graph_fib = graph_shape(stor_fib);
+    const Index nfull = 4 * 3 * 2;
+    const Index nfib = 3 * 2;
+    const Index stor_axis = 1;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_full.size()));
+    const Index batch = 1;
+    const Scalar alpha = 1.0, beta = 1.0;
+    TileGraph g("g");
+    auto* s1 = g.data(graph_fib, "s1", DataType::FP32);
+    auto* s2 = g.data(graph_full, "s2", DataType::FP32);
+    auto* d = g.data(graph_full, "d", DataType::FP32);
+    s1->mark_input(true);
+    s2->mark_input(true);
+    d->mark_output(true);
+    tg::add_fiber(alpha, s1, beta, s2, d, g_axis, batch);
+    Runtime runtime(g);
+    runtime.compile();
+    std::vector<float> f1(nfib), f2(nfull), f3(nfull, 0.f);
+    for(Index i = 0; i < nfib; ++i)
+    {
+        f1[static_cast<size_t>(i)] = 0.2f * static_cast<float>(i + 1);
+    }
+    for(Index i = 0; i < nfull; ++i)
+    {
+        f2[static_cast<size_t>(i)] = 0.1f * static_cast<float>(i + 1);
+    }
+    runtime.bind_data(s1, f1);
+    runtime.bind_data(s2, f2);
+    runtime.bind_data(d, f3);
+    runtime.execute();
+    runtime.wait();
+    const std::vector<float> gout = runtime.get_output<float>(d);
+    nntile::core::Tile<fp32_t> t1(stor_fib), t2(stor_full), dst(stor_full);
+    using Y = typename nntile::fp32_t::repr_t;
+    {
+        auto a = t1.acquire(STARPU_W);
+        auto b = t2.acquire(STARPU_W);
+        auto c = dst.acquire(STARPU_W);
+        for(Index i = 0; i < nfib; ++i) { a[i] = Y(f1[static_cast<size_t>(i)]); }
+        for(Index i = 0; i < nfull; ++i)
+        {
+            b[i] = Y(f2[static_cast<size_t>(i)]);
+            c[i] = Y(0);
+        }
+        a.release();
+        b.release();
+        c.release();
+    }
+    nntile::core::add_fiber<fp32_t>(-1, alpha, t1, beta, t2, dst, stor_axis, batch);
+    starpu_task_wait_for_all();
+    std::vector<float> tref(nfull);
+    {
+        auto l2 = dst.acquire(STARPU_R);
+        for(Index i = 0; i < nfull; ++i)
+        {
+            tref[static_cast<size_t>(i)] = static_cast<float>(l2[i]);
+        }
+        l2.release();
+    }
+    for(size_t i = 0; i < tref.size(); ++i)
+    {
+        REQUIRE(std::abs(gout[i] - tref[i]) < 1e-3f);
+    }
+}

--- a/nntile/tests/tile/ops/add_fiber_inplace.cc
+++ b/nntile/tests/tile/ops/add_fiber_inplace.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/add_fiber_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,20 +24,24 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_fiber_inplace", "[graph][tile]")
 {
-    const std::vector<Index> full = {3, 4, 5};
-    const std::vector<Index> fib = {5};
+    const std::vector<Index> stor_full = {3, 4, 5};
+    const std::vector<Index> graph_full = graph_shape(stor_full);
+    const std::vector<Index> stor_fib = {5};
+    const std::vector<Index> graph_fib = graph_shape(stor_fib);
     const Index n = 3 * 4 * 5, nf = 5;
     const Scalar a = 1.0, b = 0.5;
-    const Index axis = 2, batch = 0;
+    const Index stor_axis = 2, batch = 0;
+    const Index g_axis = graph_axis(stor_axis, static_cast<Index>(stor_full.size()));
     TileGraph g("g");
-    auto* s = g.data(fib, "s", DataType::FP32);
-    auto* d = g.data(full, "d", DataType::FP32);
+    auto* s = g.data(graph_fib, "s", DataType::FP32);
+    auto* d = g.data(graph_full, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_input(true);
     d->mark_output(true);
-    tg::add_fiber_inplace(a, s, b, d, axis, batch);
+    tg::add_fiber_inplace(a, s, b, d, g_axis, batch);
     Runtime runtime(g);
     runtime.compile();
     std::vector<float> f1(nf), f2(n);
@@ -47,7 +52,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_fiber_inplace", "[
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(fib), td(full);
+    nntile::core::Tile<fp32_t> ts(stor_fib), td(stor_full);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto A = ts.acquire(STARPU_W);
@@ -57,7 +62,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_fiber_inplace", "[
         A.release();
         B.release();
     }
-    nntile::core::add_fiber_inplace<fp32_t>(-1, a, ts, b, td, axis, batch);
+    nntile::core::add_fiber_inplace<fp32_t>(-1, a, ts, b, td, stor_axis, batch);
     starpu_task_wait_for_all();
     std::vector<float> tref(n);
     {

--- a/nntile/tests/tile/ops/add_inplace.cc
+++ b/nntile/tests/tile/ops/add_inplace.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/add_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,14 +24,16 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_inplace matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     const Scalar alpha = 2.0, beta = 1.0;
     TileGraph g("g");
-    auto* x = g.data(sh, "x", DataType::FP32);
-    auto* y = g.data(sh, "y", DataType::FP32);
+    auto* x = g.data(graph_sh, "x", DataType::FP32);
+    auto* y = g.data(graph_sh, "y", DataType::FP32);
     x->mark_input(true);
     y->mark_input(true);
     y->mark_output(true);
@@ -48,7 +51,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_inplace matches ti
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(y);
-    nntile::core::Tile<fp32_t> tx(sh), ty(sh);
+    nntile::core::Tile<fp32_t> tx(stor_sh), ty(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto a = tx.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/add_slice.cc
+++ b/nntile/tests/tile/ops/add_slice.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/add_slice.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,20 +24,28 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_slice", "[graph][tile]")
 {
-    const std::vector<Index> t1s = {4, 5}, t2s = {3, 4, 5}, ds = {3, 4, 5};
+    const std::vector<Index> stor_t1s = {4, 5};
+    const std::vector<Index> graph_t1s = graph_shape(stor_t1s);
+    const std::vector<Index> stor_t2s = {3, 4, 5};
+    const std::vector<Index> graph_t2s = graph_shape(stor_t2s);
+    const std::vector<Index> stor_ds = {3, 4, 5};
+    const std::vector<Index> graph_ds = graph_shape(stor_ds);
     const Index n1 = 20, n2 = 60;
     const Scalar a = 0.5, b = 0.5;
-    const Index axis = 0;
+    const Index stor_axis = 0;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_t2s.size()));
     TileGraph g("g");
-    auto* t1 = g.data(t1s, "t1", DataType::FP32);
-    auto* t2 = g.data(t2s, "t2", DataType::FP32);
-    auto* d = g.data(ds, "d", DataType::FP32);
+    auto* t1 = g.data(graph_t1s, "t1", DataType::FP32);
+    auto* t2 = g.data(graph_t2s, "t2", DataType::FP32);
+    auto* d = g.data(graph_ds, "d", DataType::FP32);
     t1->mark_input(true);
     t2->mark_input(true);
     d->mark_output(true);
-    tg::add_slice(a, t1, b, t2, d, axis);
+    tg::add_slice(a, t1, b, t2, d, g_axis);
     Runtime rt(g);
     rt.compile();
     std::vector<float> v1(n1), v2(n2);
@@ -49,13 +58,13 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_slice", "[graph][t
     rt.execute();
     rt.wait();
     const std::vector<float> gout = rt.get_output<float>(d);
-    nntile::core::Tile<fp32_t> T1(t1s), T2(t2s), D(ds);
+    nntile::core::Tile<fp32_t> T1(stor_t1s), T2(stor_t2s), D(stor_ds);
     using Y = typename nntile::fp32_t::repr_t;
     { auto A = T1.acquire(STARPU_W), B = T2.acquire(STARPU_W), C = D.acquire(STARPU_W);
       for(Index i = 0; i < n1; ++i) A[i] = Y(v1[static_cast<size_t>(i)]);
       for(Index i = 0; i < n2; ++i) { B[i] = Y(v2[static_cast<size_t>(i)]); C[i] = Y(0); }
       A.release(); B.release(); C.release(); }
-    nntile::core::add_slice<fp32_t>(-1, a, T1, b, T2, D, axis);
+    nntile::core::add_slice<fp32_t>(-1, a, T1, b, T2, D, stor_axis);
     starpu_task_wait_for_all();
     std::vector<float> tref(60);
     { auto L = D.acquire(STARPU_R);

--- a/nntile/tests/tile/ops/add_slice_inplace.cc
+++ b/nntile/tests/tile/ops/add_slice_inplace.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/add_slice_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,19 +24,25 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_slice_inplace", "[graph][tile]")
 {
-    const std::vector<Index> t1s = {3, 5}, t2s = {3, 4, 5};
+    const std::vector<Index> stor_t1s = {3, 5};
+    const std::vector<Index> graph_t1s = graph_shape(stor_t1s);
+    const std::vector<Index> stor_t2s = {3, 4, 5};
+    const std::vector<Index> graph_t2s = graph_shape(stor_t2s);
     const Index n1 = 15, n2 = 60;
     const Scalar a = 1.0, b = 1.0;
-    const Index axis = 1;
+    const Index stor_axis = 1;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_t2s.size()));
     TileGraph g("g");
-    auto* t1 = g.data(t1s, "t1", DataType::FP32);
-    auto* t2 = g.data(t2s, "t2", DataType::FP32);
+    auto* t1 = g.data(graph_t1s, "t1", DataType::FP32);
+    auto* t2 = g.data(graph_t2s, "t2", DataType::FP32);
     t1->mark_input(true);
     t2->mark_input(true);
     t2->mark_output(true);
-    tg::add_slice_inplace(a, t1, b, t2, axis);
+    tg::add_slice_inplace(a, t1, b, t2, g_axis);
     Runtime rt(g);
     rt.compile();
     std::vector<float> v1(n1), v2(n2);
@@ -46,13 +53,13 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph add_slice_inplace", "[
     rt.execute();
     rt.wait();
     const std::vector<float> gout = rt.get_output<float>(t2);
-    nntile::core::Tile<fp32_t> T1(t1s), T2(t2s);
+    nntile::core::Tile<fp32_t> T1(stor_t1s), T2(stor_t2s);
     using Y = typename nntile::fp32_t::repr_t;
     { auto A = T1.acquire(STARPU_W), B = T2.acquire(STARPU_W);
       for(Index i = 0; i < n1; ++i) A[i] = Y(v1[static_cast<size_t>(i)]);
       for(Index i = 0; i < n2; ++i) B[i] = Y(0.1f * static_cast<float>(i + 1));
       A.release(); B.release(); }
-    nntile::core::add_slice_inplace<fp32_t>(-1, a, T1, b, T2, axis);
+    nntile::core::add_slice_inplace<fp32_t>(-1, a, T1, b, T2, stor_axis);
     starpu_task_wait_for_all();
     std::vector<float> tref(60);
     { auto L = T2.acquire(STARPU_R);

--- a/nntile/tests/tile/ops/clear.cc
+++ b/nntile/tests/tile/ops/clear.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/clear.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,12 +24,14 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph clear matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* x = g.data(sh, "x", DataType::FP32);
+    auto* x = g.data(graph_sh, "x", DataType::FP32);
     x->mark_input(true);
     x->mark_output(true);
     tg::clear(x);
@@ -40,7 +43,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph clear matches tile", "
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(x);
-    nntile::core::Tile<fp32_t> tx(sh);
+    nntile::core::Tile<fp32_t> tx(stor_sh);
     {
         using Y = typename nntile::fp32_t::repr_t;
         auto l1 = tx.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/conv2d_bwd_input_inplace.cc
+++ b/nntile/tests/tile/ops/conv2d_bwd_input_inplace.cc
@@ -14,12 +14,14 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/conv2d_bwd_input_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/conv2d_bwd_input_inplace.hh"
 #include "nntile/core/tile.hh"
 using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph conv2d_bwd_input_inplace", "[graph][tile]")
 {
     const std::vector<Index> dYh={2,2,1,1}, Ch={2,2,1,1}, dXh={3,3,1,1};

--- a/nntile/tests/tile/ops/conv2d_bwd_input_inplace.cc
+++ b/nntile/tests/tile/ops/conv2d_bwd_input_inplace.cc
@@ -52,5 +52,5 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph conv2d_bwd_input_inpla
     { auto L=DX.acquire(STARPU_R);
       for(Index i=0;i<9;++i) tr[static_cast<size_t>(i)]=static_cast<float>(L[i]);
       L.release(); }
-    for(Index i=0;i<9;++i) REQUIRE(std::abs(gout[static_cast<size_t>(i)]-tr[static_cast<size_t>(i)])<1e+2f);
+    for(Index i=0;i<9;++i) REQUIRE(std::abs(gout[static_cast<size_t>(i)]-tr[static_cast<size_t>(i)])<1e-6f);
 }

--- a/nntile/tests/tile/ops/conv2d_bwd_weight_inplace.cc
+++ b/nntile/tests/tile/ops/conv2d_bwd_weight_inplace.cc
@@ -14,12 +14,14 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/conv2d_bwd_weight_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/conv2d_bwd_weight_inplace.hh"
 #include "nntile/core/tile.hh"
 using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph conv2d_bwd_weight_inplace", "[graph][tile]")
 {
     const std::vector<Index> xh={3,3,1,1}, dyh={2,2,1,1}, dch={2,2,1,1};

--- a/nntile/tests/tile/ops/conv2d_bwd_weight_inplace.cc
+++ b/nntile/tests/tile/ops/conv2d_bwd_weight_inplace.cc
@@ -52,5 +52,5 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph conv2d_bwd_weight_inpl
     { auto L=DC.acquire(STARPU_R);
       for(Index i=0;i<4;++i) tr[static_cast<size_t>(i)]=static_cast<float>(L[i]);
       L.release(); }
-    for(Index i=0;i<4;++i) REQUIRE(std::abs(gout[static_cast<size_t>(i)]-tr[static_cast<size_t>(i)])<1e+2f);
+    for(Index i=0;i<4;++i) REQUIRE(std::abs(gout[static_cast<size_t>(i)]-tr[static_cast<size_t>(i)])<1e-6f);
 }

--- a/nntile/tests/tile/ops/conv2d_inplace.cc
+++ b/nntile/tests/tile/ops/conv2d_inplace.cc
@@ -14,12 +14,14 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/conv2d_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/conv2d_inplace.hh"
 #include "nntile/core/tile.hh"
 using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph conv2d_inplace", "[graph][tile]")
 {
     const std::vector<Index> xh={3,3,1,1}, ch={2,2,1,1}, yh={2,2,1,1};

--- a/nntile/tests/tile/ops/conv2d_inplace.cc
+++ b/nntile/tests/tile/ops/conv2d_inplace.cc
@@ -53,5 +53,5 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph conv2d_inplace", "[gra
     { auto L=TY.acquire(STARPU_R);
       for(Index i=0;i<4;++i) tr[static_cast<size_t>(i)]=static_cast<float>(L[i]);
       L.release(); }
-    for(Index i=0;i<4;++i) REQUIRE(std::abs(gout[static_cast<size_t>(i)]-tr[static_cast<size_t>(i)])<1e+2f);
+    for(Index i=0;i<4;++i) REQUIRE(std::abs(gout[static_cast<size_t>(i)]-tr[static_cast<size_t>(i)])<1e-6f);
 }

--- a/nntile/tests/tile/ops/copy.cc
+++ b/nntile/tests/tile/ops/copy.cc
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <numeric>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/copy.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -24,13 +25,15 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph copy matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
     tg::copy(s, d);
@@ -44,7 +47,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph copy matches tile", "[
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh), td(sh);
+    nntile::core::Tile<fp32_t> ts(stor_sh), td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = ts.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/copy_intersection.cc
+++ b/nntile/tests/tile/ops/copy_intersection.cc
@@ -14,21 +14,25 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/copy_intersection.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/copy_intersection.hh"
 #include "nntile/core/tile.hh"
 using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph copy_intersection", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2,2,3};
-    const std::vector<Index> sc = {6};
+    const std::vector<Index> stor_sh = {2,2,3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
+    const std::vector<Index> stor_sc = {6};
+    const std::vector<Index> graph_sc = graph_shape(stor_sc);
     const Index n = 12;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(sh, "d", DataType::FP32);
-    auto* scra = g.data(sc, "scratch", DataType::INT64);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
+    auto* scra = g.data(graph_sc, "scratch", DataType::INT64);
     s->mark_input(true);
     d->mark_input(true);
     d->mark_output(true);
@@ -45,8 +49,8 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph copy_intersection", "[
     r.execute();
     r.wait();
     const auto gout = r.get_output<float>(d);
-    nntile::core::Tile<fp32_t> S(sh), D(sh);
-    nntile::core::Tile<nntile::int64_t> Sc(sc);
+    nntile::core::Tile<fp32_t> S(stor_sh), D(stor_sh);
+    nntile::core::Tile<nntile::int64_t> Sc(stor_sc);
     using Y = typename fp32_t::repr_t;
     { auto a=S.acquire(STARPU_W), b=D.acquire(STARPU_W);
       for(Index i=0;i<n;++i) { a[i]=Y(sv[static_cast<size_t>(i)]); b[i]=Y(0);} a.release(); b.release(); }

--- a/nntile/tests/tile/ops/embedding.cc
+++ b/nntile/tests/tile/ops/embedding.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/embedding.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -24,6 +25,7 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph embedding", "[graph][tile]")
 {

--- a/nntile/tests/tile/ops/embedding_backward.cc
+++ b/nntile/tests/tile/ops/embedding_backward.cc
@@ -60,5 +60,5 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph embedding_backward", "
     { auto L=Vg.acquire(STARPU_R);
       for(int j=0;j<15;++j) tr[static_cast<size_t>(j)]=static_cast<float>(L[j]);
       L.release(); }
-    for(int j=0;j<15;++j) REQUIRE(std::abs(gout[static_cast<size_t>(j)]-tr[static_cast<size_t>(j)])<1e+2f);
+    for(int j=0;j<15;++j) REQUIRE(std::abs(gout[static_cast<size_t>(j)]-tr[static_cast<size_t>(j)])<1e-6f);
 }

--- a/nntile/tests/tile/ops/embedding_backward.cc
+++ b/nntile/tests/tile/ops/embedding_backward.cc
@@ -14,12 +14,14 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/embedding_backward.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/embedding_backward.hh"
 #include "nntile/core/tile.hh"
 using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph embedding_backward", "[graph][tile]")
 {
     const Index m=2,n=2,k=3,k0=0,ks=3; const int redux=0;

--- a/nntile/tests/tile/ops/fill.cc
+++ b/nntile/tests/tile/ops/fill.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/fill.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,13 +24,15 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph fill matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     const Scalar v = 3.25;
     TileGraph g("g");
-    auto* x = g.data(sh, "x", DataType::FP32);
+    auto* x = g.data(graph_sh, "x", DataType::FP32);
     x->mark_input(true);
     x->mark_output(true);
     tg::fill(v, x);
@@ -40,7 +43,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph fill matches tile", "[
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(x);
-    nntile::core::Tile<fp32_t> tx(sh);
+    nntile::core::Tile<fp32_t> tx(stor_sh);
     nntile::core::fill<fp32_t>(-1, v, tx);
     starpu_task_wait_for_all();
     std::vector<float> tref(nelems);

--- a/nntile/tests/tile/ops/flash_sdpa_bwd_cudnn.cc
+++ b/nntile/tests/tile/ops/flash_sdpa_bwd_cudnn.cc
@@ -16,12 +16,14 @@
 #ifdef NNTILE_USE_CUDA
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/flash_sdpa_bwd_cudnn.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE("TileGraph flash_sdpa_bwd_cudnn structure", "[graph][tile][cuda]")
 {
     nntile::test::CudaContextFixture fx;

--- a/nntile/tests/tile/ops/flash_sdpa_fwd_cudnn.cc
+++ b/nntile/tests/tile/ops/flash_sdpa_fwd_cudnn.cc
@@ -17,12 +17,14 @@
 #include <catch2/catch_test_macros.hpp>
 #include <numeric>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/flash_sdpa_fwd_cudnn.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE("TileGraph flash_sdpa_fwd_cudnn structure", "[graph][tile][cuda]")
 {
     nntile::test::CudaContextFixture fx;

--- a/nntile/tests/tile/ops/gelu.cc
+++ b/nntile/tests/tile/ops/gelu.cc
@@ -13,6 +13,7 @@
  * */
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "mixed_tile_common.hh"
 
 #include <catch2/catch_test_macros.hpp>

--- a/nntile/tests/tile/ops/gelu_backward.cc
+++ b/nntile/tests/tile/ops/gelu_backward.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/gelu_backward.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,14 +24,16 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gelu_backward matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* x = g.data(sh, "x", DataType::FP32);
-    auto* dy = g.data(sh, "dy", DataType::FP32);
-    auto* dx = g.data(sh, "dx", DataType::FP32);
+    auto* x = g.data(graph_sh, "x", DataType::FP32);
+    auto* dy = g.data(graph_sh, "dy", DataType::FP32);
+    auto* dx = g.data(graph_sh, "dx", DataType::FP32);
     x->mark_input(true);
     dy->mark_input(true);
     dx->mark_input(true);
@@ -50,7 +53,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gelu_backward matches 
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(dx);
-    nntile::core::Tile<fp32_t> tx(sh), tdy(sh), tdx(sh);
+    nntile::core::Tile<fp32_t> tx(stor_sh), tdy(stor_sh), tdx(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = tx.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/gelu_inplace.cc
+++ b/nntile/tests/tile/ops/gelu_inplace.cc
@@ -13,6 +13,7 @@
  * */
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "mixed_tile_common.hh"
 
 #include <catch2/catch_test_macros.hpp>

--- a/nntile/tests/tile/ops/gelutanh.cc
+++ b/nntile/tests/tile/ops/gelutanh.cc
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <numeric>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/gelutanh.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -24,13 +25,15 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gelutanh matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
     tg::gelutanh(s, d);
@@ -44,7 +47,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gelutanh matches tile"
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh), td(sh);
+    nntile::core::Tile<fp32_t> ts(stor_sh), td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = ts.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/gelutanh_backward.cc
+++ b/nntile/tests/tile/ops/gelutanh_backward.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/gelutanh_backward.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,14 +24,16 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gelutanh_backward matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* x = g.data(sh, "x", DataType::FP32);
-    auto* dy = g.data(sh, "dy", DataType::FP32);
-    auto* dx = g.data(sh, "dx", DataType::FP32);
+    auto* x = g.data(graph_sh, "x", DataType::FP32);
+    auto* dy = g.data(graph_sh, "dy", DataType::FP32);
+    auto* dx = g.data(graph_sh, "dx", DataType::FP32);
     x->mark_input(true);
     dy->mark_input(true);
     dx->mark_input(true);
@@ -50,7 +53,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gelutanh_backward matc
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(dx);
-    nntile::core::Tile<fp32_t> tx(sh), tdy(sh), tdx(sh);
+    nntile::core::Tile<fp32_t> tx(stor_sh), tdy(stor_sh), tdx(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = tx.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/gelutanh_inplace.cc
+++ b/nntile/tests/tile/ops/gelutanh_inplace.cc
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <numeric>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/gelutanh_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -24,12 +25,14 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gelutanh_inplace matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     d->mark_input(true);
     d->mark_output(true);
     tg::gelutanh_inplace(d);
@@ -41,7 +44,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gelutanh_inplace match
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> td(sh);
+    nntile::core::Tile<fp32_t> td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = td.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/gemm.cc
+++ b/nntile/tests/tile/ops/gemm.cc
@@ -76,7 +76,9 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gemm matches tile", "[
         l3.release();
     }
     const TransOp opN(TransOp::NoTrans);
-    nntile::core::gemm<fp32_t>(-1, alpha, opN, ta, opN, tb, beta, tc, ndim, batch_ndim, 0);
+    // Tile execute swaps operands/transposes for Fortran storage.
+    nntile::core::gemm<fp32_t>(
+        -1, alpha, opN, tb, opN, ta, beta, tc, ndim, batch_ndim, 0);
     starpu_task_wait_for_all();
     std::vector<float> tref(nelems);
     {
@@ -86,4 +88,150 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gemm matches tile", "[
     }
     constexpr float tol = 1e-3f;
     for(size_t i = 0; i < tref.size(); ++i) { REQUIRE(std::abs(gout[i] - tref[i]) < tol); }
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "TileGraph gemm asymmetric shapes and batch_ndim",
+    "[graph][tile]")
+{
+  // Graph GEMM (ndim=1): A {N,K}, B {K,M}, C {N,M}.
+    const std::vector<Index> graph_a = {5, 4};
+    const std::vector<Index> stor_a = storage_shape(graph_a);
+    const std::vector<Index> graph_b = {4, 3};
+    const std::vector<Index> stor_b = storage_shape(graph_b);
+    const std::vector<Index> graph_c = {5, 3};
+    const std::vector<Index> stor_c = storage_shape(graph_c);
+    const Index na = 20, nb = 12, nc = 15;
+    const Scalar alpha = 1.0, beta = 0.0;
+    const bool trans_a = false, trans_b = false;
+    const Index ndim = 1, batch_ndim = 0;
+
+    TileGraph g("g");
+    auto* a = g.data(graph_a, "a", DataType::FP32);
+    auto* b = g.data(graph_b, "b", DataType::FP32);
+    auto* c = g.data(graph_c, "c", DataType::FP32);
+    a->mark_input(true);
+    b->mark_input(true);
+    c->mark_input(true);
+    c->mark_output(true);
+    tg::gemm(a, b, c, alpha, beta, trans_a, trans_b, ndim, batch_ndim);
+    Runtime runtime(g);
+    runtime.compile();
+
+    std::vector<float> av(na), bv(nb), cv(nc, 0.f);
+    for(Index i = 0; i < na; ++i)
+    {
+        av[static_cast<size_t>(i)] = 0.03f * static_cast<float>(i + 1);
+    }
+    for(Index i = 0; i < nb; ++i)
+    {
+        bv[static_cast<size_t>(i)] = 0.02f * static_cast<float>(i + 1);
+    }
+    runtime.bind_data(a, av);
+    runtime.bind_data(b, bv);
+    runtime.bind_data(c, cv);
+    runtime.execute();
+    runtime.wait();
+    const std::vector<float> gout = runtime.get_output<float>(c);
+
+    nntile::core::Tile<fp32_t> ta(stor_a), tb(stor_b), tc(stor_c);
+    using Y = typename nntile::fp32_t::repr_t;
+    {
+        auto la = ta.acquire(STARPU_W);
+        auto lb = tb.acquire(STARPU_W);
+        auto lc = tc.acquire(STARPU_W);
+        for(Index i = 0; i < na; ++i) { la[i] = Y(av[static_cast<size_t>(i)]); }
+        for(Index i = 0; i < nb; ++i) { lb[i] = Y(bv[static_cast<size_t>(i)]); }
+        for(Index i = 0; i < nc; ++i) { lc[i] = Y(0); }
+        la.release();
+        lb.release();
+        lc.release();
+    }
+    const TransOp opN(TransOp::NoTrans);
+    nntile::core::gemm<fp32_t>(
+        -1, alpha, opN, tb, opN, ta, beta, tc, ndim, batch_ndim, 0);
+    starpu_task_wait_for_all();
+
+    std::vector<float> tref(nc);
+    {
+        auto lc = tc.acquire(STARPU_R);
+        for(Index i = 0; i < nc; ++i)
+        {
+            tref[static_cast<size_t>(i)] = static_cast<float>(lc[i]);
+        }
+        lc.release();
+    }
+    constexpr float tol = 1e-3f;
+    for(size_t i = 0; i < tref.size(); ++i)
+    {
+        REQUIRE(std::abs(gout[i] - tref[i]) < tol);
+    }
+
+    // Batched graph GEMM (batch_ndim=1): {B,N,K} @ {B,K,M} -> {B,N,M}.
+    const std::vector<Index> graph_ba = {2, 5, 4};
+    const std::vector<Index> stor_ba = storage_shape(graph_ba);
+    const std::vector<Index> graph_bb = {2, 4, 3};
+    const std::vector<Index> stor_bb = storage_shape(graph_bb);
+    const std::vector<Index> graph_bc = {2, 5, 3};
+    const std::vector<Index> stor_bc = storage_shape(graph_bc);
+    const Index nba = 40, nbb = 24, nbc = 30;
+    const Index batch_nd = 1;
+
+    TileGraph g2("g2");
+    auto* ba = g2.data(graph_ba, "a", DataType::FP32);
+    auto* bb = g2.data(graph_bb, "b", DataType::FP32);
+    auto* bc = g2.data(graph_bc, "c", DataType::FP32);
+    ba->mark_input(true);
+    bb->mark_input(true);
+    bc->mark_input(true);
+    bc->mark_output(true);
+    tg::gemm(ba, bb, bc, alpha, beta, trans_a, trans_b, ndim, batch_nd);
+    Runtime runtime2(g2);
+    runtime2.compile();
+
+    std::vector<float> bav(nba), bbv(nbb), bcv(nbc, 0.f);
+    for(Index i = 0; i < nba; ++i)
+    {
+        bav[static_cast<size_t>(i)] = 0.01f * static_cast<float>(i + 1);
+    }
+    for(Index i = 0; i < nbb; ++i)
+    {
+        bbv[static_cast<size_t>(i)] = 0.015f * static_cast<float>(i + 1);
+    }
+    runtime2.bind_data(ba, bav);
+    runtime2.bind_data(bb, bbv);
+    runtime2.bind_data(bc, bcv);
+    runtime2.execute();
+    runtime2.wait();
+    const std::vector<float> gout2 = runtime2.get_output<float>(bc);
+
+    nntile::core::Tile<fp32_t> tba(stor_ba), tbb(stor_bb), tbc(stor_bc);
+    {
+        auto la = tba.acquire(STARPU_W);
+        auto lb = tbb.acquire(STARPU_W);
+        auto lc = tbc.acquire(STARPU_W);
+        for(Index i = 0; i < nba; ++i) { la[i] = Y(bav[static_cast<size_t>(i)]); }
+        for(Index i = 0; i < nbb; ++i) { lb[i] = Y(bbv[static_cast<size_t>(i)]); }
+        for(Index i = 0; i < nbc; ++i) { lc[i] = Y(0); }
+        la.release();
+        lb.release();
+        lc.release();
+    }
+    nntile::core::gemm<fp32_t>(
+        -1, alpha, opN, tbb, opN, tba, beta, tbc, ndim, batch_nd, 0);
+    starpu_task_wait_for_all();
+
+    std::vector<float> tref2(nbc);
+    {
+        auto lc = tbc.acquire(STARPU_R);
+        for(Index i = 0; i < nbc; ++i)
+        {
+            tref2[static_cast<size_t>(i)] = static_cast<float>(lc[i]);
+        }
+        lc.release();
+    }
+    for(size_t i = 0; i < tref2.size(); ++i)
+    {
+        REQUIRE(std::abs(gout2[i] - tref2[i]) < tol);
+    }
 }

--- a/nntile/tests/tile/ops/gemm.cc
+++ b/nntile/tests/tile/ops/gemm.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/gemm.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -24,14 +25,16 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gemm matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 2};
+    const std::vector<Index> stor_sh = {2, 2};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 4;
     TileGraph g("g");
-    auto* a = g.data(sh, "a", DataType::FP32);
-    auto* b = g.data(sh, "b", DataType::FP32);
-    auto* c = g.data(sh, "c", DataType::FP32);
+    auto* a = g.data(graph_sh, "a", DataType::FP32);
+    auto* b = g.data(graph_sh, "b", DataType::FP32);
+    auto* c = g.data(graph_sh, "c", DataType::FP32);
     a->mark_input(true);
     b->mark_input(true);
     c->mark_input(true);
@@ -56,7 +59,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph gemm matches tile", "[
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(c);
-    nntile::core::Tile<fp32_t> ta(sh), tb(sh), tc(sh);
+    nntile::core::Tile<fp32_t> ta(stor_sh), tb(stor_sh), tc(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = ta.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/hypot.cc
+++ b/nntile/tests/tile/ops/hypot.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/hypot.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,15 +24,17 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph hypot matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     const Scalar alpha = 1.0, beta = 1.0;
     TileGraph g("g");
-    auto* s1 = g.data(sh, "s1", DataType::FP32);
-    auto* s2 = g.data(sh, "s2", DataType::FP32);
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* s1 = g.data(graph_sh, "s1", DataType::FP32);
+    auto* s2 = g.data(graph_sh, "s2", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     s1->mark_input(true);
     s2->mark_input(true);
     d->mark_output(true);
@@ -51,7 +54,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph hypot matches tile", "
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> t1(sh), t2(sh), td(sh);
+    nntile::core::Tile<fp32_t> t1(stor_sh), t2(stor_sh), td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto a = t1.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/hypot_inplace.cc
+++ b/nntile/tests/tile/ops/hypot_inplace.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/hypot_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,14 +24,16 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph hypot_inplace matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     const Scalar alpha = 0.5, beta = 0.5;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_input(true);
     d->mark_output(true);
@@ -48,7 +51,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph hypot_inplace matches 
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh), td(sh);
+    nntile::core::Tile<fp32_t> ts(stor_sh), td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto a = ts.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/hypot_scalar_inverse.cc
+++ b/nntile/tests/tile/ops/hypot_scalar_inverse.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/hypot_scalar_inverse.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,13 +24,15 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph hypot_scalar_inverse matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     const Scalar eps = 0.1, alpha = 2.0;
     TileGraph g("g");
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     d->mark_input(true);
     d->mark_output(true);
     tg::hypot_scalar_inverse(eps, alpha, d);
@@ -41,7 +44,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph hypot_scalar_inverse m
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> td(sh);
+    nntile::core::Tile<fp32_t> td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = td.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/log_scalar.cc
+++ b/nntile/tests/tile/ops/log_scalar.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/log_scalar.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -22,6 +23,7 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph log_scalar runs", "[graph][tile]")
 {

--- a/nntile/tests/tile/ops/logsumexp.cc
+++ b/nntile/tests/tile/ops/logsumexp.cc
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <numeric>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/logsumexp.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -24,14 +25,17 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph logsumexp matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh_src = {2, 2, 3};
-    const std::vector<Index> sh_dst = {2, 3};
+    const std::vector<Index> stor_sh_src = {2, 2, 3};
+    const std::vector<Index> graph_sh_src = graph_shape(stor_sh_src);
+    const std::vector<Index> stor_sh_dst = {2, 3};
+    const std::vector<Index> graph_sh_dst = graph_shape(stor_sh_dst);
     const Index n_src = 12, n_dst = 6;
     TileGraph g("g");
-    auto* s = g.data(sh_src, "s", DataType::FP32);
-    auto* d = g.data(sh_dst, "d", DataType::FP32);
+    auto* s = g.data(graph_sh_src, "s", DataType::FP32);
+    auto* d = g.data(graph_sh_dst, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
     tg::logsumexp(s, d);
@@ -50,7 +54,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph logsumexp matches tile
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh_src), td(sh_dst);
+    nntile::core::Tile<fp32_t> ts(stor_sh_src), td(stor_sh_dst);
     {
         using Y2 = typename nntile::fp32_t::repr_t;
         auto l1 = ts.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/mask_scalar.cc
+++ b/nntile/tests/tile/ops/mask_scalar.cc
@@ -14,6 +14,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/mask_scalar.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,15 +24,17 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph mask_scalar", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index n = 6;
     const Scalar val = -9.0;
     const Index batch = 0;
     TileGraph g("g");
-    auto* mask = g.data(sh, "mask", DataType::BOOL);
-    auto* a = g.data(sh, "a", DataType::FP32);
+    auto* mask = g.data(graph_sh, "mask", DataType::BOOL);
+    auto* a = g.data(graph_sh, "a", DataType::FP32);
     mask->mark_input(true);
     a->mark_input(true);
     a->mark_output(true);
@@ -47,8 +50,8 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph mask_scalar", "[graph]
     r.execute();
     r.wait();
     const std::vector<float> gout = r.get_output<float>(a);
-    nntile::core::Tile<bool_t> Tm(sh);
-    nntile::core::Tile<fp32_t> Ta(sh);
+    nntile::core::Tile<bool_t> Tm(stor_sh);
+    nntile::core::Tile<fp32_t> Ta(stor_sh);
     using Y = typename fp32_t::repr_t;
     { auto mloc = Tm.acquire(STARPU_W);
       for(Index i = 0; i < n; ++i) { mloc[i] = nntile::bool_t(mb[static_cast<size_t>(i)]); }

--- a/nntile/tests/tile/ops/maxsumexp.cc
+++ b/nntile/tests/tile/ops/maxsumexp.cc
@@ -3,9 +3,6 @@
  *                 2023-present Artificial Intelligence Research Institute
  *                              (AIRI), Russia. All rights reserved.
  *
- * NNTile is software framework for fast training of big neural networks on
- * distributed-memory heterogeneous systems based on StarPU runtime system.
- *
  * @file nntile/tests/tile_graph/maxsumexp.cc
  * Test TileGraph maxsumexp vs nntile::core (parity).
  *
@@ -15,40 +12,75 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/maxsumexp.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/maxsumexp.hh"
 #include "nntile/core/tile.hh"
-using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile;
+using namespace nntile;
+namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph maxsumexp axis0", "[graph][tile]")
 {
-    const std::vector<Index> sh = {3,4,5}, dh = {2,4,5};
-    const Index n1 = 60, n2 = 2*4*5;
-    const Index axis = 0; const int redux = 0;
+    const std::vector<Index> stor_sh = {3, 4, 5};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
+    const std::vector<Index> stor_dh = {2, 4, 5};
+    const std::vector<Index> graph_dh = graph_shape(stor_dh);
+    const Index n1 = 60, n2 = 2 * 4 * 5;
+    const Index stor_axis = 0;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_sh.size()));
+    const int redux = 0;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(dh, "d", DataType::FP32);
-    s->mark_input(true); d->mark_output(true);
-    tg::maxsumexp(s, d, axis, redux);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_dh, "d", DataType::FP32);
+    s->mark_input(true);
+    d->mark_output(true);
+    tg::maxsumexp(s, d, g_axis, redux);
     Runtime r(g);
     r.compile();
-    std::vector<float> a(n1); std::vector<float> b(n2, 0.f);
-    for(Index i=0;i<n1;++i) a[static_cast<size_t>(i)] = static_cast<float>(i+1);
-    r.bind_data(s, a); r.bind_data(d, b);
-    r.execute(); r.wait();
+    std::vector<float> a(n1);
+    std::vector<float> b(n2, 0.f);
+    for(Index i = 0; i < n1; ++i)
+    {
+        a[static_cast<size_t>(i)] = static_cast<float>(i + 1);
+    }
+    r.bind_data(s, a);
+    r.bind_data(d, b);
+    r.execute();
+    r.wait();
     const auto gout = r.get_output<float>(d);
-    nntile::core::Tile<fp32_t> S(sh), D(dh);
+    nntile::core::Tile<fp32_t> S(stor_sh), D(stor_dh);
     using Y = typename fp32_t::repr_t;
-    { auto p=S.acquire(STARPU_W), q=D.acquire(STARPU_W);
-      for(Index i=0;i<n1;++i) p[i]=Y(a[static_cast<size_t>(i)]);
-      for(Index j=0;j<n2;++j) q[j]=Y(0);
-      p.release(); q.release(); }
-    nntile::core::maxsumexp<fp32_t>(-1, S, D, axis, redux);
+    {
+        auto p = S.acquire(STARPU_W);
+        auto q = D.acquire(STARPU_W);
+        for(Index i = 0; i < n1; ++i)
+        {
+            p[i] = Y(a[static_cast<size_t>(i)]);
+        }
+        for(Index j = 0; j < n2; ++j)
+        {
+            q[j] = Y(0);
+        }
+        p.release();
+        q.release();
+    }
+    nntile::core::maxsumexp<fp32_t>(-1, S, D, stor_axis, redux);
     starpu_task_wait_for_all();
     std::vector<float> tr(n2);
-    { auto L=D.acquire(STARPU_R);
-      for(Index j=0;j<n2;++j) tr[static_cast<size_t>(j)]=static_cast<float>(L[j]);
-      L.release(); }
-    for(size_t j=0;j<tr.size();++j) REQUIRE(std::abs(gout[j]-tr[j])<1e+2f);
+    {
+        auto L = D.acquire(STARPU_R);
+        for(Index j = 0; j < n2; ++j)
+        {
+            tr[static_cast<size_t>(j)] = static_cast<float>(L[j]);
+        }
+        L.release();
+    }
+    for(size_t j = 0; j < tr.size(); ++j)
+    {
+        REQUIRE(std::abs(gout[j] - tr[j]) < 1e+2f);
+    }
 }

--- a/nntile/tests/tile/ops/maxsumexp.cc
+++ b/nntile/tests/tile/ops/maxsumexp.cc
@@ -81,6 +81,6 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph maxsumexp axis0", "[gr
     }
     for(size_t j = 0; j < tr.size(); ++j)
     {
-        REQUIRE(std::abs(gout[j] - tr[j]) < 1e+2f);
+        REQUIRE(std::abs(gout[j] - tr[j]) < 1e-6f);
     }
 }

--- a/nntile/tests/tile/ops/multiply.cc
+++ b/nntile/tests/tile/ops/multiply.cc
@@ -13,6 +13,7 @@
  * */
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "mixed_tile_common.hh"
 
 #include <catch2/catch_test_macros.hpp>

--- a/nntile/tests/tile/ops/multiply_fiber.cc
+++ b/nntile/tests/tile/ops/multiply_fiber.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/multiply_fiber.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,22 +24,26 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph multiply_fiber matches tile", "[graph][tile]")
 {
-    const std::vector<Index> full = {3, 4, 5};
-    const std::vector<Index> fib = {5};
+    const std::vector<Index> stor_full = {3, 4, 5};
+    const std::vector<Index> graph_full = graph_shape(stor_full);
+    const std::vector<Index> stor_fib = {5};
+    const std::vector<Index> graph_fib = graph_shape(stor_fib);
     const Index nfull = 3 * 4 * 5;
     const Index nfib = 5;
-    const Index axis = 2;
+    const Index stor_axis = 2;
+    const Index g_axis = graph_axis(stor_axis, static_cast<Index>(stor_full.size()));
     const Scalar alpha = 1.0;
     TileGraph g("g");
-    auto* s1 = g.data(fib, "s1", DataType::FP32);
-    auto* s2 = g.data(full, "s2", DataType::FP32);
-    auto* d = g.data(full, "d", DataType::FP32);
+    auto* s1 = g.data(graph_fib, "s1", DataType::FP32);
+    auto* s2 = g.data(graph_full, "s2", DataType::FP32);
+    auto* d = g.data(graph_full, "d", DataType::FP32);
     s1->mark_input(true);
     s2->mark_input(true);
     d->mark_output(true);
-    tg::multiply_fiber(alpha, s1, s2, d, axis);
+    tg::multiply_fiber(alpha, s1, s2, d, g_axis);
     Runtime runtime(g);
     runtime.compile();
     std::vector<float> f1(nfib), f2(nfull), f3(nfull, 0.f);
@@ -50,7 +55,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph multiply_fiber matches
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> t1(fib), t2(full), dst(full);
+    nntile::core::Tile<fp32_t> t1(stor_fib), t2(stor_full), dst(stor_full);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto a = t1.acquire(STARPU_W);
@@ -66,7 +71,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph multiply_fiber matches
         b.release();
         c.release();
     }
-    nntile::core::multiply_fiber<fp32_t>(-1, alpha, t1, t2, dst, axis);
+    nntile::core::multiply_fiber<fp32_t>(-1, alpha, t1, t2, dst, stor_axis);
     starpu_task_wait_for_all();
     std::vector<float> tref(nfull);
     {

--- a/nntile/tests/tile/ops/multiply_fiber_inplace.cc
+++ b/nntile/tests/tile/ops/multiply_fiber_inplace.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/multiply_fiber_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,20 +24,24 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph multiply_fiber_inplace", "[graph][tile]")
 {
-    const std::vector<Index> full = {3, 4, 5};
-    const std::vector<Index> fib = {5};
+    const std::vector<Index> stor_full = {3, 4, 5};
+    const std::vector<Index> graph_full = graph_shape(stor_full);
+    const std::vector<Index> stor_fib = {5};
+    const std::vector<Index> graph_fib = graph_shape(stor_fib);
     const Index n = 60, nf = 5;
     const Scalar a = 1.0;
-    const Index axis = 2;
+    const Index stor_axis = 2;
+    const Index g_axis = graph_axis(stor_axis, static_cast<Index>(stor_full.size()));
     TileGraph g("g");
-    auto* s = g.data(fib, "s", DataType::FP32);
-    auto* d = g.data(full, "d", DataType::FP32);
+    auto* s = g.data(graph_fib, "s", DataType::FP32);
+    auto* d = g.data(graph_full, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_input(true);
     d->mark_output(true);
-    tg::multiply_fiber_inplace(a, s, d, axis);
+    tg::multiply_fiber_inplace(a, s, d, g_axis);
     Runtime rt(g);
     rt.compile();
     std::vector<float> f1(nf), f2(n);
@@ -47,13 +52,13 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph multiply_fiber_inplace
     rt.execute();
     rt.wait();
     const std::vector<float> gout = rt.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(fib), td(full);
+    nntile::core::Tile<fp32_t> ts(stor_fib), td(stor_full);
     using Y = typename nntile::fp32_t::repr_t;
     { auto A = ts.acquire(STARPU_W), B = td.acquire(STARPU_W);
       for(Index i = 0; i < nf; ++i) A[i] = Y(f1[static_cast<size_t>(i)]);
       for(Index i = 0; i < n; ++i) B[i] = Y(0.2f * static_cast<float>(i + 1));
       A.release(); B.release(); }
-    nntile::core::multiply_fiber_inplace<fp32_t>(-1, a, ts, td, axis);
+    nntile::core::multiply_fiber_inplace<fp32_t>(-1, a, ts, td, stor_axis);
     starpu_task_wait_for_all();
     std::vector<float> tref(n);
     { auto L = td.acquire(STARPU_R);

--- a/nntile/tests/tile/ops/multiply_inplace.cc
+++ b/nntile/tests/tile/ops/multiply_inplace.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/multiply_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,14 +24,16 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph multiply_inplace matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     const Scalar alpha = 0.5;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_input(true);
     d->mark_output(true);
@@ -48,7 +51,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph multiply_inplace match
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh), td(sh);
+    nntile::core::Tile<fp32_t> ts(stor_sh), td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto a = ts.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/multiply_slice.cc
+++ b/nntile/tests/tile/ops/multiply_slice.cc
@@ -3,9 +3,6 @@
  *                 2023-present Artificial Intelligence Research Institute
  *                              (AIRI), Russia. All rights reserved.
  *
- * NNTile is software framework for fast training of big neural networks on
- * distributed-memory heterogeneous systems based on StarPU runtime system.
- *
  * @file nntile/tests/tile_graph/multiply_slice.cc
  * Test TileGraph multiply slice vs nntile::core (parity).
  *
@@ -15,6 +12,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/multiply_slice.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,41 +21,71 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph multiply_slice", "[graph][tile]")
 {
-    const std::vector<Index> shs = {3, 5}, shd = {3, 4, 5};
+    const std::vector<Index> stor_shs = {3, 5};
+    const std::vector<Index> graph_shs = graph_shape(stor_shs);
+    const std::vector<Index> stor_shd = {3, 4, 5};
+    const std::vector<Index> graph_shd = graph_shape(stor_shd);
     const Index ns = 15, n = 60;
     const Scalar a = 0.5;
-    const Index axis = 1;
+    const Index stor_axis = 1;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_shd.size()));
     TileGraph g("g");
-    auto* s = g.data(shs, "s", DataType::FP32);
-    auto* d = g.data(shd, "d", DataType::FP32);
+    auto* s = g.data(graph_shs, "s", DataType::FP32);
+    auto* d = g.data(graph_shd, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_input(true);
     d->mark_output(true);
-    tg::multiply_slice(a, s, d, axis);
+    tg::multiply_slice(a, s, d, g_axis);
     Runtime rt(g);
     rt.compile();
     std::vector<float> sv(ns), dv(n);
-    for(Index i = 0; i < ns; ++i) { sv[static_cast<size_t>(i)] = 0.1f * static_cast<float>(i + 1); }
-    for(Index i = 0; i < n; ++i) { dv[static_cast<size_t>(i)] = 0.2f * static_cast<float>(i + 1); }
+    for(Index i = 0; i < ns; ++i)
+    {
+        sv[static_cast<size_t>(i)] = 0.1f * static_cast<float>(i + 1);
+    }
+    for(Index i = 0; i < n; ++i)
+    {
+        dv[static_cast<size_t>(i)] = 0.2f * static_cast<float>(i + 1);
+    }
     rt.bind_data(s, sv);
     rt.bind_data(d, dv);
     rt.execute();
     rt.wait();
     const std::vector<float> gout = rt.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(shs), td(shd);
+    nntile::core::Tile<fp32_t> ts(stor_shs), td(stor_shd);
     using Y = typename nntile::fp32_t::repr_t;
-    { auto A = ts.acquire(STARPU_W), B = td.acquire(STARPU_W);
-      for(Index i = 0; i < ns; ++i) { A[i] = Y(sv[static_cast<size_t>(i)]); }
-      for(Index i = 0; i < n; ++i) { B[i] = Y(dv[static_cast<size_t>(i)]); }
-      A.release(); B.release(); }
-    nntile::core::multiply_slice<fp32_t>(-1, a, ts, td, axis);
+    {
+        auto A = ts.acquire(STARPU_W);
+        auto B = td.acquire(STARPU_W);
+        for(Index i = 0; i < ns; ++i)
+        {
+            A[i] = Y(sv[static_cast<size_t>(i)]);
+        }
+        for(Index i = 0; i < n; ++i)
+        {
+            B[i] = Y(dv[static_cast<size_t>(i)]);
+        }
+        A.release();
+        B.release();
+    }
+    nntile::core::multiply_slice<fp32_t>(-1, a, ts, td, stor_axis);
     starpu_task_wait_for_all();
     std::vector<float> tref(n);
-    { auto L = td.acquire(STARPU_R);
-      for(Index i = 0; i < n; ++i) tref[static_cast<size_t>(i)] = static_cast<float>(L[i]);
-      L.release(); }
+    {
+        auto L = td.acquire(STARPU_R);
+        for(Index i = 0; i < n; ++i)
+        {
+            tref[static_cast<size_t>(i)] = static_cast<float>(L[i]);
+        }
+        L.release();
+    }
     constexpr float tol = 1.1e-2f;
-    for(size_t i = 0; i < tref.size(); ++i) { REQUIRE(std::abs(gout[i] - tref[i]) < tol); }
+    for(size_t i = 0; i < tref.size(); ++i)
+    {
+        REQUIRE(std::abs(gout[i] - tref[i]) < tol);
+    }
 }

--- a/nntile/tests/tile/ops/norm.cc
+++ b/nntile/tests/tile/ops/norm.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/norm.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,13 +24,15 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     const Scalar alpha = 1.0, beta = 0.0;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
     auto* d = g.data(std::vector<Index>{}, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
@@ -44,7 +47,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm matches tile", "[
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh), td(std::vector<Index>{});
+    nntile::core::Tile<fp32_t> ts(stor_sh), td(std::vector<Index>{});
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto a = ts.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/norm_fiber.cc
+++ b/nntile/tests/tile/ops/norm_fiber.cc
@@ -72,5 +72,5 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm_fiber", "[graph][
     { auto L = D.acquire(STARPU_R);
       for(Index j = 0; j < 5; ++j) tref[static_cast<size_t>(j)] = static_cast<float>(L[j]);
       L.release(); }
-    for(int j = 0; j < 5; ++j) { REQUIRE(std::abs(gout[static_cast<size_t>(j)] - tref[static_cast<size_t>(j)]) < 1e-1f); }
+    for(int j = 0; j < 5; ++j) { REQUIRE(std::abs(gout[static_cast<size_t>(j)] - tref[static_cast<size_t>(j)]) < 1e-6f); }
 }

--- a/nntile/tests/tile/ops/norm_fiber.cc
+++ b/nntile/tests/tile/ops/norm_fiber.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/norm_fiber.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,23 +24,29 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm_fiber", "[graph][tile]")
 {
-    const std::vector<Index> s1h = {5, 3, 20, 1};
-    const std::vector<Index> s2h = {5};
-    const std::vector<Index> dh = {5};
+    const std::vector<Index> stor_s1h = {5, 3, 20, 1};
+    const std::vector<Index> graph_s1h = graph_shape(stor_s1h);
+    const std::vector<Index> stor_s2h = {5};
+    const std::vector<Index> graph_s2h = graph_shape(stor_s2h);
+    const std::vector<Index> stor_dh = {5};
+    const std::vector<Index> graph_dh = graph_shape(stor_dh);
     const Scalar a = 1.0, b = 0.0;
-    const Index ax = 0, bd = 0;
+    const Index stor_axis = 0, bd = 0;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_s1h.size()));
     const int redux = 0;
     const Index n1 = 5 * 3 * 20, n2 = 5, n3 = 5;
     TileGraph g("g");
-    auto* t1 = g.data(s1h, "s1", DataType::FP32);
-    auto* t2 = g.data(s2h, "s2", DataType::FP32);
-    auto* d = g.data(dh, "d", DataType::FP32);
+    auto* t1 = g.data(graph_s1h, "s1", DataType::FP32);
+    auto* t2 = g.data(graph_s2h, "s2", DataType::FP32);
+    auto* d = g.data(graph_dh, "d", DataType::FP32);
     t1->mark_input(true);
     t2->mark_input(true);
     d->mark_output(true);
-    tg::norm_fiber(a, t1, b, t2, d, ax, bd, redux);
+    tg::norm_fiber(a, t1, b, t2, d, g_axis, bd, redux);
     Runtime rt(g);
     rt.compile();
     std::vector<float> v1(n1), v2(n2);
@@ -52,14 +59,14 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm_fiber", "[graph][
     rt.execute();
     rt.wait();
     const std::vector<float> gout = rt.get_output<float>(d);
-    nntile::core::Tile<fp32_t> T1(s1h), T2(s2h), D(dh);
+    nntile::core::Tile<fp32_t> T1(stor_s1h), T2(stor_s2h), D(stor_dh);
     using Y = typename nntile::fp32_t::repr_t;
     { auto a1 = T1.acquire(STARPU_W), a2 = T2.acquire(STARPU_W), a3 = D.acquire(STARPU_W);
       for(Index i = 0; i < n1; ++i) a1[i] = Y(-1.0f);
       for(Index i = 0; i < n2; ++i) a2[i] = Y(0.0f);
       for(Index i = 0; i < n3; ++i) a3[i] = Y(0.0f);
       a1.release(); a2.release(); a3.release(); }
-    nntile::core::norm_fiber<fp32_t>(-1, a, T1, b, T2, D, ax, bd, redux);
+    nntile::core::norm_fiber<fp32_t>(-1, a, T1, b, T2, D, stor_axis, bd, redux);
     starpu_task_wait_for_all();
     std::vector<float> tref(5);
     { auto L = D.acquire(STARPU_R);

--- a/nntile/tests/tile/ops/norm_fiber_inplace.cc
+++ b/nntile/tests/tile/ops/norm_fiber_inplace.cc
@@ -65,5 +65,5 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm_fiber_inplace", "
     { auto L = D.acquire(STARPU_R);
       for(Index j = 0; j < 5; ++j) tref[static_cast<size_t>(j)] = static_cast<float>(L[j]);
       L.release(); }
-    for(int j = 0; j < 5; ++j) { REQUIRE(std::abs(gout[static_cast<size_t>(j)] - tref[static_cast<size_t>(j)]) < 1e+2f); }
+    for(int j = 0; j < 5; ++j) { REQUIRE(std::abs(gout[static_cast<size_t>(j)] - tref[static_cast<size_t>(j)]) < 1e-6f); }
 }

--- a/nntile/tests/tile/ops/norm_fiber_inplace.cc
+++ b/nntile/tests/tile/ops/norm_fiber_inplace.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/norm_fiber_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,21 +24,26 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm_fiber_inplace", "[graph][tile]")
 {
-    const std::vector<Index> sh = {5, 3, 20, 1};
-    const std::vector<Index> dh = {5};
+    const std::vector<Index> stor_sh = {5, 3, 20, 1};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
+    const std::vector<Index> stor_dh = {5};
+    const std::vector<Index> graph_dh = graph_shape(stor_dh);
     const Index n1 = 300, n2 = 5;
     const Scalar a = 1.0, b = 0.0;
-    const Index ax = 0, bd = 0;
+    const Index stor_axis = 0, bd = 0;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_sh.size()));
     const int redux = 0;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(dh, "d", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_dh, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_input(true);
     d->mark_output(true);
-    tg::norm_fiber_inplace(a, s, b, d, ax, bd, redux);
+    tg::norm_fiber_inplace(a, s, b, d, g_axis, bd, redux);
     Runtime rt(g);
     rt.compile();
     std::vector<float> v1(n1), v2(n2, -1.f);
@@ -47,13 +53,13 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm_fiber_inplace", "
     rt.execute();
     rt.wait();
     const std::vector<float> gout = rt.get_output<float>(d);
-    nntile::core::Tile<fp32_t> S(sh), D(dh);
+    nntile::core::Tile<fp32_t> S(stor_sh), D(stor_dh);
     using Y = typename nntile::fp32_t::repr_t;
     { auto a1 = S.acquire(STARPU_W), a2 = D.acquire(STARPU_W);
       for(Index i = 0; i < n1; ++i) a1[i] = Y(-1.0f);
       for(Index j = 0; j < n2; ++j) a2[j] = Y(-1.0f);
       a1.release(); a2.release(); }
-    nntile::core::norm_fiber_inplace<fp32_t>(-1, a, S, b, D, ax, bd, redux);
+    nntile::core::norm_fiber_inplace<fp32_t>(-1, a, S, b, D, stor_axis, bd, redux);
     starpu_task_wait_for_all();
     std::vector<float> tref(5);
     { auto L = D.acquire(STARPU_R);

--- a/nntile/tests/tile/ops/norm_slice.cc
+++ b/nntile/tests/tile/ops/norm_slice.cc
@@ -89,6 +89,6 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm_slice (axis=0)", 
     }
     for(size_t j = 0; j < tref.size(); ++j)
     {
-        REQUIRE(std::abs(gout[j] - tref[j]) < 1e+2f);
+        REQUIRE(std::abs(gout[j] - tref[j]) < 1e-6f);
     }
 }

--- a/nntile/tests/tile/ops/norm_slice.cc
+++ b/nntile/tests/tile/ops/norm_slice.cc
@@ -3,9 +3,6 @@
  *                 2023-present Artificial Intelligence Research Institute
  *                              (AIRI), Russia. All rights reserved.
  *
- * NNTile is software framework for fast training of big neural networks on
- * distributed-memory heterogeneous systems based on StarPU runtime system.
- *
  * @file nntile/tests/tile_graph/norm_slice.cc
  * Test TileGraph norm slice vs nntile::core (parity).
  *
@@ -15,6 +12,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/norm_slice.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,42 +21,74 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm_slice (axis=0)", "[graph][tile]")
 {
-    const std::vector<Index> t1h = {3, 4, 5}, t2h = {4, 5}, dh = {4, 5};
+    const std::vector<Index> stor_t1h = {3, 4, 5};
+    const std::vector<Index> graph_t1h = graph_shape(stor_t1h);
+    const std::vector<Index> stor_t2h = {4, 5};
+    const std::vector<Index> graph_t2h = graph_shape(stor_t2h);
+    const std::vector<Index> stor_dh = {4, 5};
+    const std::vector<Index> graph_dh = graph_shape(stor_dh);
     const Index n1 = 60, n2 = 20, n3 = 20;
     const Scalar a = -1.0, b = 0.5;
-    const Index ax = 0;
+    const Index stor_axis = 0;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_t1h.size()));
     const int redux = 0;
     TileGraph g("g");
-    auto* t1 = g.data(t1h, "t1", DataType::FP32);
-    auto* t2 = g.data(t2h, "t2", DataType::FP32);
-    auto* d = g.data(dh, "d", DataType::FP32);
+    auto* t1 = g.data(graph_t1h, "t1", DataType::FP32);
+    auto* t2 = g.data(graph_t2h, "t2", DataType::FP32);
+    auto* d = g.data(graph_dh, "d", DataType::FP32);
     t1->mark_input(true);
     t2->mark_input(true);
     d->mark_output(true);
-    tg::norm_slice(a, t1, b, t2, d, ax, redux);
+    tg::norm_slice(a, t1, b, t2, d, g_axis, redux);
     Runtime rt(g);
     rt.compile();
     std::vector<float> u1(n1), u2(n2, 0.f), o(n3, 0.f);
-    for(Index i = 0; i < n1; ++i) { u1[static_cast<size_t>(i)] = static_cast<float>(i + 1); }
+    for(Index i = 0; i < n1; ++i)
+    {
+        u1[static_cast<size_t>(i)] = static_cast<float>(i + 1);
+    }
     rt.bind_data(t1, u1);
     rt.bind_data(t2, u2);
     rt.bind_data(d, o);
     rt.execute();
     rt.wait();
     const std::vector<float> gout = rt.get_output<float>(d);
-    nntile::core::Tile<fp32_t> T1(t1h), T2(t2h), D(dh);
+    nntile::core::Tile<fp32_t> T1(stor_t1h), T2(stor_t2h), D(stor_dh);
     using Y = typename nntile::fp32_t::repr_t;
-    { auto A = T1.acquire(STARPU_W), B = T2.acquire(STARPU_W), C = D.acquire(STARPU_W);
-      for(Index i = 0; i < n1; ++i) A[i] = Y(u1[static_cast<size_t>(i)]);
-      for(Index j = 0; j < n2; ++j) { B[j] = Y(0); C[j] = Y(0); }
-      A.release(); B.release(); C.release(); }
-    nntile::core::norm_slice<fp32_t>(-1, a, T1, b, T2, D, ax, redux);
+    {
+        auto A = T1.acquire(STARPU_W);
+        auto B = T2.acquire(STARPU_W);
+        auto C = D.acquire(STARPU_W);
+        for(Index i = 0; i < n1; ++i)
+        {
+            A[i] = Y(u1[static_cast<size_t>(i)]);
+        }
+        for(Index j = 0; j < n2; ++j)
+        {
+            B[j] = Y(0);
+            C[j] = Y(0);
+        }
+        A.release();
+        B.release();
+        C.release();
+    }
+    nntile::core::norm_slice<fp32_t>(-1, a, T1, b, T2, D, stor_axis, redux);
     starpu_task_wait_for_all();
     std::vector<float> tref(20);
-    { auto L = D.acquire(STARPU_R);
-      for(Index j = 0; j < 20; ++j) tref[static_cast<size_t>(j)] = static_cast<float>(L[j]);
-      L.release(); }
-    for(size_t j = 0; j < tref.size(); ++j) { REQUIRE(std::abs(gout[j] - tref[j]) < 1e+2f); }
+    {
+        auto L = D.acquire(STARPU_R);
+        for(Index j = 0; j < 20; ++j)
+        {
+            tref[static_cast<size_t>(j)] = static_cast<float>(L[j]);
+        }
+        L.release();
+    }
+    for(size_t j = 0; j < tref.size(); ++j)
+    {
+        REQUIRE(std::abs(gout[j] - tref[j]) < 1e+2f);
+    }
 }

--- a/nntile/tests/tile/ops/norm_slice_inplace.cc
+++ b/nntile/tests/tile/ops/norm_slice_inplace.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/norm_slice_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,20 +24,26 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm_slice_inplace (axis=0)", "[graph][tile]")
 {
-    const std::vector<Index> t1h = {3, 4, 5}, t2h = {4, 5};
+    const std::vector<Index> stor_t1h = {3, 4, 5};
+    const std::vector<Index> graph_t1h = graph_shape(stor_t1h);
+    const std::vector<Index> stor_t2h = {4, 5};
+    const std::vector<Index> graph_t2h = graph_shape(stor_t2h);
     const Index n1 = 60, n2 = 20;
     const Scalar a = 1.0, b = 0.0;
-    const Index ax = 0;
+    const Index stor_axis = 0;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_t1h.size()));
     const int redux = 0;
     TileGraph g("g");
-    auto* t1 = g.data(t1h, "t1", DataType::FP32);
-    auto* t2 = g.data(t2h, "t2", DataType::FP32);
+    auto* t1 = g.data(graph_t1h, "t1", DataType::FP32);
+    auto* t2 = g.data(graph_t2h, "t2", DataType::FP32);
     t1->mark_input(true);
     t2->mark_input(true);
     t2->mark_output(true);
-    tg::norm_slice_inplace(a, t1, b, t2, ax, redux);
+    tg::norm_slice_inplace(a, t1, b, t2, g_axis, redux);
     Runtime rt(g);
     rt.compile();
     std::vector<float> u1(n1), u2(n2, 0.f);
@@ -47,13 +54,13 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm_slice_inplace (ax
     rt.execute();
     rt.wait();
     const std::vector<float> gout = rt.get_output<float>(t2);
-    nntile::core::Tile<fp32_t> T1(t1h), T2(t2h);
+    nntile::core::Tile<fp32_t> T1(stor_t1h), T2(stor_t2h);
     using Y = typename nntile::fp32_t::repr_t;
     { auto A = T1.acquire(STARPU_W), B = T2.acquire(STARPU_W);
       for(Index i = 0; i < n1; ++i) A[i] = Y(u1[static_cast<size_t>(i)]);
       for(Index j = 0; j < n2; ++j) B[j] = Y(0);
       A.release(); B.release(); }
-    nntile::core::norm_slice_inplace<fp32_t>(-1, a, T1, b, T2, ax, redux);
+    nntile::core::norm_slice_inplace<fp32_t>(-1, a, T1, b, T2, stor_axis, redux);
     starpu_task_wait_for_all();
     std::vector<float> tref(20);
     { auto L = T2.acquire(STARPU_R);

--- a/nntile/tests/tile/ops/norm_slice_inplace.cc
+++ b/nntile/tests/tile/ops/norm_slice_inplace.cc
@@ -66,5 +66,5 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph norm_slice_inplace (ax
     { auto L = T2.acquire(STARPU_R);
       for(Index j = 0; j < 20; ++j) tref[static_cast<size_t>(j)] = static_cast<float>(L[j]);
       L.release(); }
-    for(size_t j = 0; j < tref.size(); ++j) { REQUIRE(std::abs(gout[j] - tref[j]) < 1e+2f); }
+    for(size_t j = 0; j < tref.size(); ++j) { REQUIRE(std::abs(gout[j] - tref[j]) < 1e-6f); }
 }

--- a/nntile/tests/tile/ops/pow.cc
+++ b/nntile/tests/tile/ops/pow.cc
@@ -13,6 +13,7 @@
  * */
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "mixed_tile_common.hh"
 
 #include <catch2/catch_test_macros.hpp>

--- a/nntile/tests/tile/ops/randn.cc
+++ b/nntile/tests/tile/ops/randn.cc
@@ -14,20 +14,23 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/randn.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/randn.hh"
 #include "nntile/core/tile.hh"
 using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph randn", "[graph][tile]")
 {
-    const std::vector<Index> sh = {3,4,5};
+    const std::vector<Index> stor_sh = {3,4,5};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const std::vector<Index> st = {1,1,1}, us = {5,6,7};
     const unsigned long long seed = static_cast<unsigned long long>(-1);
     const Scalar mean = 1.0, std = 2.0;
     TileGraph g("g");
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     d->mark_input(true);
     d->mark_output(true);
     tg::randn(d, st, us, seed, mean, std);
@@ -38,7 +41,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph randn", "[graph][tile]
     r.execute();
     r.wait();
     const auto gout = r.get_output<float>(d);
-    nntile::core::Tile<fp32_t> Td(sh);
+    nntile::core::Tile<fp32_t> Td(stor_sh);
     nntile::core::randn<fp32_t>(-1, Td, st, us, seed, mean, std);
     starpu_task_wait_for_all();
     std::vector<float> tref(60);

--- a/nntile/tests/tile/ops/relu.cc
+++ b/nntile/tests/tile/ops/relu.cc
@@ -15,6 +15,7 @@
 #include "nntile/tile/ops/relu.hh"
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "mixed_tile_common.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -29,17 +30,19 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 namespace gt = nntile::tensor;
 namespace tt = nntile::core_tests;
 TEST_CASE_METHOD(nntile::test::ContextFixture,
     "TileGraph relu matches tile",
     "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto *s = g.data(sh, "s", DataType::FP32);
-    auto *d = g.data(sh, "d", DataType::FP32);
+    auto *s = g.data(graph_sh, "s", DataType::FP32);
+    auto *d = g.data(graph_sh, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
     tg::relu(s, d);
@@ -56,7 +59,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture,
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh), td(sh);
+    nntile::core::Tile<fp32_t> ts(stor_sh), td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = ts.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/relu_backward.cc
+++ b/nntile/tests/tile/ops/relu_backward.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/relu_backward.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,14 +24,16 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph relu_backward matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* x = g.data(sh, "x", DataType::FP32);
-    auto* dy = g.data(sh, "dy", DataType::FP32);
-    auto* dx = g.data(sh, "dx", DataType::FP32);
+    auto* x = g.data(graph_sh, "x", DataType::FP32);
+    auto* dy = g.data(graph_sh, "dy", DataType::FP32);
+    auto* dx = g.data(graph_sh, "dx", DataType::FP32);
     x->mark_input(true);
     dy->mark_input(true);
     dx->mark_input(true);
@@ -50,7 +53,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph relu_backward matches 
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(dx);
-    nntile::core::Tile<fp32_t> tx(sh), tdy(sh), tdx(sh);
+    nntile::core::Tile<fp32_t> tx(stor_sh), tdy(stor_sh), tdx(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = tx.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/relu_inplace.cc
+++ b/nntile/tests/tile/ops/relu_inplace.cc
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <numeric>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/relu_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -24,12 +25,14 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph relu_inplace matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     d->mark_input(true);
     d->mark_output(true);
     tg::relu_inplace(d);
@@ -41,7 +44,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph relu_inplace matches t
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> td(sh);
+    nntile::core::Tile<fp32_t> td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = td.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/rope.cc
+++ b/nntile/tests/tile/ops/rope.cc
@@ -100,6 +100,6 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph rope", "[graph][tile]"
     }
     for(int i = 0; i < 20; ++i)
     {
-        REQUIRE(std::abs(gout[static_cast<size_t>(i)] - tr[static_cast<size_t>(i)]) < 1e+2f);
+        REQUIRE(std::abs(gout[static_cast<size_t>(i)] - tr[static_cast<size_t>(i)]) < 1e-6f);
     }
 }

--- a/nntile/tests/tile/ops/rope.cc
+++ b/nntile/tests/tile/ops/rope.cc
@@ -3,9 +3,6 @@
  *                 2023-present Artificial Intelligence Research Institute
  *                              (AIRI), Russia. All rights reserved.
  *
- * NNTile is software framework for fast training of big neural networks on
- * distributed-memory heterogeneous systems based on StarPU runtime system.
- *
  * @file nntile/tests/tile_graph/rope.cc
  * Test TileGraph rope vs nntile::core (parity).
  *
@@ -14,48 +11,95 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/rope.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/rope.hh"
 #include "nntile/core/tile.hh"
-using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile;
+using namespace nntile;
+namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph rope", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2}, tsh = {4,5};
-    const Index n2=2, n=20;
+    const std::vector<Index> stor_sh = {2};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
+    const std::vector<Index> stor_tsh = {4, 5};
+    const std::vector<Index> graph_tsh = graph_shape(stor_tsh);
+    const Index n = 20;
     TileGraph g("g");
-    auto* si = g.data(sh, "si", DataType::FP32);
-    auto* co = g.data(sh, "co", DataType::FP32);
-    auto* sr = g.data(tsh, "src", DataType::FP32);
-    auto* d = g.data(tsh, "d", DataType::FP32);
-    si->mark_input(true); co->mark_input(true); sr->mark_input(true); d->mark_output(true);
+    auto* si = g.data(graph_sh, "si", DataType::FP32);
+    auto* co = g.data(graph_sh, "co", DataType::FP32);
+    auto* sr = g.data(graph_tsh, "src", DataType::FP32);
+    auto* d = g.data(graph_tsh, "d", DataType::FP32);
+    si->mark_input(true);
+    co->mark_input(true);
+    sr->mark_input(true);
+    d->mark_output(true);
     tg::rope(si, co, sr, d);
     Runtime r(g);
     r.compile();
-    std::vector<float> sv(2), cv(2), src(20,0.03f);
-    for(int i=0;i<2;++i) { sv[static_cast<size_t>(i)]=0.1f*static_cast<float>(i+1);
-      cv[static_cast<size_t>(i)]=0.2f*static_cast<float>(i+1);}
-    for(int i=0;i<20;++i) src[static_cast<size_t>(i)]=0.03f*static_cast<float>(i+1);
-    std::vector<float> dv(20,0.f);
+    std::vector<float> sv(2), cv(2), src(n, 0.03f);
+    for(int i = 0; i < 2; ++i)
+    {
+        sv[static_cast<size_t>(i)] = 0.1f * static_cast<float>(i + 1);
+        cv[static_cast<size_t>(i)] = 0.2f * static_cast<float>(i + 1);
+    }
+    for(int i = 0; i < 20; ++i)
+    {
+        src[static_cast<size_t>(i)] = 0.03f * static_cast<float>(i + 1);
+    }
+    std::vector<float> dv(n, 0.f);
     r.bind_data(si, sv);
     r.bind_data(co, cv);
     r.bind_data(sr, src);
     r.bind_data(d, dv);
-    r.execute(); r.wait();
+    r.execute();
+    r.wait();
     const auto gout = r.get_output<float>(d);
-    nntile::core::Tile<fp32_t> Si(sh), Co(sh), Src(tsh), D(tsh);
+    nntile::core::Tile<fp32_t> Si(stor_sh), Co(stor_sh), Src(stor_tsh), D(stor_tsh);
     using Y = typename fp32_t::repr_t;
-    { auto a=Si.acquire(STARPU_W),b=Co.acquire(STARPU_W);
-      for(int i=0;i<2;++i) {a[i]=Y(sv[static_cast<size_t>(i)]); b[i]=Y(cv[static_cast<size_t>(i)]);}a.release();b.release(); }
-    { auto c=Src.acquire(STARPU_W);
-      for(int i=0;i<20;++i) c[i]=Y(src[static_cast<size_t>(i)]); c.release(); }
-    { auto d0=D.acquire(STARPU_W); for(int i=0;i<20;++i) d0[i]=Y(0.0f); d0.release(); }
+    {
+        auto a = Si.acquire(STARPU_W);
+        auto b = Co.acquire(STARPU_W);
+        for(int i = 0; i < 2; ++i)
+        {
+            a[i] = Y(sv[static_cast<size_t>(i)]);
+            b[i] = Y(cv[static_cast<size_t>(i)]);
+        }
+        a.release();
+        b.release();
+    }
+    {
+        auto c = Src.acquire(STARPU_W);
+        for(int i = 0; i < 20; ++i)
+        {
+            c[i] = Y(src[static_cast<size_t>(i)]);
+        }
+        c.release();
+    }
+    {
+        auto d0 = D.acquire(STARPU_W);
+        for(int i = 0; i < 20; ++i)
+        {
+            d0[i] = Y(0.0f);
+        }
+        d0.release();
+    }
     nntile::core::rope<fp32_t>(-1, Si, Co, Src, D);
     starpu_task_wait_for_all();
     std::vector<float> tr(20);
-    { auto L=D.acquire(STARPU_R);
-      for(int i=0;i<20;++i) tr[static_cast<size_t>(i)]=static_cast<float>(L[i]);
-      L.release(); }
-    for(int i=0;i<20;++i) REQUIRE(std::abs(gout[static_cast<size_t>(i)]-tr[static_cast<size_t>(i)])<1e+2f);
+    {
+        auto L = D.acquire(STARPU_R);
+        for(int i = 0; i < 20; ++i)
+        {
+            tr[static_cast<size_t>(i)] = static_cast<float>(L[i]);
+        }
+        L.release();
+    }
+    for(int i = 0; i < 20; ++i)
+    {
+        REQUIRE(std::abs(gout[static_cast<size_t>(i)] - tr[static_cast<size_t>(i)]) < 1e+2f);
+    }
 }

--- a/nntile/tests/tile/ops/rope_backward.cc
+++ b/nntile/tests/tile/ops/rope_backward.cc
@@ -3,9 +3,6 @@
  *                 2023-present Artificial Intelligence Research Institute
  *                              (AIRI), Russia. All rights reserved.
  *
- * NNTile is software framework for fast training of big neural networks on
- * distributed-memory heterogeneous systems based on StarPU runtime system.
- *
  * @file nntile/tests/tile_graph/rope_backward.cc
  * Test TileGraph rope backward vs nntile::core (parity).
  *
@@ -14,45 +11,94 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/rope_backward.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/rope_backward.hh"
 #include "nntile/core/tile.hh"
-using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile;
+using namespace nntile;
+namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph rope_backward", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2}, tsh = {4,5};
+    const std::vector<Index> stor_sh = {2};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
+    const std::vector<Index> stor_tsh = {4, 5};
+    const std::vector<Index> graph_tsh = graph_shape(stor_tsh);
     TileGraph g("g");
-    auto* si = g.data(sh, "si", DataType::FP32);
-    auto* co = g.data(sh, "co", DataType::FP32);
-    auto* dy = g.data(tsh, "dy", DataType::FP32);
-    auto* dx = g.data(tsh, "dx", DataType::FP32);
-    si->mark_input(true); co->mark_input(true); dy->mark_input(true);
-    dx->mark_input(true); dx->mark_output(true);
+    auto* si = g.data(graph_sh, "si", DataType::FP32);
+    auto* co = g.data(graph_sh, "co", DataType::FP32);
+    auto* dy = g.data(graph_tsh, "dy", DataType::FP32);
+    auto* dx = g.data(graph_tsh, "dx", DataType::FP32);
+    si->mark_input(true);
+    co->mark_input(true);
+    dy->mark_input(true);
+    dx->mark_input(true);
+    dx->mark_output(true);
     tg::rope_backward(si, co, dy, dx);
     Runtime r(g);
     r.compile();
     std::vector<float> siv(2), cev(2), dyy(20), dxx(20, 0.01f);
-    for(int i=0;i<2;++i){siv[static_cast<size_t>(i)]=0.1f; cev[static_cast<size_t>(i)]=0.2f;}
-    for(int i=0;i<20;++i) dyy[static_cast<size_t>(i)]=0.05f*static_cast<float>(i+1);
-    r.bind_data(si, siv); r.bind_data(co, cev); r.bind_data(dy, dyy); r.bind_data(dx, dxx);
-    r.execute(); r.wait();
+    for(int i = 0; i < 2; ++i)
+    {
+        siv[static_cast<size_t>(i)] = 0.1f;
+        cev[static_cast<size_t>(i)] = 0.2f;
+    }
+    for(int i = 0; i < 20; ++i)
+    {
+        dyy[static_cast<size_t>(i)] = 0.05f * static_cast<float>(i + 1);
+    }
+    r.bind_data(si, siv);
+    r.bind_data(co, cev);
+    r.bind_data(dy, dyy);
+    r.bind_data(dx, dxx);
+    r.execute();
+    r.wait();
     const auto gout = r.get_output<float>(dx);
-    nntile::core::Tile<fp32_t> Si(sh), Co(sh), DY(tsh), DX(tsh);
+    nntile::core::Tile<fp32_t> Si(stor_sh), Co(stor_sh), DY(stor_tsh), DX(stor_tsh);
     using Y = typename fp32_t::repr_t;
-    { auto a=Si.acquire(STARPU_W),b=Co.acquire(STARPU_W);
-      for(int i=0;i<2;++i){a[i]=Y(0.1f);b[i]=Y(0.2f);} a.release(); b.release(); }
-    { auto c=DY.acquire(STARPU_W);
-      for(int i=0;i<20;++i) c[i]=Y(0.05f*static_cast<float>(i+1)); c.release(); }
-    { auto d=DX.acquire(STARPU_W);
-      for(int i=0;i<20;++i) d[i]=Y(0.01f);
-      d.release(); }
+    {
+        auto a = Si.acquire(STARPU_W);
+        auto b = Co.acquire(STARPU_W);
+        for(int i = 0; i < 2; ++i)
+        {
+            a[i] = Y(0.1f);
+            b[i] = Y(0.2f);
+        }
+        a.release();
+        b.release();
+    }
+    {
+        auto c = DY.acquire(STARPU_W);
+        for(int i = 0; i < 20; ++i)
+        {
+            c[i] = Y(0.05f * static_cast<float>(i + 1));
+        }
+        c.release();
+    }
+    {
+        auto d = DX.acquire(STARPU_W);
+        for(int i = 0; i < 20; ++i)
+        {
+            d[i] = Y(0.01f);
+        }
+        d.release();
+    }
     nntile::core::rope_backward<fp32_t>(-1, Si, Co, DY, DX);
     starpu_task_wait_for_all();
     std::vector<float> tr(20);
-    { auto L=DX.acquire(STARPU_R);
-      for(int i=0;i<20;++i) tr[static_cast<size_t>(i)]=static_cast<float>(L[i]);
-      L.release(); }
-    for(int i=0;i<20;++i) REQUIRE(std::abs(gout[static_cast<size_t>(i)]-tr[static_cast<size_t>(i)])<1e+2f);
+    {
+        auto L = DX.acquire(STARPU_R);
+        for(int i = 0; i < 20; ++i)
+        {
+            tr[static_cast<size_t>(i)] = static_cast<float>(L[i]);
+        }
+        L.release();
+    }
+    for(int i = 0; i < 20; ++i)
+    {
+        REQUIRE(std::abs(gout[static_cast<size_t>(i)] - tr[static_cast<size_t>(i)]) < 1e+2f);
+    }
 }

--- a/nntile/tests/tile/ops/rope_backward.cc
+++ b/nntile/tests/tile/ops/rope_backward.cc
@@ -99,6 +99,6 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph rope_backward", "[grap
     }
     for(int i = 0; i < 20; ++i)
     {
-        REQUIRE(std::abs(gout[static_cast<size_t>(i)] - tr[static_cast<size_t>(i)]) < 1e+2f);
+        REQUIRE(std::abs(gout[static_cast<size_t>(i)] - tr[static_cast<size_t>(i)]) < 1e-6f);
     }
 }

--- a/nntile/tests/tile/ops/scale.cc
+++ b/nntile/tests/tile/ops/scale.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/scale.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,14 +24,16 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph scale matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     const Scalar alpha = 1.25;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
     tg::scale(alpha, s, d);
@@ -44,7 +47,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph scale matches tile", "
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh), td(sh);
+    nntile::core::Tile<fp32_t> ts(stor_sh), td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto a = ts.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/scale_fiber.cc
+++ b/nntile/tests/tile/ops/scale_fiber.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/scale_fiber.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,19 +24,23 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph scale_fiber", "[graph][tile]")
 {
-    const std::vector<Index> full = {3, 4, 5};
-    const std::vector<Index> fib = {5};
+    const std::vector<Index> stor_full = {3, 4, 5};
+    const std::vector<Index> graph_full = graph_shape(stor_full);
+    const std::vector<Index> stor_fib = {5};
+    const std::vector<Index> graph_fib = graph_shape(stor_fib);
     const Index n = 60, nf = 5;
     const Scalar a = 1.25;
-    const Index axis = 2, batch = 0;
+    const Index stor_axis = 2, batch = 0;
+    const Index g_axis = graph_axis(stor_axis, static_cast<Index>(stor_full.size()));
     TileGraph g("g");
-    auto* s = g.data(fib, "s", DataType::FP32);
-    auto* d = g.data(full, "d", DataType::FP32);
+    auto* s = g.data(graph_fib, "s", DataType::FP32);
+    auto* d = g.data(graph_full, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
-    tg::scale_fiber(a, s, d, axis, batch);
+    tg::scale_fiber(a, s, d, g_axis, batch);
     Runtime rt(g);
     rt.compile();
     std::vector<float> f1(nf);
@@ -46,13 +51,13 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph scale_fiber", "[graph]
     rt.execute();
     rt.wait();
     const std::vector<float> gout = rt.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(fib), td(full);
+    nntile::core::Tile<fp32_t> ts(stor_fib), td(stor_full);
     using Y = typename nntile::fp32_t::repr_t;
     { auto A = ts.acquire(STARPU_W), B = td.acquire(STARPU_W);
       for(Index i = 0; i < nf; ++i) A[i] = Y(f1[static_cast<size_t>(i)]);
       for(Index i = 0; i < n; ++i) B[i] = Y(0);
       A.release(); B.release(); }
-    nntile::core::scale_fiber<fp32_t>(-1, a, ts, td, axis, batch);
+    nntile::core::scale_fiber<fp32_t>(-1, a, ts, td, stor_axis, batch);
     starpu_task_wait_for_all();
     std::vector<float> tref(n);
     { auto L = td.acquire(STARPU_R);

--- a/nntile/tests/tile/ops/scale_inplace.cc
+++ b/nntile/tests/tile/ops/scale_inplace.cc
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <numeric>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/scale_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -24,13 +25,15 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph scale_inplace matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     const Scalar alpha = 1.5;
     TileGraph g("g");
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     d->mark_input(true);
     d->mark_output(true);
     tg::scale_inplace(alpha, d);
@@ -42,7 +45,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph scale_inplace matches 
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> td(sh);
+    nntile::core::Tile<fp32_t> td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = td.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/scale_slice.cc
+++ b/nntile/tests/tile/ops/scale_slice.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/scale_slice.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,18 +24,24 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph scale_slice", "[graph][tile]")
 {
-    const std::vector<Index> t1s = {3, 5}, t2s = {3, 4, 5};
+    const std::vector<Index> stor_t1s = {3, 5};
+    const std::vector<Index> graph_t1s = graph_shape(stor_t1s);
+    const std::vector<Index> stor_t2s = {3, 4, 5};
+    const std::vector<Index> graph_t2s = graph_shape(stor_t2s);
     const Index n1 = 15, n2 = 60;
     const Scalar a = 0.75;
-    const Index axis = 1;
+    const Index stor_axis = 1;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_t2s.size()));
     TileGraph g("g");
-    auto* t1 = g.data(t1s, "t1", DataType::FP32);
-    auto* t2 = g.data(t2s, "t2", DataType::FP32);
+    auto* t1 = g.data(graph_t1s, "t1", DataType::FP32);
+    auto* t2 = g.data(graph_t2s, "t2", DataType::FP32);
     t1->mark_input(true);
     t2->mark_output(true);
-    tg::scale_slice(a, t1, t2, axis);
+    tg::scale_slice(a, t1, t2, g_axis);
     Runtime rt(g);
     rt.compile();
     std::vector<float> v1(n1), v2(n2, 0.f);
@@ -44,13 +51,13 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph scale_slice", "[graph]
     rt.execute();
     rt.wait();
     const std::vector<float> gout = rt.get_output<float>(t2);
-    nntile::core::Tile<fp32_t> T1(t1s), T2(t2s);
+    nntile::core::Tile<fp32_t> T1(stor_t1s), T2(stor_t2s);
     using Y = typename nntile::fp32_t::repr_t;
     { auto A = T1.acquire(STARPU_W), B = T2.acquire(STARPU_W);
       for(Index i = 0; i < n1; ++i) A[i] = Y(v1[static_cast<size_t>(i)]);
       for(Index i = 0; i < n2; ++i) B[i] = Y(0);
       A.release(); B.release(); }
-    nntile::core::scale_slice<fp32_t>(-1, a, T1, T2, axis);
+    nntile::core::scale_slice<fp32_t>(-1, a, T1, T2, stor_axis);
     starpu_task_wait_for_all();
     std::vector<float> tref(60);
     { auto L = T2.acquire(STARPU_R);

--- a/nntile/tests/tile/ops/sgd_step.cc
+++ b/nntile/tests/tile/ops/sgd_step.cc
@@ -13,6 +13,7 @@
  * */
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "mixed_tile_common.hh"
 
 #include <catch2/catch_test_macros.hpp>

--- a/nntile/tests/tile/ops/silu.cc
+++ b/nntile/tests/tile/ops/silu.cc
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <numeric>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/silu.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -24,13 +25,15 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph silu matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
     tg::silu(s, d);
@@ -44,7 +47,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph silu matches tile", "[
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh), td(sh);
+    nntile::core::Tile<fp32_t> ts(stor_sh), td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = ts.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/silu_backward.cc
+++ b/nntile/tests/tile/ops/silu_backward.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/silu_backward.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,14 +24,16 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph silu_backward matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* x = g.data(sh, "x", DataType::FP32);
-    auto* dy = g.data(sh, "dy", DataType::FP32);
-    auto* dx = g.data(sh, "dx", DataType::FP32);
+    auto* x = g.data(graph_sh, "x", DataType::FP32);
+    auto* dy = g.data(graph_sh, "dy", DataType::FP32);
+    auto* dx = g.data(graph_sh, "dx", DataType::FP32);
     x->mark_input(true);
     dy->mark_input(true);
     dx->mark_input(true);
@@ -50,7 +53,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph silu_backward matches 
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(dx);
-    nntile::core::Tile<fp32_t> tx(sh), tdy(sh), tdx(sh);
+    nntile::core::Tile<fp32_t> tx(stor_sh), tdy(stor_sh), tdx(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = tx.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/silu_inplace.cc
+++ b/nntile/tests/tile/ops/silu_inplace.cc
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <numeric>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/silu_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -24,12 +25,14 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph silu_inplace matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     d->mark_input(true);
     d->mark_output(true);
     tg::silu_inplace(d);
@@ -41,7 +44,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph silu_inplace matches t
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> td(sh);
+    nntile::core::Tile<fp32_t> td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = td.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/softmax.cc
+++ b/nntile/tests/tile/ops/softmax.cc
@@ -3,9 +3,6 @@
  *                 2023-present Artificial Intelligence Research Institute
  *                              (AIRI), Russia. All rights reserved.
  *
- * NNTile is software framework for fast training of big neural networks on
- * distributed-memory heterogeneous systems based on StarPU runtime system.
- *
  * @file nntile/tests/tile_graph/softmax.cc
  * Test TileGraph softmax vs nntile::core (parity).
  *
@@ -15,40 +12,87 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/softmax.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/softmax.hh"
 #include "nntile/core/tile.hh"
-using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile;
+using namespace nntile;
+namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph softmax axis0", "[graph][tile]")
 {
-    const std::vector<Index> mh = {2,4,5}, sh = {3,4,5};
+    const std::vector<Index> stor_mh = {2, 4, 5};
+    const std::vector<Index> graph_mh = graph_shape(stor_mh);
+    const std::vector<Index> stor_sh = {3, 4, 5};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nms = 40, n = 60;
-    const Scalar al = 1.0; const Index axis = 0;
+    const Scalar al = 1.0;
+    const Index stor_axis = 0;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_sh.size()));
     TileGraph g("g");
-    auto* m = g.data(mh, "m", DataType::FP32);
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(sh, "d", DataType::FP32);
-    m->mark_input(true); s->mark_input(true); d->mark_output(true);
-    tg::softmax(m, s, al, d, axis);
+    auto* m = g.data(graph_mh, "m", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
+    m->mark_input(true);
+    s->mark_input(true);
+    d->mark_output(true);
+    tg::softmax(m, s, al, d, g_axis);
     Runtime r(g);
     r.compile();
     std::vector<float> mv(nms), sv(n), dv(n, 0.f);
-    for(Index j=0;j<nms;j+=2) { mv[static_cast<size_t>(j)]=static_cast<float>(j+1);
-      mv[static_cast<size_t>(j+1)]=std::exp(static_cast<float>(j+2)/10.f); }
-    for(Index i=0;i<n;++i) sv[static_cast<size_t>(i)]=0.01f*static_cast<float>(i+1);
-    r.bind_data(m, mv); r.bind_data(s, sv); r.bind_data(d, dv);
-    r.execute(); r.wait();
+    for(Index j = 0; j < nms; j += 2)
+    {
+        mv[static_cast<size_t>(j)] = static_cast<float>(j + 1);
+        mv[static_cast<size_t>(j + 1)] =
+            std::exp(static_cast<float>(j + 2) / 10.f);
+    }
+    for(Index i = 0; i < n; ++i)
+    {
+        sv[static_cast<size_t>(i)] = 0.01f * static_cast<float>(i + 1);
+    }
+    r.bind_data(m, mv);
+    r.bind_data(s, sv);
+    r.bind_data(d, dv);
+    r.execute();
+    r.wait();
     const auto gout = r.get_output<float>(d);
-    nntile::core::Tile<fp32_t> M(mh), S(sh), D(sh);
+    nntile::core::Tile<fp32_t> M(stor_mh), S(stor_sh), D(stor_sh);
     using Y = typename fp32_t::repr_t;
-    { auto a=M.acquire(STARPU_W), b=S.acquire(STARPU_W), c=D.acquire(STARPU_W);
-      for(Index j=0;j<nms;j+=2) { a[j]=Y(mv[static_cast<size_t>(j)]); a[j+1]=Y(mv[static_cast<size_t>(j+1)]);}
-      for(Index i=0;i<n;++i) { b[i]=Y(0.01f*static_cast<float>(i+1)); c[i]=Y(0);} a.release(); b.release(); c.release(); }
-    nntile::core::softmax<fp32_t>(-1, M, S, al, D, axis);
+    {
+        auto a = M.acquire(STARPU_W);
+        auto b = S.acquire(STARPU_W);
+        auto c = D.acquire(STARPU_W);
+        for(Index j = 0; j < nms; j += 2)
+        {
+            a[j] = Y(mv[static_cast<size_t>(j)]);
+            a[j + 1] = Y(mv[static_cast<size_t>(j + 1)]);
+        }
+        for(Index i = 0; i < n; ++i)
+        {
+            b[i] = Y(0.01f * static_cast<float>(i + 1));
+            c[i] = Y(0);
+        }
+        a.release();
+        b.release();
+        c.release();
+    }
+    nntile::core::softmax<fp32_t>(-1, M, S, al, D, stor_axis);
     starpu_task_wait_for_all();
     std::vector<float> tr(n);
-    { auto L=D.acquire(STARPU_R); for(Index i=0;i<n;++i) tr[static_cast<size_t>(i)]=static_cast<float>(L[i]); L.release(); }
-    for(size_t i=0;i<tr.size();++i) REQUIRE(std::abs(gout[i]-tr[i])<1e+2f);
+    {
+        auto L = D.acquire(STARPU_R);
+        for(Index i = 0; i < n; ++i)
+        {
+            tr[static_cast<size_t>(i)] = static_cast<float>(L[i]);
+        }
+        L.release();
+    }
+    for(size_t i = 0; i < tr.size(); ++i)
+    {
+        REQUIRE(std::abs(gout[i] - tr[i]) < 1e+2f);
+    }
 }

--- a/nntile/tests/tile/ops/softmax.cc
+++ b/nntile/tests/tile/ops/softmax.cc
@@ -93,6 +93,6 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph softmax axis0", "[grap
     }
     for(size_t i = 0; i < tr.size(); ++i)
     {
-        REQUIRE(std::abs(gout[i] - tr[i]) < 1e+2f);
+        REQUIRE(std::abs(gout[i] - tr[i]) < 1e-6f);
     }
 }

--- a/nntile/tests/tile/ops/softmax_inplace.cc
+++ b/nntile/tests/tile/ops/softmax_inplace.cc
@@ -88,6 +88,6 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph softmax_inplace axis0"
     }
     for(size_t i = 0; i < tr.size(); ++i)
     {
-        REQUIRE(std::abs(gout[i] - tr[i]) < 1e+2f);
+        REQUIRE(std::abs(gout[i] - tr[i]) < 1e-6f);
     }
 }

--- a/nntile/tests/tile/ops/softmax_inplace.cc
+++ b/nntile/tests/tile/ops/softmax_inplace.cc
@@ -3,9 +3,6 @@
  *                 2023-present Artificial Intelligence Research Institute
  *                              (AIRI), Russia. All rights reserved.
  *
- * NNTile is software framework for fast training of big neural networks on
- * distributed-memory heterogeneous systems based on StarPU runtime system.
- *
  * @file nntile/tests/tile_graph/softmax_inplace.cc
  * Test TileGraph softmax inplace vs nntile::core (parity).
  *
@@ -15,39 +12,82 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/softmax_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/softmax_inplace.hh"
 #include "nntile/core/tile.hh"
-using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile;
+using namespace nntile;
+namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph softmax_inplace axis0", "[graph][tile]")
 {
-    const std::vector<Index> mh = {2,4,5}, dh = {3,4,5};
-    const Index nms=40, n=60; const Scalar al=1.0; const Index axis=0;
+    const std::vector<Index> stor_mh = {2, 4, 5};
+    const std::vector<Index> graph_mh = graph_shape(stor_mh);
+    const std::vector<Index> stor_dh = {3, 4, 5};
+    const std::vector<Index> graph_dh = graph_shape(stor_dh);
+    const Index nms = 40, n = 60;
+    const Scalar al = 1.0;
+    const Index stor_axis = 0;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_dh.size()));
     TileGraph g("g");
-    auto* m = g.data(mh, "m", DataType::FP32);
-    auto* d = g.data(dh, "d", DataType::FP32);
-    m->mark_input(true); d->mark_input(true); d->mark_output(true);
-    tg::softmax_inplace(m, al, d, axis);
+    auto* m = g.data(graph_mh, "m", DataType::FP32);
+    auto* d = g.data(graph_dh, "d", DataType::FP32);
+    m->mark_input(true);
+    d->mark_input(true);
+    d->mark_output(true);
+    tg::softmax_inplace(m, al, d, g_axis);
     Runtime r(g);
     r.compile();
     std::vector<float> mv(nms), dd(n);
-    for(Index j=0;j<nms;j+=2){ mv[static_cast<size_t>(j)]=static_cast<float>(j+1);
-      mv[static_cast<size_t>(j+1)]=std::exp(static_cast<float>(j+2)/10.f);}
-    for(Index i=0;i<n;++i) dd[static_cast<size_t>(i)]=static_cast<float>(i+1);
-    r.bind_data(m, mv); r.bind_data(d, dd);
-    r.execute(); r.wait();
+    for(Index j = 0; j < nms; j += 2)
+    {
+        mv[static_cast<size_t>(j)] = static_cast<float>(j + 1);
+        mv[static_cast<size_t>(j + 1)] =
+            std::exp(static_cast<float>(j + 2) / 10.f);
+    }
+    for(Index i = 0; i < n; ++i)
+    {
+        dd[static_cast<size_t>(i)] = static_cast<float>(i + 1);
+    }
+    r.bind_data(m, mv);
+    r.bind_data(d, dd);
+    r.execute();
+    r.wait();
     const auto gout = r.get_output<float>(d);
-    nntile::core::Tile<fp32_t> M(mh), D(dh);
+    nntile::core::Tile<fp32_t> M(stor_mh), D(stor_dh);
     using Y = typename fp32_t::repr_t;
-    { auto a=M.acquire(STARPU_W),c=D.acquire(STARPU_W);
-      for(Index j=0;j<nms;j+=2) {a[j]=Y(mv[static_cast<size_t>(j)]); a[j+1]=Y(mv[static_cast<size_t>(j+1)]);}
-      for(Index i=0;i<n;++i) c[i]=Y(static_cast<float>(i+1));
-      a.release(); c.release(); }
-    nntile::core::softmax_inplace<fp32_t>(-1, M, al, D, axis);
+    {
+        auto a = M.acquire(STARPU_W);
+        auto c = D.acquire(STARPU_W);
+        for(Index j = 0; j < nms; j += 2)
+        {
+            a[j] = Y(mv[static_cast<size_t>(j)]);
+            a[j + 1] = Y(mv[static_cast<size_t>(j + 1)]);
+        }
+        for(Index i = 0; i < n; ++i)
+        {
+            c[i] = Y(static_cast<float>(i + 1));
+        }
+        a.release();
+        c.release();
+    }
+    nntile::core::softmax_inplace<fp32_t>(-1, M, al, D, stor_axis);
     starpu_task_wait_for_all();
     std::vector<float> tr(n);
-    { auto L=D.acquire(STARPU_R); for(Index i=0;i<n;++i) tr[static_cast<size_t>(i)]=static_cast<float>(L[i]); L.release(); }
-    for(size_t i=0;i<tr.size();++i) REQUIRE(std::abs(gout[i]-tr[i])<1e+2f);
+    {
+        auto L = D.acquire(STARPU_R);
+        for(Index i = 0; i < n; ++i)
+        {
+            tr[static_cast<size_t>(i)] = static_cast<float>(L[i]);
+        }
+        L.release();
+    }
+    for(size_t i = 0; i < tr.size(); ++i)
+    {
+        REQUIRE(std::abs(gout[i] - tr[i]) < 1e+2f);
+    }
 }

--- a/nntile/tests/tile/ops/sqrt.cc
+++ b/nntile/tests/tile/ops/sqrt.cc
@@ -13,6 +13,7 @@
  * */
 
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "mixed_tile_common.hh"
 
 #include <catch2/catch_test_macros.hpp>

--- a/nntile/tests/tile/ops/sqrt_inplace.cc
+++ b/nntile/tests/tile/ops/sqrt_inplace.cc
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <numeric>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/sqrt_inplace.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -24,12 +25,14 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sqrt_inplace matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3};
+    const std::vector<Index> stor_sh = {2, 3};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 6;
     TileGraph g("g");
-    auto* d = g.data(sh, "d", DataType::FP32);
+    auto* d = g.data(graph_sh, "d", DataType::FP32);
     d->mark_input(true);
     d->mark_output(true);
     tg::sqrt_inplace(d);
@@ -41,7 +44,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sqrt_inplace matches t
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> td(sh);
+    nntile::core::Tile<fp32_t> td(stor_sh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto l1 = td.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/subtract_indexed_outputs.cc
+++ b/nntile/tests/tile/ops/subtract_indexed_outputs.cc
@@ -3,9 +3,6 @@
  *                 2023-present Artificial Intelligence Research Institute
  *                              (AIRI), Russia. All rights reserved.
  *
- * NNTile is software framework for fast training of big neural networks on
- * distributed-memory heterogeneous systems based on StarPU runtime system.
- *
  * @file nntile/tests/tile_graph/subtract_indexed_outputs.cc
  * Test TileGraph subtract indexed outputs vs nntile::core (parity).
  *
@@ -14,21 +11,28 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/subtract_indexed_outputs.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/subtract_indexed_outputs.hh"
 #include "nntile/core/tile.hh"
-using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile;
+using namespace nntile;
+namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph subtract_indexed_outputs", "[graph][tile]")
 {
-    const std::vector<Index> lh = {2,2}, dh = {3,2,2};
-    const Index nl = 4, nd = 3*2*2;
+    const std::vector<Index> stor_lh = {2, 2};
+    const std::vector<Index> graph_lh = graph_shape(stor_lh);
+    const std::vector<Index> stor_dh = {3, 2, 2};
+    const std::vector<Index> graph_dh = graph_shape(stor_dh);
+    const Index nl = 4, nd = 3 * 2 * 2;
     const Scalar v = 0.5;
     const Index ign = -1;
     TileGraph g("g");
-    auto* lab = g.data(lh, "labels", DataType::INT64);
-    auto* d = g.data(dh, "d", DataType::FP32);
+    auto* lab = g.data(graph_lh, "labels", DataType::INT64);
+    auto* d = g.data(graph_dh, "d", DataType::FP32);
     lab->mark_input(true);
     d->mark_input(true);
     d->mark_output(true);
@@ -36,27 +40,52 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph subtract_indexed_outpu
     Runtime r(g);
     r.compile();
     std::vector<std::int64_t> lv(4);
-    lv[0]=0; lv[1]=1; lv[2]=2; lv[3]=0;
+    lv[0] = 0;
+    lv[1] = 1;
+    lv[2] = 2;
+    lv[3] = 0;
     std::vector<float> dv(nd);
-    for(Index i=0;i<nd;++i) dv[static_cast<size_t>(i)]=1.0f+0.1f*static_cast<float>(i);
+    for(Index i = 0; i < nd; ++i)
+    {
+        dv[static_cast<size_t>(i)] = 1.0f + 0.1f * static_cast<float>(i);
+    }
     r.bind_data(lab, lv);
     r.bind_data(d, dv);
     r.execute();
     r.wait();
     const auto gout = r.get_output<float>(d);
-    nntile::core::Tile<nntile::int64_t> L(lh);
-    nntile::core::Tile<fp32_t> D(dh);
+    nntile::core::Tile<nntile::int64_t> L(stor_lh);
+    nntile::core::Tile<fp32_t> D(stor_dh);
     using Y = typename fp32_t::repr_t;
-    { auto a=L.acquire(STARPU_W);
-      a[0]=0; a[1]=1; a[2]=2; a[3]=0; a.release(); }
-    { auto b=D.acquire(STARPU_W);
-      for(Index i=0;i<nd;++i) b[i]=Y(1.0f+0.1f*static_cast<float>(i));
-      b.release(); }
+    {
+        auto a = L.acquire(STARPU_W);
+        a[0] = 0;
+        a[1] = 1;
+        a[2] = 2;
+        a[3] = 0;
+        a.release();
+    }
+    {
+        auto b = D.acquire(STARPU_W);
+        for(Index i = 0; i < nd; ++i)
+        {
+            b[i] = Y(1.0f + 0.1f * static_cast<float>(i));
+        }
+        b.release();
+    }
     nntile::core::subtract_indexed_outputs<fp32_t>(-1, v, L, D, ign);
     starpu_task_wait_for_all();
     std::vector<float> tr(nd);
-    { auto L2=D.acquire(STARPU_R);
-      for(Index i=0;i<nd;++i) tr[static_cast<size_t>(i)]=static_cast<float>(L2[i]);
-      L2.release(); }
-    for(size_t i=0;i<nd;++i) REQUIRE(std::abs(gout[i]-tr[i])<1e-4f);
+    {
+        auto L2 = D.acquire(STARPU_R);
+        for(Index i = 0; i < nd; ++i)
+        {
+            tr[static_cast<size_t>(i)] = static_cast<float>(L2[i]);
+        }
+        L2.release();
+    }
+    for(size_t i = 0; i < nd; ++i)
+    {
+        REQUIRE(std::abs(gout[i] - tr[i]) < 1e-4f);
+    }
 }

--- a/nntile/tests/tile/ops/sum.cc
+++ b/nntile/tests/tile/ops/sum.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/sum.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,12 +24,14 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sum matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sh = {2, 3, 4};
+    const std::vector<Index> stor_sh = {2, 3, 4};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
     const Index nelems = 2 * 3 * 4;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
     auto* d = g.data(std::vector<Index>{}, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
@@ -45,7 +48,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sum matches tile", "[g
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh);
+    nntile::core::Tile<fp32_t> ts(stor_sh);
     nntile::core::Tile<fp32_t> td(std::vector<Index>{});
     using Y = typename nntile::fp32_t::repr_t;
     {

--- a/nntile/tests/tile/ops/sum_fiber.cc
+++ b/nntile/tests/tile/ops/sum_fiber.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/sum_fiber.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,19 +24,23 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sum_fiber matches tile (axis=0)", "[graph][tile]")
 {
-    const std::vector<Index> sh = {3, 4, 5};
-    const std::vector<Index> dh = {3};
+    const std::vector<Index> stor_sh = {3, 4, 5};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
+    const std::vector<Index> stor_dh = {3};
+    const std::vector<Index> graph_dh = graph_shape(stor_dh);
     const Index nelems = 3 * 4 * 5;
     const Scalar alpha = 1.0, beta = 0.0;
-    const Index axis = 0, batch_ndim = 0, redux = 0;
+    const Index stor_axis = 0, batch_ndim = 0, redux = 0;
+    const Index g_axis = graph_axis(stor_axis, static_cast<Index>(stor_sh.size()));
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(dh, "d", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_dh, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
-    tg::sum_fiber(alpha, s, beta, d, axis, batch_ndim, redux);
+    tg::sum_fiber(alpha, s, beta, d, g_axis, batch_ndim, redux);
     Runtime runtime(g);
     runtime.compile();
     std::vector<float> sv(nelems);
@@ -46,7 +51,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sum_fiber matches tile
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh), td(dh);
+    nntile::core::Tile<fp32_t> ts(stor_sh), td(stor_dh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto a = ts.acquire(STARPU_W);
@@ -56,7 +61,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sum_fiber matches tile
         a.release();
         b.release();
     }
-    nntile::core::sum_fiber<fp32_t>(-1, alpha, ts, beta, td, axis, batch_ndim, redux);
+    nntile::core::sum_fiber<fp32_t>(-1, alpha, ts, beta, td, stor_axis, batch_ndim, redux);
     starpu_task_wait_for_all();
     std::vector<float> tref(3);
     {

--- a/nntile/tests/tile/ops/sum_slice.cc
+++ b/nntile/tests/tile/ops/sum_slice.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/sum_slice.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,20 +24,24 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sum_slice (axis=0)", "[graph][tile]")
 {
-    const std::vector<Index> sh = {3, 4, 5};
-    const std::vector<Index> dh = {4, 5};
+    const std::vector<Index> stor_sh = {3, 4, 5};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
+    const std::vector<Index> stor_dh = {4, 5};
+    const std::vector<Index> graph_dh = graph_shape(stor_dh);
     const Index nelems = 60, nd = 4 * 5;
     const Scalar a = 1.0, b = 0.0;
-    const Index axis = 0;
+    const Index stor_axis = 0;
+    const Index g_axis = graph_axis(stor_axis, static_cast<Index>(stor_sh.size()));
     const int redux = 0;
     TileGraph g("g");
-    auto* s = g.data(sh, "s", DataType::FP32);
-    auto* d = g.data(dh, "d", DataType::FP32);
+    auto* s = g.data(graph_sh, "s", DataType::FP32);
+    auto* d = g.data(graph_dh, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
-    tg::sum_slice(a, s, b, d, axis, redux);
+    tg::sum_slice(a, s, b, d, g_axis, redux);
     Runtime runtime(g);
     runtime.compile();
     std::vector<float> sv(nelems);
@@ -47,7 +52,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sum_slice (axis=0)", "
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sh), td(dh);
+    nntile::core::Tile<fp32_t> ts(stor_sh), td(stor_dh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto A = ts.acquire(STARPU_W);
@@ -57,7 +62,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sum_slice (axis=0)", "
         A.release();
         B.release();
     }
-    nntile::core::sum_slice<fp32_t>(-1, a, ts, b, td, axis, redux);
+    nntile::core::sum_slice<fp32_t>(-1, a, ts, b, td, stor_axis, redux);
     starpu_task_wait_for_all();
     std::vector<float> tref(nd);
     {

--- a/nntile/tests/tile/ops/sumprod_fiber.cc
+++ b/nntile/tests/tile/ops/sumprod_fiber.cc
@@ -82,5 +82,5 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sumprod_fiber (axis=0)
         for(Index j = 0; j < 3; ++j) { tref[static_cast<size_t>(j)] = static_cast<float>(L[j]); }
         L.release();
     }
-    for(size_t j = 0; j < 3; ++j) { REQUIRE(std::abs(gout[j] - tref[j]) < 1e+2f); }
+    for(size_t j = 0; j < 3; ++j) { REQUIRE(std::abs(gout[j] - tref[j]) < 1e-6f); }
 }

--- a/nntile/tests/tile/ops/sumprod_fiber.cc
+++ b/nntile/tests/tile/ops/sumprod_fiber.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/sumprod_fiber.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,22 +24,26 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sumprod_fiber (axis=0)", "[graph][tile]")
 {
-    const std::vector<Index> sh = {3, 4, 5};
-    const std::vector<Index> dh = {3};
+    const std::vector<Index> stor_sh = {3, 4, 5};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
+    const std::vector<Index> stor_dh = {3};
+    const std::vector<Index> graph_dh = graph_shape(stor_dh);
     const Index n = 60;
     const Scalar a = 1.0, b = 0.0;
-    const Index axis = 0;
+    const Index stor_axis = 0;
+    const Index g_axis = graph_axis(stor_axis, static_cast<Index>(stor_sh.size()));
     const int redux = 0;
     TileGraph g("g");
-    auto* s1 = g.data(sh, "s1", DataType::FP32);
-    auto* s2 = g.data(sh, "s2", DataType::FP32);
-    auto* d = g.data(dh, "d", DataType::FP32);
+    auto* s1 = g.data(graph_sh, "s1", DataType::FP32);
+    auto* s2 = g.data(graph_sh, "s2", DataType::FP32);
+    auto* d = g.data(graph_dh, "d", DataType::FP32);
     s1->mark_input(true);
     s2->mark_input(true);
     d->mark_output(true);
-    tg::sumprod_fiber(a, s1, s2, b, d, axis, redux);
+    tg::sumprod_fiber(a, s1, s2, b, d, g_axis, redux);
     Runtime runtime(g);
     runtime.compile();
     std::vector<float> v1(n), v2(n), dd(3, 0.f);
@@ -53,7 +58,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sumprod_fiber (axis=0)
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> t1(sh), t2(sh), td(dh);
+    nntile::core::Tile<fp32_t> t1(stor_sh), t2(stor_sh), td(stor_dh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto A = t1.acquire(STARPU_W);
@@ -69,7 +74,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sumprod_fiber (axis=0)
         B.release();
         C.release();
     }
-    nntile::core::sumprod_fiber<fp32_t>(-1, a, t1, t2, b, td, axis, redux);
+    nntile::core::sumprod_fiber<fp32_t>(-1, a, t1, t2, b, td, stor_axis, redux);
     starpu_task_wait_for_all();
     std::vector<float> tref(3);
     {

--- a/nntile/tests/tile/ops/sumprod_slice.cc
+++ b/nntile/tests/tile/ops/sumprod_slice.cc
@@ -83,5 +83,5 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sumprod_slice (axis=0)
         for(Index j = 0; j < nd; ++j) { tref[static_cast<size_t>(j)] = static_cast<float>(L[j]); }
         L.release();
     }
-    for(size_t j = 0; j < tref.size(); ++j) { REQUIRE(std::abs(gout[j] - tref[j]) < 1e+2f); }
+    for(size_t j = 0; j < tref.size(); ++j) { REQUIRE(std::abs(gout[j] - tref[j]) < 1e-6f); }
 }

--- a/nntile/tests/tile/ops/sumprod_slice.cc
+++ b/nntile/tests/tile/ops/sumprod_slice.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/sumprod_slice.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,22 +24,27 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sumprod_slice (axis=0)", "[graph][tile]")
 {
-    const std::vector<Index> sh = {3, 4, 5};
-    const std::vector<Index> dh = {4, 5};
+    const std::vector<Index> stor_sh = {3, 4, 5};
+    const std::vector<Index> graph_sh = graph_shape(stor_sh);
+    const std::vector<Index> stor_dh = {4, 5};
+    const std::vector<Index> graph_dh = graph_shape(stor_dh);
     const Index n = 60, nd = 4 * 5;
     const Scalar a = 1.0, b = 0.0;
-    const Index ax = 0;
+    const Index stor_axis = 0;
+    const Index g_axis =
+        graph_axis(stor_axis, static_cast<Index>(stor_sh.size()));
     const int redux = 0;
     TileGraph g("g");
-    auto* s1 = g.data(sh, "s1", DataType::FP32);
-    auto* s2 = g.data(sh, "s2", DataType::FP32);
-    auto* d = g.data(dh, "d", DataType::FP32);
+    auto* s1 = g.data(graph_sh, "s1", DataType::FP32);
+    auto* s2 = g.data(graph_sh, "s2", DataType::FP32);
+    auto* d = g.data(graph_dh, "d", DataType::FP32);
     s1->mark_input(true);
     s2->mark_input(true);
     d->mark_output(true);
-    tg::sumprod_slice(a, s1, s2, b, d, ax, redux);
+    tg::sumprod_slice(a, s1, s2, b, d, g_axis, redux);
     Runtime runtime(g);
     runtime.compile();
     std::vector<float> v1(n), v2(n), dd(nd, 0.f);
@@ -53,7 +59,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sumprod_slice (axis=0)
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> t1(sh), t2(sh), td(dh);
+    nntile::core::Tile<fp32_t> t1(stor_sh), t2(stor_sh), td(stor_dh);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto A = t1.acquire(STARPU_W);
@@ -69,7 +75,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph sumprod_slice (axis=0)
         B.release();
         C.release();
     }
-    nntile::core::sumprod_slice<fp32_t>(-1, a, t1, t2, b, td, ax, redux);
+    nntile::core::sumprod_slice<fp32_t>(-1, a, t1, t2, b, td, stor_axis, redux);
     starpu_task_wait_for_all();
     std::vector<float> tref(nd);
     {

--- a/nntile/tests/tile/ops/total_sum_accum.cc
+++ b/nntile/tests/tile/ops/total_sum_accum.cc
@@ -14,20 +14,28 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/total_sum_accum.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
 #include "nntile/core/total_sum_accum.hh"
 #include "nntile/core/tile.hh"
 using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph total_sum_accum", "[graph][tile]")
 {
-    const std::vector<Index> leh = {2,2}, srh = {3,2,2}, clh = {2,2}, vh = std::vector<Index>{};
+    const std::vector<Index> stor_leh = {2, 2};
+    const std::vector<Index> graph_leh = graph_shape(stor_leh);
+    const std::vector<Index> stor_srh = {3, 2, 2};
+    const std::vector<Index> graph_srh = graph_shape(stor_srh);
+    const std::vector<Index> stor_clh = {2, 2};
+    const std::vector<Index> graph_clh = graph_shape(stor_clh);
+    const std::vector<Index> vh = std::vector<Index>{};
     const Scalar a = 1.0; const Index ign = -1;
     TileGraph g("g");
-    auto* l = g.data(leh, "lse", DataType::FP32);
-    auto* s = g.data(srh, "src", DataType::FP32);
-    auto* c = g.data(clh, "cl", DataType::INT64);
+    auto* l = g.data(graph_leh, "lse", DataType::FP32);
+    auto* s = g.data(graph_srh, "src", DataType::FP32);
+    auto* c = g.data(graph_clh, "cl", DataType::INT64);
     auto* v = g.data(vh, "val", DataType::FP32);
     l->mark_input(true); s->mark_input(true); c->mark_input(true); v->mark_input(true); v->mark_output(true);
     tg::total_sum_accum(a, l, s, c, v, ign);
@@ -45,8 +53,8 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph total_sum_accum", "[gr
     r.execute();
     r.wait();
     const auto gout = r.get_output<float>(v);
-    nntile::core::Tile<fp32_t> L(leh), S(srh), Vref(vh);
-    nntile::core::Tile<nntile::int64_t> C(clh);
+    nntile::core::Tile<fp32_t> L(stor_leh), S(stor_srh), Vref(vh);
+    nntile::core::Tile<nntile::int64_t> C(stor_clh);
     using Y = typename fp32_t::repr_t;
     { auto a1=L.acquire(STARPU_W),a2=S.acquire(STARPU_W);
       for(Index i=0;i<4;++i) a1[i]=Y(lse[static_cast<size_t>(i)]);

--- a/nntile/tests/tile/ops/transpose.cc
+++ b/nntile/tests/tile/ops/transpose.cc
@@ -15,6 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
 #include "context_fixture.hh"
+#include "tile_graph_shape_helpers.hh"
 #include "nntile/tile/ops/transpose.hh"
 #include "nntile/tile.hh"
 #include "nntile/tile.hh"
@@ -23,16 +24,19 @@
 using namespace nntile;
 using namespace nntile;
 namespace tg = nntile::tile;
+using namespace nntile::test::tile_graph_shapes;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph transpose matches tile", "[graph][tile]")
 {
-    const std::vector<Index> sshape = {3, 5};
-    const std::vector<Index> dshape = {5, 3};
+    const std::vector<Index> stor_sshape = {3, 5};
+    const std::vector<Index> graph_sshape = graph_shape(stor_sshape);
+    const std::vector<Index> stor_dshape = {5, 3};
+    const std::vector<Index> graph_dshape = graph_shape(stor_dshape);
     const Index nelems = 3 * 5;
     const Scalar alpha = 0.5;
     const Index ndim = 1;
     TileGraph g("g");
-    auto* s = g.data(sshape, "s", DataType::FP32);
-    auto* d = g.data(dshape, "d", DataType::FP32);
+    auto* s = g.data(graph_sshape, "s", DataType::FP32);
+    auto* d = g.data(graph_dshape, "d", DataType::FP32);
     s->mark_input(true);
     d->mark_output(true);
     tg::transpose(alpha, s, d, ndim);
@@ -46,7 +50,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph transpose matches tile
     runtime.execute();
     runtime.wait();
     const std::vector<float> gout = runtime.get_output<float>(d);
-    nntile::core::Tile<fp32_t> ts(sshape), td(dshape);
+    nntile::core::Tile<fp32_t> ts(stor_sshape), td(stor_dshape);
     using Y = typename nntile::fp32_t::repr_t;
     {
         auto a = ts.acquire(STARPU_W);

--- a/nntile/tests/tile/ops/transpose.cc
+++ b/nntile/tests/tile/ops/transpose.cc
@@ -72,3 +72,66 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph transpose matches tile
     REQUIRE(gout.size() == tref.size());
     for(size_t i = 0; i < tref.size(); ++i) { REQUIRE(std::abs(gout[i] - tref[i]) < tol); }
 }
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "TileGraph transpose ndim=2 on 4D",
+    "[graph][tile]")
+{
+    const std::vector<Index> stor_sshape = {2, 3, 4, 5};
+    const std::vector<Index> graph_sshape = graph_shape(stor_sshape);
+    const std::vector<Index> stor_dshape = {4, 5, 2, 3};
+    const std::vector<Index> graph_dshape = graph_shape(stor_dshape);
+    const Index nelems = 2 * 3 * 4 * 5;
+    const Scalar alpha = 1.0;
+    const Index graph_ndim = 2;
+    // Cyclic shift of leading graph axes on {5,4,3,2} -> {3,2,5,4}.
+    TileGraph g("g");
+    auto* s = g.data(graph_sshape, "s", DataType::FP32);
+    auto* d = g.data(graph_dshape, "d", DataType::FP32);
+    s->mark_input(true);
+    d->mark_output(true);
+    tg::transpose(alpha, s, d, graph_ndim);
+    Runtime runtime(g);
+    runtime.compile();
+    std::vector<float> sv(nelems);
+    for(Index i = 0; i < nelems; ++i)
+    {
+        sv[static_cast<size_t>(i)] = 0.01f * static_cast<float>(i + 1);
+    }
+    runtime.bind_data(s, sv);
+    std::vector<float> dv(nelems, 0.f);
+    runtime.bind_data(d, dv);
+    runtime.execute();
+    runtime.wait();
+    const std::vector<float> gout = runtime.get_output<float>(d);
+    nntile::core::Tile<fp32_t> ts(stor_sshape), td(stor_dshape);
+    using Y = typename nntile::fp32_t::repr_t;
+    {
+        auto a = ts.acquire(STARPU_W);
+        auto b = td.acquire(STARPU_W);
+        for(Index i = 0; i < nelems; ++i)
+        {
+            a[i] = Y(sv[static_cast<size_t>(i)]);
+            b[i] = Y(0);
+        }
+        a.release();
+        b.release();
+    }
+    const Index stor_ndim =
+        static_cast<Index>(stor_sshape.size()) - graph_ndim;
+    nntile::core::transpose<fp32_t>(-1, alpha, ts, td, stor_ndim);
+    starpu_task_wait_for_all();
+    std::vector<float> tref(nelems);
+    {
+        auto l2 = td.acquire(STARPU_R);
+        for(Index i = 0; i < nelems; ++i)
+        {
+            tref[static_cast<size_t>(i)] = static_cast<float>(l2[i]);
+        }
+        l2.release();
+    }
+    for(size_t i = 0; i < tref.size(); ++i)
+    {
+        REQUIRE(std::abs(gout[i] - tref[i]) < 1e-4f);
+    }
+}

--- a/nntile/tests/tile/tile_graph.cc
+++ b/nntile/tests/tile/tile_graph.cc
@@ -160,10 +160,10 @@ TEST_CASE("TileGraph from_tensor_graph structure")
     REQUIRE(ty->is_input());
     REQUIRE(tz->is_output());
 
-    // Tile payloads use storage-order shapes; graph tensor is {2, 3}.
-    REQUIRE(tx->shape() == std::vector<Index>{3, 2});
-    REQUIRE(ty->shape() == std::vector<Index>{3, 2});
-    REQUIRE(tz->shape() == std::vector<Index>{3, 2});
+    // Tile payloads use graph-order shapes (match tensor {2, 3}).
+    REQUIRE(tx->shape() == std::vector<Index>{2, 3});
+    REQUIRE(ty->shape() == std::vector<Index>{2, 3});
+    REQUIRE(tz->shape() == std::vector<Index>{2, 3});
 
     REQUIRE(tile_graph.ops()[0]->op_name() == "TILE_ADD");
 
@@ -172,7 +172,7 @@ TEST_CASE("TileGraph from_tensor_graph structure")
     REQUIRE(xd != nullptr);
     REQUIRE(xd->tensor_name == "x");
     REQUIRE(xd->tensor_shape == std::vector<Index>{2, 3});
-    REQUIRE(xd->tile_shape == std::vector<Index>{3, 2});
+    REQUIRE(xd->tile_shape == std::vector<Index>{2, 3});
     REQUIRE(xd->grid_shape == std::vector<Index>{1, 1});
     REQUIRE(xd->dtype == DataType::FP32);
     REQUIRE(xd->tiles.size() == 1);

--- a/nntile/tests/tile/tile_graph_shape_helpers.hh
+++ b/nntile/tests/tile/tile_graph_shape_helpers.hh
@@ -1,0 +1,42 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file nntile/tests/tile/tile_graph_shape_helpers.hh
+ * Helpers for TileGraph C-order vs core Fortran-order parity tests.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include <nntile/base_types.hh>
+#include <nntile/tensor/shape_layout.hh>
+
+#include <vector>
+
+namespace nntile::test::tile_graph_shapes
+{
+
+inline std::vector<Index> storage_shape(std::vector<Index> graph_shape)
+{
+    return nntile::tensor::graph_shape_to_storage(std::move(graph_shape));
+}
+
+inline std::vector<Index> graph_shape(std::vector<Index> storage_shape)
+{
+    return nntile::tensor::storage_shape_to_graph(std::move(storage_shape));
+}
+
+inline Index storage_axis(Index graph_axis, Index ndim)
+{
+    return nntile::tensor::graph_axis_to_storage(graph_axis, ndim);
+}
+
+inline Index graph_axis(Index storage_axis, Index ndim)
+{
+    return nntile::tensor::storage_axis_to_graph(storage_axis, ndim);
+}
+
+} // namespace nntile::test::tile_graph_shapes

--- a/python/nntile/_bindings/nntile.cc
+++ b/python/nntile/_bindings/nntile.cc
@@ -15,7 +15,7 @@
 #include <cstring>
 #include <memory>
 #include <nntile/context.hh>
-#include <nntile/core/execution_schedule.hh>
+#include <nntile/runtime.hh>
 #include <nntile/graph.hh>
 #include <nntile/nn/graph_ops.hh>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates the graph stack (`TensorGraph` / `NNGraph` / `TileGraph`) to **PyTorch-style C-order** shape labels at the public API, while keeping **Fortran storage** in `core::*`. Conversion happens at tile `execute()` and tensor `lower_to_tile` via `shape_layout.hh`.

### Shape conventions

| Layer | Convention |
|-------|------------|
| Graph API (`TensorNode::shape()`) | Outermost-first (C-order); `batch_ndim` = leading prefix `shape[0:batch_ndim)` |
| Fiber tensors | `[batch…, fiber_dim]` — batch leading, fiber extent last |
| Tile storage / `core::*` | Reversed labels; batch trailing at `shape[ndim-batch_ndim:ndim]` |

### Main changes

- **`TileNode::storage_shape()`** and `from_tensor_graph` emit graph-order tile shapes; storage allocation unchanged.
- **Axis-aware ops** take **graph axis indices** at tensor/tile API; `execute()` converts with `graph_axis_to_storage`.
- **Tensor lowering** stores graph axes on op nodes; `layout_axis()` used only at `TensorAxisLayout` boundaries.
- **GEMM**: graph operand order through tensor/tile lowering; operand/transpose swap only at `TileGemmOp::execute` → `core::gemm`.
- **Fiber ops**: `validate_fiber_shape_and_merge`, `graph_fiber_shape()`, and lowering coord mapping updated for `[batch…, fiber_dim]`.
- **Docs**: expanded `graph.md` (shape labels, GEMM rules, GPT-2 walkthrough); fixed stale header comments in `sdpa_eager`, `tensor/ops/gemm`, and `nn/ops/gemm`.
- **Tests**: broad tile parity coverage with shape helpers; asymmetric and batched GEMM; `add_fiber` `batch_ndim=1`; `mask_scalar` `batch_ndim=1`; tile tolerances tightened to `1e-6`.
- **CI**: include-check script excludes `nntile/` internals and `.md` examples.

### Known debt (documented)

- **NNGraph `transpose`** still accepts storage-order axes via a compatibility shim.
- **`multiply_fiber`** hardcodes `batch_ndim=0`.

## Test plan

- [x] `ctest --test-dir build -R 'tile|tensor' -E wrappers -LE "(MPI|NotImplemented)"` — 152/152 passed
- [x] `tests_graph_tile_ops_add_fiber` (batched, `1e-6` tolerance)
- [x] `tests_graph_tensor_ops_mask_scalar` (includes `batch_ndim=1` case)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-481c6d0c-b95d-444f-bfd5-c0d07365cf1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-481c6d0c-b95d-444f-bfd5-c0d07365cf1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

