### PR TITLE
Phase 2: TensorGraph add for torch_nntile device

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -254,4 +254,36 @@ jobs:
           pip install --break-system-packages torch pytest
           CXX=g++ pip install --break-system-packages \
             -e ./torch_nntile --no-build-isolation
+          pytest -vv torch_nntile/tests/test_device_stub.py
+
+  torch-nntile-tensograph-add:
+    name: torch nntile TensorGraph add
+    needs: build-lib
+    runs-on: ubuntu-24.04
+    container: {image: ubuntu:24.04}
+    defaults:
+      run:
+        shell: bash
+        working-directory: /__w/nntile/nntile
+    steps:
+      - run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates git python3 python3-dev python3-pip g++ ninja-build \
+            pkg-config
+        working-directory: /
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/nntile-starpu-setup
+      - uses: actions/download-artifact@v4
+        with:
+          name: nntile-build
+          path: build
+      - run: rm -rf build/_deps
+      - run: |
+          pip install --break-system-packages torch pytest
+          export NNTILE_BUILD_DIR="${PWD}/build"
+          export NNTILE_SOURCE_DIR="${PWD}"
+          export LD_LIBRARY_PATH="${PWD}/build/nntile:/opt/starpu/lib:${LD_LIBRARY_PATH:-}"
+          CXX=g++ pip install --break-system-packages \
+            -e ./torch_nntile --no-build-isolation --force-reinstall
           pytest -vv torch_nntile/tests

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -234,3 +234,24 @@ jobs:
         with:
           path: /tmp/ccache
           key: ccache-build-examples-${{ github.sha }}
+
+  torch-nntile-device-stub:
+    name: torch nntile device stub
+    runs-on: ubuntu-24.04
+    container: {image: ubuntu:24.04}
+    defaults:
+      run:
+        shell: bash
+        working-directory: /__w/nntile/nntile
+    steps:
+      - run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates git python3 python3-pip g++
+        working-directory: /
+      - uses: actions/checkout@v6
+      - run: |
+          pip install --break-system-packages torch pytest
+          CXX=g++ pip install --break-system-packages \
+            -e ./torch_nntile --no-build-isolation
+          pytest -vv torch_nntile/tests

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -247,7 +247,7 @@ jobs:
       - run: |
           apt-get update
           apt-get install -y --no-install-recommends \
-            ca-certificates git python3 python3-pip g++
+            ca-certificates git python3 python3-dev python3-pip g++ ninja-build
         working-directory: /
       - uses: actions/checkout@v6
       - run: |

--- a/torch_nntile/.gitignore
+++ b/torch_nntile/.gitignore
@@ -1,0 +1,6 @@
+*.egg-info/
+*.so
+build/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -1,24 +1,53 @@
 # torch_nntile
 
-PyTorch **PrivateUse1** device stub registered as `device="nntile"`.
+PyTorch **PrivateUse1** device registered as `device="nntile"`.
 
-Tensor storage is backed by a host `std::vector<uint8_t>` buffer. Phase 1
-supports allocation, `tensor.to("nntile")` / `.cpu()`, and a global CPU
-fallback for unsupported ATen ops.
+## Phase 1 (stub)
 
-This package does **not** link to `libnntile`.
+Tensor storage is backed by a host `std::vector<uint8_t>` buffer. Supports
+allocation, `tensor.to("nntile")` / `.cpu()`, and a global CPU fallback for
+unsupported ATen ops. Does **not** require `libnntile`.
 
-## Install
+## Phase 2 (TensorGraph add)
+
+When built with `NNTILE_BUILD_DIR` pointing at a CMake build tree, `a + b` on
+`device="nntile"` runs `nntile::tensor::add` through `TensorGraph` →
+`TileGraph` → `Runtime`. PyTorch shapes use C-order labels; the bridge converts
+to TensorGraph storage layout internally. Gradients use **PyTorch autograd**
+(not `NNGraph` autograd).
+
+## Install (stub only)
 
 ```bash
 CXX=g++ pip install -e ./torch_nntile --no-build-isolation
 ```
 
-Requires PyTorch >= 2.1 with C++ extension build tools (g++). Use `CXX=g++` because
-the default `c++` on some images may lack libstdc++ headers. Use
-`--no-build-isolation` so the extension compiles against the installed `torch`.
+## Install (with libnntile / phase 2)
+
+Build NNTile first (CPU-only example):
+
+```bash
+export PKG_CONFIG_PATH=/opt/starpu/lib/pkgconfig
+TORCH_PREFIX=$(python3 -c 'import torch; print(torch.utils.cmake_prefix_path)')
+cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_CUDA=OFF \
+  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ \
+  -DCMAKE_PREFIX_PATH="$TORCH_PREFIX" -GNinja
+cmake --build build -j$(nproc)
+```
+
+Then install the extension against that build:
+
+```bash
+export NNTILE_BUILD_DIR=$PWD/build
+export NNTILE_SOURCE_DIR=$PWD
+export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+CXX=g++ pip install -e ./torch_nntile --no-build-isolation --force-reinstall
+```
 
 ## Usage
+
+Run Python from **outside** the repo root (or from inside `torch_nntile/`) so
+`import torch_nntile` resolves the installed package, not the project folder.
 
 ```python
 import torch
@@ -26,11 +55,19 @@ import torch_nntile  # registers the nntile backend once
 
 x = torch.tensor([1.0, 2.0, 3.0], device="nntile")
 y = x.cpu()
-assert torch.allclose(y, torch.tensor([1.0, 2.0, 3.0]))
+
+a = torch.tensor([1.0, 2.0], device="nntile")
+b = torch.tensor([3.0, 4.0], device="nntile")
+z = a + b  # TensorGraph add when libnntile is linked
 ```
 
 ## Tests
 
 ```bash
+# Stub tests (no libnntile)
+pytest -vv torch_nntile/tests/test_device_stub.py
+
+# Full suite (requires libnntile build + LD_LIBRARY_PATH)
+export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 pytest -vv torch_nntile/tests
 ```

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -1,0 +1,36 @@
+# torch_nntile
+
+PyTorch **PrivateUse1** device stub registered as `device="nntile"`.
+
+Tensor storage is backed by a host `std::vector<uint8_t>` buffer. Phase 1
+supports allocation, `tensor.to("nntile")` / `.cpu()`, and a global CPU
+fallback for unsupported ATen ops.
+
+This package does **not** link to `libnntile`.
+
+## Install
+
+```bash
+CXX=g++ pip install -e ./torch_nntile --no-build-isolation
+```
+
+Requires PyTorch >= 2.1 with C++ extension build tools (g++). Use `CXX=g++` because
+the default `c++` on some images may lack libstdc++ headers. Use
+`--no-build-isolation` so the extension compiles against the installed `torch`.
+
+## Usage
+
+```python
+import torch
+import torch_nntile  # registers the nntile backend once
+
+x = torch.tensor([1.0, 2.0, 3.0], device="nntile")
+y = x.cpu()
+assert torch.allclose(y, torch.tensor([1.0, 2.0, 3.0]))
+```
+
+## Tests
+
+```bash
+pytest -vv torch_nntile/tests
+```

--- a/torch_nntile/csrc/nntile_add.cpp
+++ b/torch_nntile/csrc/nntile_add.cpp
@@ -1,0 +1,108 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_add.cpp
+ */
+
+#include "nntile_executor.h"
+
+#include <ATen/Functions.h>
+#include <ATen/TensorUtils.h>
+#include <c10/core/DeviceGuard.h>
+#include <torch/library.h>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+bool is_nntile_device(c10::Device device)
+{
+    return device.type() == c10::DeviceType::PrivateUse1;
+}
+
+void check_add_inputs(
+    const at::Tensor &self,
+    const at::Tensor &other,
+    const std::optional<at::Tensor> &out = std::nullopt)
+{
+    TORCH_CHECK(
+        is_nntile_device(self.device()) &&
+            is_nntile_device(other.device()),
+        "nntile add expects both operands on device nntile");
+    if (out.has_value())
+    {
+        TORCH_CHECK(
+            is_nntile_device(out->device()),
+            "nntile add.out expects output on device nntile");
+    }
+    TORCH_CHECK(self.sizes() == other.sizes(), "nntile add: shape mismatch");
+    TORCH_CHECK(
+        self.scalar_type() == other.scalar_type(),
+        "nntile add: dtype mismatch");
+    TORCH_CHECK(
+        self.scalar_type() == at::ScalarType::Float,
+        "nntile add supports float32 only in phase 2");
+    TORCH_CHECK(
+        self.is_contiguous() && other.is_contiguous(),
+        "nntile add requires contiguous tensors");
+    if (out.has_value())
+    {
+        TORCH_CHECK(
+            out->sizes() == self.sizes(),
+            "nntile add.out: output shape mismatch");
+        TORCH_CHECK(
+            out->is_contiguous(),
+            "nntile add.out requires contiguous output");
+    }
+}
+
+void run_add_kernel(
+    const at::Tensor &self,
+    const at::Tensor &other,
+    const at::Scalar &alpha,
+    at::Tensor &out)
+{
+    const float self_scale = 1.0f;
+    const float other_scale = alpha.to<float>();
+    tensor_add_fp32(
+        self_scale,
+        self.data_ptr<float>(),
+        other_scale,
+        other.data_ptr<float>(),
+        out.data_ptr<float>(),
+        self.sizes());
+}
+
+} // namespace
+
+at::Tensor add_tensor(
+    const at::Tensor &self,
+    const at::Tensor &other,
+    const at::Scalar &alpha)
+{
+    check_add_inputs(self, other);
+    at::Tensor out = at::empty_like(self);
+    run_add_kernel(self, other, alpha, out);
+    return out;
+}
+
+at::Tensor &add_out(
+    const at::Tensor &self,
+    const at::Tensor &other,
+    const at::Scalar &alpha,
+    at::Tensor &out)
+{
+    check_add_inputs(self, other, out);
+    run_add_kernel(self, other, alpha, out);
+    return out;
+}
+
+} // namespace torch_nntile
+
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
+{
+    m.impl("add.Tensor", TORCH_FN(torch_nntile::add_tensor));
+    m.impl("add.out", TORCH_FN(torch_nntile::add_out));
+}

--- a/torch_nntile/csrc/nntile_allocator.cpp
+++ b/torch_nntile/csrc/nntile_allocator.cpp
@@ -1,0 +1,73 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_allocator.cpp
+ */
+
+#include "nntile_allocator.h"
+
+#include <c10/core/Allocator.h>
+#include <c10/core/DeviceType.h>
+
+#include <cstring>
+#include <vector>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+struct VectorStorage
+{
+    std::vector<std::uint8_t> bytes;
+};
+
+} // namespace
+
+struct NntileAllocator final : c10::Allocator
+{
+    c10::DataPtr allocate(std::size_t nbytes) override
+    {
+        auto *storage = new VectorStorage();
+        storage->bytes.resize(nbytes);
+        return c10::DataPtr(
+            storage->bytes.data(),
+            storage,
+            &NntileAllocator::release_storage,
+            c10::Device(c10::DeviceType::PrivateUse1, 0));
+    }
+
+    void copy_data(
+        void *dest,
+        const void *src,
+        std::size_t count) const override
+    {
+        if (count == 0)
+        {
+            return;
+        }
+        std::memcpy(dest, src, count);
+    }
+
+    c10::DeleterFnPtr raw_deleter() const override
+    {
+        return &NntileAllocator::release_storage;
+    }
+
+    static void release_storage(void *ctx)
+    {
+        delete static_cast<VectorStorage *>(ctx);
+    }
+};
+
+NntileAllocator g_nntile_allocator;
+
+c10::Allocator *get_nntile_allocator()
+{
+    return &g_nntile_allocator;
+}
+
+} // namespace torch_nntile
+
+REGISTER_ALLOCATOR(c10::DeviceType::PrivateUse1, &torch_nntile::g_nntile_allocator);

--- a/torch_nntile/csrc/nntile_allocator.h
+++ b/torch_nntile/csrc/nntile_allocator.h
@@ -1,0 +1,17 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_allocator.h
+ * Host std::vector-backed allocator for PrivateUse1.
+ */
+
+#pragma once
+
+#include <c10/core/Allocator.h>
+
+namespace torch_nntile
+{
+
+c10::Allocator *get_nntile_allocator();
+
+} // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_context.cpp
+++ b/torch_nntile/csrc/nntile_context.cpp
@@ -1,0 +1,62 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_context.cpp
+ */
+
+#include "nntile_context.h"
+
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
+
+#include <nntile/context.hh>
+
+#include <memory>
+#include <mutex>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+std::mutex g_context_mutex;
+std::unique_ptr<nntile::Context> g_context;
+
+} // namespace
+
+void ensure_nntile_context()
+{
+    std::lock_guard<std::mutex> lock(g_context_mutex);
+    if (g_context != nullptr)
+    {
+        return;
+    }
+    constexpr int ncpu = 1;
+    constexpr int ncuda = 0;
+    constexpr int ooc_enabled = 0;
+    constexpr char const *ooc_path = "/tmp/nntile_ooc";
+    constexpr std::size_t ooc_size = 16 * 1024 * 1024;
+    constexpr int logger = 0;
+    g_context = std::make_unique<nntile::Context>(
+        ncpu,
+        ncuda,
+        ooc_enabled,
+        ooc_path,
+        ooc_size,
+        logger);
+}
+
+} // namespace torch_nntile
+
+#else
+
+namespace torch_nntile
+{
+
+void ensure_nntile_context()
+{
+}
+
+} // namespace torch_nntile
+
+#endif

--- a/torch_nntile/csrc/nntile_context.h
+++ b/torch_nntile/csrc/nntile_context.h
@@ -1,0 +1,14 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_context.h
+ */
+
+#pragma once
+
+namespace torch_nntile
+{
+
+void ensure_nntile_context();
+
+} // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_executor.cpp
+++ b/torch_nntile/csrc/nntile_executor.cpp
@@ -1,0 +1,118 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_executor.cpp
+ */
+
+#include "nntile_executor.h"
+
+#include "nntile_context.h"
+
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
+
+#include <nntile/base_types.hh>
+#include <nntile/nn/shape_layout.hh>
+#include <nntile/runtime.hh>
+#include <nntile/tensor/ops/add.hh>
+#include <nntile/tile/graph.hh>
+
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+std::vector<nntile::Index> pytorch_shape_to_storage(c10::IntArrayRef shape)
+{
+    std::vector<nntile::Index> graph_shape;
+    graph_shape.reserve(shape.size());
+    for (const auto dim : shape)
+    {
+        graph_shape.push_back(static_cast<nntile::Index>(dim));
+    }
+    return nntile::nn::graph_shape_to_storage(graph_shape);
+}
+
+} // namespace
+
+void tensor_add_fp32(
+    float alpha,
+    const float *x_data,
+    float beta,
+    const float *y_data,
+    float *out_data,
+    c10::IntArrayRef pytorch_shape)
+{
+    ensure_nntile_context();
+
+    const std::vector<nntile::Index> storage_shape =
+        pytorch_shape_to_storage(pytorch_shape);
+    nntile::Index nelems = 1;
+    for (const nntile::Index dim : storage_shape)
+    {
+        nelems *= dim;
+    }
+
+    nntile::TensorGraph graph("torch_add");
+    auto *x_node =
+        graph.data(storage_shape, nntile::DataType::FP32)->set_name("x");
+    auto *y_node =
+        graph.data(storage_shape, nntile::DataType::FP32)->set_name("y");
+    x_node->mark_input(true);
+    y_node->mark_input(true);
+
+    auto *z_node = nntile::tensor::add(
+        static_cast<nntile::Scalar>(alpha),
+        x_node,
+        static_cast<nntile::Scalar>(beta),
+        y_node)->set_name("z");
+    z_node->mark_output(true);
+
+    nntile::TileGraph tile_graph =
+        nntile::TileGraph::from_tensor_graph(graph);
+    nntile::Runtime runtime(tile_graph);
+    runtime.compile();
+
+    const std::size_t count = static_cast<std::size_t>(nelems);
+    runtime.bind_data(x_node, x_data, count);
+    runtime.bind_data(y_node, y_data, count);
+    runtime.execute();
+    runtime.wait();
+
+    const std::vector<float> result = runtime.get_output<float>(z_node);
+    if (result.size() != count)
+    {
+        throw std::runtime_error("torch_nntile add: output size mismatch");
+    }
+    std::memcpy(out_data, result.data(), count * sizeof(float));
+}
+
+} // namespace torch_nntile
+
+#else
+
+#include <stdexcept>
+
+namespace torch_nntile
+{
+
+void tensor_add_fp32(
+    float /*alpha*/,
+    const float * /*x_data*/,
+    float /*beta*/,
+    const float * /*y_data*/,
+    float * /*out_data*/,
+    c10::IntArrayRef /*pytorch_shape*/)
+{
+    throw std::runtime_error(
+        "torch_nntile add requires libnntile "
+        "(rebuild with NNTILE_BUILD_DIR set)");
+}
+
+} // namespace torch_nntile
+
+#endif

--- a/torch_nntile/csrc/nntile_executor.h
+++ b/torch_nntile/csrc/nntile_executor.h
@@ -1,0 +1,22 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_executor.h
+ */
+
+#pragma once
+
+#include <c10/util/ArrayRef.h>
+
+namespace torch_nntile
+{
+
+void tensor_add_fp32(
+    float alpha,
+    const float *x_data,
+    float beta,
+    const float *y_data,
+    float *out_data,
+    c10::IntArrayRef pytorch_shape);
+
+} // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_guard.cpp
+++ b/torch_nntile/csrc/nntile_guard.cpp
@@ -1,0 +1,66 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_guard.cpp
+ */
+
+#include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
+#include <c10/core/Stream.h>
+#include <c10/core/impl/DeviceGuardImplInterface.h>
+
+namespace torch_nntile
+{
+
+struct NntileGuardImpl final : public c10::impl::DeviceGuardImplInterface
+{
+    static constexpr c10::DeviceType kDeviceType = c10::DeviceType::PrivateUse1;
+
+    c10::DeviceType type() const override
+    {
+        return kDeviceType;
+    }
+
+    c10::Device exchangeDevice(c10::Device device) const override
+    {
+        TORCH_INTERNAL_ASSERT(device.type() == kDeviceType);
+        TORCH_INTERNAL_ASSERT(device.index() < deviceCount());
+        return c10::Device(kDeviceType, 0);
+    }
+
+    c10::Device getDevice() const override
+    {
+        return c10::Device(kDeviceType, 0);
+    }
+
+    void setDevice(c10::Device device) const override
+    {
+        TORCH_INTERNAL_ASSERT(device.type() == kDeviceType);
+        TORCH_INTERNAL_ASSERT(device.index() < deviceCount());
+    }
+
+    void uncheckedSetDevice(c10::Device /*device*/) const noexcept override
+    {
+    }
+
+    c10::Stream getStream(c10::Device device) const noexcept override
+    {
+        return c10::Stream(c10::Stream::DEFAULT, device);
+    }
+
+    c10::Stream exchangeStream(c10::Stream /*stream*/) const noexcept override
+    {
+        return c10::Stream(
+            c10::Stream::DEFAULT,
+            c10::Device(kDeviceType, 0));
+    }
+
+    c10::DeviceIndex deviceCount() const noexcept override
+    {
+        return 1;
+    }
+};
+
+} // namespace torch_nntile
+
+C10_REGISTER_GUARD_IMPL(PrivateUse1, torch_nntile::NntileGuardImpl);

--- a/torch_nntile/csrc/nntile_kernels.cpp
+++ b/torch_nntile/csrc/nntile_kernels.cpp
@@ -1,0 +1,323 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_kernels.cpp
+ */
+
+#include "nntile_allocator.h"
+
+#include <ATen/EmptyTensor.h>
+#include <ATen/InferSize.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/native/CPUFallback.h>
+#include <ATen/native/Resize.h>
+#include <c10/core/DeviceGuard.h>
+#include <c10/core/ScalarType.h>
+#include <torch/library.h>
+
+#include <cstring>
+#include <optional>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+constexpr c10::DispatchKeySet kPrivateUse1DispatchKeySet(
+    c10::DispatchKey::PrivateUse1);
+
+bool is_nntile_device(c10::Device device)
+{
+    return device.type() == c10::DeviceType::PrivateUse1;
+}
+
+bool is_nntile_or_cpu(const at::Tensor &tensor)
+{
+    return tensor.is_cpu() || is_nntile_device(tensor.device());
+}
+
+void check_copy_devices(const at::Tensor &self, const at::Tensor &dst)
+{
+    TORCH_CHECK(
+        is_nntile_or_cpu(self) && is_nntile_or_cpu(dst),
+        "nntile stub copy supports CPU <-> nntile only");
+    TORCH_CHECK(self.sizes() == dst.sizes(), "copy size mismatch");
+    TORCH_CHECK(
+        self.scalar_type() == dst.scalar_type(),
+        "copy dtype mismatch");
+    TORCH_CHECK(
+        self.is_contiguous() && dst.is_contiguous(),
+        "nntile stub copy requires contiguous tensors");
+}
+
+void memcpy_tensors(const at::Tensor &src, at::Tensor &dst)
+{
+    const std::size_t nbytes = static_cast<std::size_t>(src.nbytes());
+    if (nbytes == 0)
+    {
+        return;
+    }
+    std::memcpy(
+        dst.storage().data_ptr().get(),
+        src.storage().data_ptr().get(),
+        nbytes);
+}
+
+at::Scalar tensor_to_scalar(const at::Tensor &self)
+{
+    if (self.scalar_type() == at::ScalarType::Float)
+    {
+        return *self.data_ptr<float>();
+    }
+    if (self.scalar_type() == at::ScalarType::Double)
+    {
+        return *self.data_ptr<double>();
+    }
+    if (self.scalar_type() == at::ScalarType::Int)
+    {
+        return *self.data_ptr<int32_t>();
+    }
+    if (self.scalar_type() == at::ScalarType::Long)
+    {
+        return *self.data_ptr<int64_t>();
+    }
+    TORCH_CHECK(false, "Unsupported dtype for _local_scalar_dense on nntile");
+    return at::Scalar();
+}
+
+} // namespace
+
+at::Tensor empty_memory_format(
+    at::IntArrayRef size,
+    std::optional<at::ScalarType> dtype_opt,
+    std::optional<at::Layout> layout_opt,
+    std::optional<at::Device> device_opt,
+    std::optional<bool> pin_memory_opt,
+    std::optional<at::MemoryFormat> memory_format_opt)
+{
+    const auto device = c10::device_or_default(device_opt);
+    TORCH_CHECK(is_nntile_device(device), "empty.memory_format: expected nntile");
+    TORCH_CHECK(
+        c10::layout_or_default(layout_opt) == c10::Layout::Strided,
+        "Non-strided layout not supported on nntile stub");
+    TORCH_CHECK(
+        !c10::pinned_memory_or_default(pin_memory_opt),
+        "Pin memory is CPU-only");
+    const c10::DeviceGuard device_guard(device);
+    return at::detail::empty_generic(
+        size,
+        get_nntile_allocator(),
+        kPrivateUse1DispatchKeySet,
+        c10::dtype_or_default(dtype_opt),
+        memory_format_opt);
+}
+
+at::Tensor empty_strided(
+    at::IntArrayRef size,
+    at::IntArrayRef stride,
+    std::optional<at::ScalarType> dtype_opt,
+    std::optional<at::Layout> layout_opt,
+    std::optional<at::Device> device_opt,
+    std::optional<bool> pin_memory_opt)
+{
+    const auto device = c10::device_or_default(device_opt);
+    TORCH_CHECK(is_nntile_device(device), "empty_strided: expected nntile");
+    TORCH_CHECK(
+        c10::layout_or_default(layout_opt) == c10::Layout::Strided,
+        "Non-strided layout not supported on nntile stub");
+    TORCH_CHECK(
+        !c10::pinned_memory_or_default(pin_memory_opt),
+        "Pin memory is CPU-only");
+    const c10::DeviceGuard device_guard(device);
+    return at::detail::empty_strided_generic(
+        size,
+        stride,
+        get_nntile_allocator(),
+        kPrivateUse1DispatchKeySet,
+        c10::dtype_or_default(dtype_opt));
+}
+
+at::Tensor as_strided(
+    const at::Tensor &self,
+    at::IntArrayRef size,
+    at::IntArrayRef stride,
+    std::optional<int64_t> storage_offset)
+{
+    TORCH_CHECK(is_nntile_device(self.device()), "as_strided: expected nntile");
+    const int64_t storage_offset_value =
+        storage_offset.value_or(self.storage_offset());
+    at::Tensor result = at::detail::make_tensor<at::TensorImpl>(
+        c10::Storage(self.storage()),
+        self.key_set(),
+        self.dtype());
+    auto *result_impl = result.unsafeGetTensorImpl();
+    result_impl->set_storage_offset(storage_offset_value);
+    result_impl->set_sizes_and_strides(size, stride);
+    return result;
+}
+
+at::Tensor reshape_alias(
+    const at::Tensor &self,
+    at::IntArrayRef size,
+    at::IntArrayRef stride)
+{
+    TORCH_CHECK(
+        is_nntile_device(self.device()),
+        "_reshape_alias: expected nntile");
+    at::Tensor result = at::detail::make_tensor<at::TensorImpl>(
+        c10::Storage(self.storage()),
+        self.key_set(),
+        self.dtype());
+    auto *result_impl = result.unsafeGetTensorImpl();
+    result_impl->set_storage_offset(self.storage_offset());
+    result_impl->set_sizes_and_strides(size, stride);
+    return result;
+}
+
+at::Tensor view(const at::Tensor &self, at::IntArrayRef size)
+{
+    TORCH_CHECK(is_nntile_device(self.device()), "view: expected nntile");
+    const auto inferred = at::infer_size_dv(size, self.numel());
+    const auto stride = at::detail::computeStride(
+        self.sizes(),
+        self.strides(),
+        inferred);
+    TORCH_CHECK(
+        stride.has_value(),
+        "view size is not compatible with input tensor's size and stride");
+    return reshape_alias(self, inferred, *stride);
+}
+
+const at::Tensor &resize_(
+    const at::Tensor &self,
+    c10::SymIntArrayRef size,
+    std::optional<at::MemoryFormat> memory_format)
+{
+    TORCH_CHECK(is_nntile_device(self.device()), "resize_: expected nntile");
+    if (memory_format.has_value())
+    {
+        TORCH_CHECK(
+            *memory_format == at::MemoryFormat::Contiguous,
+            "nntile stub resize_ supports contiguous layout only");
+    }
+    std::vector<int64_t> sizes;
+    sizes.reserve(size.size());
+    for (const auto &dim : size)
+    {
+        sizes.push_back(dim.guard_int(__FILE__, __LINE__));
+    }
+    at::native::resize_impl_cpu_(
+        self.unsafeGetTensorImpl(),
+        sizes,
+        std::nullopt);
+    return self;
+}
+
+at::Tensor copy_from(
+    const at::Tensor &self,
+    const at::Tensor &dst,
+    bool /*non_blocking*/)
+{
+    check_copy_devices(self, dst);
+    at::Tensor mutable_dst = dst;
+    memcpy_tensors(self, mutable_dst);
+    return dst;
+}
+
+at::Tensor copy_from_and_resize(const at::Tensor &self, const at::Tensor &dst)
+{
+    if (self.sizes() != dst.sizes())
+    {
+        resize_(dst, c10::SymIntArrayRef(self.sym_sizes()), std::nullopt);
+    }
+    return copy_from(self, dst, false);
+}
+
+at::Scalar local_scalar_dense(const at::Tensor &self)
+{
+    TORCH_CHECK(
+        is_nntile_device(self.device()),
+        "_local_scalar_dense: expected nntile");
+    TORCH_CHECK(self.numel() > 0, "Cannot convert empty tensor to scalar");
+    return tensor_to_scalar(self);
+}
+
+at::Tensor &set_source_tensor(at::Tensor &result, const at::Tensor &source)
+{
+    TORCH_CHECK(
+        is_nntile_device(result.device()),
+        "set_.source_Tensor: expected nntile result");
+    TORCH_CHECK(
+        is_nntile_device(source.device()),
+        "set_.source_Tensor: expected nntile source");
+    result.unsafeGetTensorImpl()->set_storage_offset(source.storage_offset());
+    result.unsafeGetTensorImpl()->set_sizes_and_strides(
+        source.sizes(),
+        source.strides());
+    return result;
+}
+
+at::Tensor &set_source_storage(at::Tensor &result, at::Storage src)
+{
+    TORCH_CHECK(
+        is_nntile_device(result.device()),
+        "set_.source_Storage: expected nntile");
+    const int64_t new_size = static_cast<int64_t>(
+        src.nbytes() / result.dtype().itemsize());
+    result.unsafeGetTensorImpl()->set_storage_offset(0);
+    at::native::resize_impl_cpu_(
+        result.unsafeGetTensorImpl(),
+        new_size,
+        std::nullopt,
+        /*resize_storage=*/false);
+    result.unsafeGetTensorImpl()->set_storage_keep_dtype(std::move(src));
+    return result;
+}
+
+at::Tensor &set_source_storage_storage_offset(
+    at::Tensor &result,
+    at::Storage src,
+    int64_t storage_offset,
+    at::IntArrayRef size,
+    at::IntArrayRef stride)
+{
+    TORCH_CHECK(
+        is_nntile_device(result.device()),
+        "set_.source_Storage_storage_offset: expected nntile");
+    result.unsafeGetTensorImpl()->set_storage_offset(storage_offset);
+    result.unsafeGetTensorImpl()->set_storage_keep_dtype(std::move(src));
+    result.unsafeGetTensorImpl()->set_sizes_and_strides(size, stride);
+    return result;
+}
+
+void cpu_fallback(const c10::OperatorHandle &op, torch::jit::Stack *stack)
+{
+    at::native::cpu_fallback(op, stack);
+}
+
+} // namespace torch_nntile
+
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
+{
+    m.impl("empty.memory_format", TORCH_FN(torch_nntile::empty_memory_format));
+    m.impl("empty_strided", TORCH_FN(torch_nntile::empty_strided));
+    m.impl("as_strided", TORCH_FN(torch_nntile::as_strided));
+    m.impl("view", TORCH_FN(torch_nntile::view));
+    m.impl("_reshape_alias", TORCH_FN(torch_nntile::reshape_alias));
+    m.impl("resize_", TORCH_FN(torch_nntile::resize_));
+    m.impl("_copy_from", TORCH_FN(torch_nntile::copy_from));
+    m.impl("_copy_from_and_resize", TORCH_FN(torch_nntile::copy_from_and_resize));
+    m.impl("_local_scalar_dense", TORCH_FN(torch_nntile::local_scalar_dense));
+    m.impl("set_.source_Tensor", TORCH_FN(torch_nntile::set_source_tensor));
+    m.impl("set_.source_Storage", TORCH_FN(torch_nntile::set_source_storage));
+    m.impl(
+        "set_.source_Storage_storage_offset",
+        TORCH_FN(torch_nntile::set_source_storage_storage_offset));
+}
+
+TORCH_LIBRARY_IMPL(_, PrivateUse1, m)
+{
+    m.fallback(torch::CppFunction::makeFromBoxedFunction<
+               &torch_nntile::cpu_fallback>());
+}

--- a/torch_nntile/csrc/nntile_module.cpp
+++ b/torch_nntile/csrc/nntile_module.cpp
@@ -1,0 +1,55 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_module.cpp
+ */
+
+#include <torch/extension.h>
+
+#include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
+
+namespace torch_nntile
+{
+
+c10::Device nntile_device()
+{
+    return c10::Device(c10::DeviceType::PrivateUse1, 0);
+}
+
+bool is_registered()
+{
+    return true;
+}
+
+int64_t buffer_nbytes(const at::Tensor &tensor)
+{
+    TORCH_CHECK(
+        tensor.device().type() == c10::DeviceType::PrivateUse1,
+        "buffer_nbytes expects an nntile tensor");
+    return static_cast<int64_t>(tensor.storage().nbytes());
+}
+
+bool buffer_equal_cpu(const at::Tensor &nntile_tensor, const at::Tensor &cpu_tensor)
+{
+    TORCH_CHECK(
+        nntile_tensor.device().type() == c10::DeviceType::PrivateUse1,
+        "buffer_equal_cpu expects nntile tensor as first argument");
+    TORCH_CHECK(cpu_tensor.is_cpu(), "buffer_equal_cpu expects CPU tensor");
+    at::Tensor lhs = nntile_tensor.contiguous().cpu();
+    at::Tensor rhs = cpu_tensor.contiguous();
+    return lhs.equal(rhs);
+}
+
+} // namespace torch_nntile
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.def("nntile_device", &torch_nntile::nntile_device, "Return nntile device");
+    m.def("is_registered", &torch_nntile::is_registered, "Backend loaded");
+    m.def("buffer_nbytes", &torch_nntile::buffer_nbytes, "Storage nbytes");
+    m.def(
+        "buffer_equal_cpu",
+        &torch_nntile::buffer_equal_cpu,
+        "Compare nntile tensor to CPU tensor");
+}

--- a/torch_nntile/csrc/nntile_module.cpp
+++ b/torch_nntile/csrc/nntile_module.cpp
@@ -22,6 +22,15 @@ bool is_registered()
     return true;
 }
 
+bool has_libnntile()
+{
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
+    return true;
+#else
+    return false;
+#endif
+}
+
 int64_t buffer_nbytes(const at::Tensor &tensor)
 {
     TORCH_CHECK(
@@ -47,6 +56,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {
     m.def("nntile_device", &torch_nntile::nntile_device, "Return nntile device");
     m.def("is_registered", &torch_nntile::is_registered, "Backend loaded");
+    m.def(
+        "has_libnntile",
+        &torch_nntile::has_libnntile,
+        "Whether libnntile TensorGraph add is linked");
     m.def("buffer_nbytes", &torch_nntile::buffer_nbytes, "Storage nbytes");
     m.def(
         "buffer_equal_cpu",

--- a/torch_nntile/pyproject.toml
+++ b/torch_nntile/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torch_nntile"
-version = "0.1.0"
-description = "PyTorch PrivateUse1 device stub for nntile (host std::vector buffer)"
+version = "0.2.0"
+description = "PyTorch PrivateUse1 device for nntile (TensorGraph add via libnntile)"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [

--- a/torch_nntile/pyproject.toml
+++ b/torch_nntile/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61", "torch>=2.1"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "torch_nntile"
+version = "0.1.0"
+description = "PyTorch PrivateUse1 device stub for nntile (host std::vector buffer)"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "torch>=2.1",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.2",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["torch_nntile*"]

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -1,0 +1,31 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/setup.py
+# Build PyTorch PrivateUse1 extension for the nntile device stub.
+
+from setuptools import setup
+
+from torch.utils.cpp_extension import BuildExtension, CppExtension
+
+CSRC = [
+    "csrc/nntile_allocator.cpp",
+    "csrc/nntile_kernels.cpp",
+    "csrc/nntile_guard.cpp",
+    "csrc/nntile_module.cpp",
+]
+
+setup(
+    name="torch_nntile",
+    version="0.1.0",
+    packages=["torch_nntile"],
+    ext_modules=[
+        CppExtension(
+            name="torch_nntile._C",
+            sources=CSRC,
+            extra_compile_args=["-std=c++17"],
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension.with_options(no_python_abi_suffix=True)},
+    install_requires=["torch>=2.1"],
+)

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -2,28 +2,124 @@
 #                              (Skoltech), Russia. All rights reserved.
 #
 # @file torch_nntile/setup.py
-# Build PyTorch PrivateUse1 extension for the nntile device stub.
+# Build PyTorch PrivateUse1 extension for the nntile device.
+
+import os
+import subprocess
+from pathlib import Path
 
 from setuptools import setup
-
 from torch.utils.cpp_extension import BuildExtension, CppExtension
+
+ROOT = Path(__file__).resolve().parent
+REPO_ROOT = ROOT.parent
 
 CSRC = [
     "csrc/nntile_allocator.cpp",
     "csrc/nntile_kernels.cpp",
     "csrc/nntile_guard.cpp",
     "csrc/nntile_module.cpp",
+    "csrc/nntile_context.cpp",
+    "csrc/nntile_executor.cpp",
+    "csrc/nntile_add.cpp",
 ]
+
+
+def _pkg_config(package: str, flag: str) -> list[str]:
+    env = os.environ.copy()
+    pkg_config_path = env.get("PKG_CONFIG_PATH", "")
+    starpu_pkg = "/opt/starpu/lib/pkgconfig"
+    if starpu_pkg not in pkg_config_path.split(":"):
+        env["PKG_CONFIG_PATH"] = (
+            f"{starpu_pkg}:{pkg_config_path}" if pkg_config_path else starpu_pkg
+        )
+    try:
+        out = subprocess.check_output(
+            ["pkg-config", flag, package],
+            env=env,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    return [part for part in out.strip().split() if part]
+
+
+def _apply_pkg_config(
+    package: str,
+    include_dirs: list[str],
+    library_dirs: list[str],
+    extra_compile_args: list[str],
+    extra_link_args: list[str],
+    libraries: list[str],
+) -> None:
+    for flag in _pkg_config(package, "--cflags"):
+        if flag.startswith("-I"):
+            include_dirs.append(flag[2:])
+        else:
+            extra_compile_args.append(flag)
+    for flag in _pkg_config(package, "--libs"):
+        if flag.startswith("-L"):
+            library_dirs.append(flag[2:])
+        elif flag.startswith("-l"):
+            libraries.append(flag[2:])
+        else:
+            extra_link_args.append(flag)
+
+
+def _nntile_extension_kwargs() -> dict:
+    nntile_build = os.environ.get("NNTILE_BUILD_DIR")
+    nntile_source = os.environ.get("NNTILE_SOURCE_DIR", str(REPO_ROOT))
+
+    extra_compile_args = ["-std=c++17"]
+    define_macros: list[tuple[str, str | None]] = []
+    include_dirs: list[str] = []
+    library_dirs: list[str] = []
+    libraries: list[str] = []
+    extra_link_args: list[str] = []
+
+    if nntile_build:
+        define_macros.append(("TORCH_NNTILE_USE_LIBNNTILE", "1"))
+        include_dirs.extend(
+            [
+                str(Path(nntile_source) / "nntile" / "include"),
+                str(Path(nntile_build) / "include"),
+            ]
+        )
+        library_dirs.append(str(Path(nntile_build) / "nntile"))
+        libraries.append("nntile")
+        extra_link_args.append(
+            f"-Wl,-rpath,$ORIGIN/../../build/nntile"
+        )
+        _apply_pkg_config(
+            "starpu-1.4",
+            include_dirs,
+            library_dirs,
+            extra_compile_args,
+            extra_link_args,
+            libraries,
+        )
+
+    return {
+        "define_macros": define_macros,
+        "include_dirs": include_dirs,
+        "library_dirs": library_dirs,
+        "libraries": libraries,
+        "extra_compile_args": extra_compile_args,
+        "extra_link_args": extra_link_args,
+    }
+
+
+ext_kwargs = _nntile_extension_kwargs()
 
 setup(
     name="torch_nntile",
-    version="0.1.0",
+    version="0.2.0",
     packages=["torch_nntile"],
     ext_modules=[
         CppExtension(
             name="torch_nntile._C",
             sources=CSRC,
-            extra_compile_args=["-std=c++17"],
+            **ext_kwargs,
         )
     ],
     cmdclass={"build_ext": BuildExtension.with_options(no_python_abi_suffix=True)},

--- a/torch_nntile/tests/test_add_parity.py
+++ b/torch_nntile/tests/test_add_parity.py
@@ -1,0 +1,52 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_add_parity.py
+# Parity tests for nntile add via TensorGraph (libnntile).
+
+import torch
+import pytest
+
+import torch_nntile
+from torch_nntile import _C
+
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+
+def test_add_matches_cpu():
+    a_cpu = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    b_cpu = torch.tensor([[0.5, -1.0], [2.0, 0.25]])
+
+    a = a_cpu.to("nntile")
+    b = b_cpu.to("nntile")
+    z = a + b
+
+    assert z.device.type == "nntile"
+    assert torch.allclose(z.cpu(), a_cpu + b_cpu)
+
+
+def test_add_with_alpha_matches_cpu():
+    a_cpu = torch.tensor([1.0, -2.0, 3.5])
+    b_cpu = torch.tensor([0.25, 4.0, -1.5])
+
+    a = a_cpu.to("nntile")
+    b = b_cpu.to("nntile")
+    z = torch.add(a, b, alpha=2.0)
+
+    expected = torch.add(a_cpu, b_cpu, alpha=2.0)
+    assert torch.allclose(z.cpu(), expected)
+
+
+def test_add_2d_shape_parity():
+    shape = (4, 6)
+    a_cpu = torch.randn(shape, dtype=torch.float32)
+    b_cpu = torch.randn(shape, dtype=torch.float32)
+
+    z_nntile = (a_cpu.to("nntile") + b_cpu.to("nntile")).cpu()
+    z_cpu = a_cpu + b_cpu
+
+    assert torch.allclose(z_nntile, z_cpu, rtol=1e-5, atol=1e-5)

--- a/torch_nntile/tests/test_device_stub.py
+++ b/torch_nntile/tests/test_device_stub.py
@@ -1,0 +1,48 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_device_stub.py
+# Tests for the PyTorch nntile device stub.
+
+import torch
+import pytest
+
+import torch_nntile
+from torch_nntile import _C, device
+
+
+def test_import_registers_device():
+    assert torch_nntile._registered
+    assert device.type == "nntile"
+    assert _C.is_registered()
+    assert torch.device("nntile").type == "nntile"
+    assert hasattr(torch, "nntile")
+
+
+def test_empty_on_device():
+    x = torch.empty((2, 3), device="nntile")
+    assert x.device.type == "nntile"
+    assert x.shape == (2, 3)
+    assert x.dtype == torch.float32
+    assert _C.buffer_nbytes(x) == x.element_size() * x.numel()
+
+
+def test_cpu_to_nntile_copy():
+    cpu = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    nnt = cpu.to("nntile")
+    assert nnt.device.type == "nntile"
+    assert _C.buffer_equal_cpu(nnt, cpu)
+
+
+def test_nntile_to_cpu_copy():
+    cpu = torch.tensor([1.0, -2.0, 3.5, 0.0])
+    nnt = cpu.to("nntile")
+    back = nnt.cpu()
+    assert back.device.type == "cpu"
+    assert torch.allclose(back, cpu)
+
+
+def test_tensor_factory_on_device():
+    x = torch.tensor([1.0, 2.0, 3.0], device="nntile")
+    y = x.cpu()
+    assert torch.allclose(y, torch.tensor([1.0, 2.0, 3.0]))

--- a/torch_nntile/torch_nntile/__init__.py
+++ b/torch_nntile/torch_nntile/__init__.py
@@ -1,0 +1,60 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/torch_nntile/__init__.py
+# Register the PyTorch nntile device (PrivateUse1).
+
+"""PyTorch nntile device stub (PrivateUse1 open registration)."""
+
+from __future__ import annotations
+
+import torch
+
+from . import _C  # noqa: F401 — loads kernels and allocator
+
+_registered = False
+
+
+class _NntileBackendModule:
+    """Minimal torch.nntile runtime module required by PyTorch 2.12+."""
+
+    @staticmethod
+    def is_initialized() -> bool:
+        return True
+
+    @staticmethod
+    def is_available() -> bool:
+        return True
+
+    @staticmethod
+    def current_device() -> int:
+        return 0
+
+    @staticmethod
+    def _is_in_bad_fork() -> bool:
+        return False
+
+    @staticmethod
+    def manual_seed_all(seed: int) -> None:
+        del seed
+
+    @staticmethod
+    def device_count() -> int:
+        return 1
+
+
+def _register_backend() -> None:
+    global _registered
+    if _registered:
+        return
+    torch.utils.rename_privateuse1_backend("nntile")
+    torch.utils.generate_methods_for_privateuse1_backend()
+    torch._register_device_module("nntile", _NntileBackendModule)
+    _registered = True
+
+
+_register_backend()
+
+device = torch.device("nntile")
+
+__all__ = ["device", "_C"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **phase 2** of the PyTorch `nntile` device plan: element-wise `add` on `device="nntile"` runs through **libnntile TensorGraph** (`tensor::add` → `TileGraph` → `Runtime`). Phase 1 (PrivateUse1 stub, CPU copy, allocation) is unchanged.

- **`a + b` / `torch.add(a, b, alpha=…)`** on nntile tensors execute via `nntile::tensor::add` (not `NNGraph` autograd)
- PyTorch **C-order** shapes are converted to TensorGraph **storage** layout via `graph_shape_to_storage`
- Gradients remain **PyTorch autograd** (no NNGraph backward in this phase)
- **Optional libnntile link**: set `NNTILE_BUILD_DIR` when building; stub-only install still works for phase 1

## Changes

| Area | Details |
|------|---------|
| `nntile_context.cpp` | Lazy `nntile::Context` init (1 CPU worker) |
| `nntile_executor.cpp` | Eager per-op TensorGraph build + execute for `add` |
| `nntile_add.cpp` | `aten::add.Tensor` / `aten::add.out` for PrivateUse1 |
| `setup.py` | Links `libnntile` + StarPU when `NNTILE_BUILD_DIR` is set |
| Tests | `test_add_parity.py` — CPU vs nntile parity (skipped without libnntile) |
| CI | New `torch-nntile-tensograph-add` job; stub job runs phase-1 tests only |

## Build & test

```bash
# Build libnntile (CPU)
cmake -S . -B build -DUSE_CUDA=OFF -DBUILD_PYTHON_WRAPPERS=OFF ...
cmake --build build --target nntile -j$(nproc)

# Install torch_nntile with libnntile
export NNTILE_BUILD_DIR=$PWD/build NNTILE_SOURCE_DIR=$PWD
export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
CXX=g++ pip install -e ./torch_nntile --no-build-isolation --force-reinstall

# Run from torch_nntile/ (not repo root — avoids namespace import shadow)
cd torch_nntile && pytest -vv tests
```

## Example

```python
import torch
import torch_nntile

a = torch.tensor([1.0, 2.0], device="nntile")
b = torch.tensor([3.0, 4.0], device="nntile")
z = a + b
assert torch.allclose(z.cpu(), torch.tensor([4.0, 6.0]))
```

## Follow-ups (not in this PR)

- Persistent TensorGraph across ops (vs eager per-op graph today)
- More ATen ops beyond `add`
- PyTorch autograd backward kernels on nntile
- `src/` layout fix for import-from-repo-root footgun
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-523cc3d4-1e73-4e17-b454-8f03109d685f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-523cc3d4-1e73-4e17-b454-8f03109d685f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

