### PR TITLE
torch_nntile: graph runtime mode and nntile-native cross-entropy

### DIFF
--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -89,10 +89,10 @@ pytest -vv torch_nntile/tests/test_deep_relu_parity.py
 Train `DeepReLU.mnist()` on all **60 000** MNIST training images in one batch,
 comparing CPU PyTorch vs `device="nntile"` with the same weight initialization.
 
-Cross-entropy runs entirely on nntile via `torch_nntile.training.cross_entropy`
-(same tensor-op chain as `NNCrossEntropyOp` in libnntile). The scalar loss is
-returned on CPU so PyTorch autograd can call `loss.backward()` without extra
-ATen kernels on PrivateUse1. Optimizer steps use fused `tensor::sgd_step` via
+Cross-entropy is evaluated on nntile via `torch_nntile.training.cross_entropy`
+(same tensor-op chain as `NNCrossEntropyOp` in libnntile). The scalar loss lives
+on ``device="nntile"``; call ``torch_nntile.execute()`` in graph mode before
+reading it on the host. Optimizer steps use fused ``tensor::sgd_step`` via
 ``torch_nntile.training.SGD`` (no per-parameter CPU round-trip).
 
 ```bash

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -41,26 +41,23 @@ Use this to verify that a model forward uses only nntile kernels.
 # Default: each op records a TensorGraph slice and runs it immediately.
 torch_nntile.init_context(ncpu=1, ncuda=0, cpu_fallback=False)
 
-# Deferred: ops append to one shared TensorGraph until sync.
+# Deferred: ops append to one shared TensorGraph until you flush.
 torch_nntile.init_context(
     ncpu=1, ncuda=0, cpu_fallback=False, runtime_mode="graph"
 )
-y = model(x)  # recorded, not executed yet
-torch_nntile.execute()  # explicit flush
-# or: y.cpu() / tensor.to("cpu") / scalar .item() on nntile tensors
+y = model(x)              # recorded, not executed yet
+loss.backward()           # backward ops recorded too
+torch_nntile.execute()    # compile + run the full graph, then reset
+z = y.cpu()               # safe after execute()
 ```
 
 In graph mode, forward and backward can stay in one pending graph (StarPU
-resolves dependencies). The graph runs when host-visible data is needed:
-``tensor.cpu()``, ``tensor.to("cpu")``, ``tensor.item()`` on nntile tensors,
-or an explicit ``torch_nntile.execute()``. Copies **to** ``device="nntile"``
-do not flush the graph.
-
-```python
-y = model(x)              # recorded only
-z = y.cpu()               # execute() then copy nntile -> host
-# torch_nntile.execute()  # optional explicit flush
-```
+resolves dependencies). Call ``torch_nntile.execute()`` to compile and run
+the batch. Host reads from **nntile** tensors (``.cpu()``, ``.to("cpu")``,
+``.item()``) raise until ``execute()`` has run. Copies **to**
+``device="nntile"`` do not flush the graph. Training helpers such as
+``train_full_batch_step`` call ``execute()`` automatically in graph mode
+before returning the scalar loss.
 
 Tests: `pytest -vv torch_nntile/tests/test_graph_execution.py`
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -20,7 +20,7 @@ run through libnntile `TensorGraph` → `TileGraph` → `Runtime`:
 | `F.relu` / `nn.ReLU` | `tensor::relu` |
 | ReLU backward | `tensor::relu_backward` (+ `tensor::clear` on output) |
 | `linear` backward / `mm` | `tensor::gemm` |
-| `torch_nntile.training.cross_entropy` | `maxsumexp`, `logsumexp`, `total_sum_accum`, `softmax`, `subtract_indexed_outputs` |
+| `torch_nntile.training.cross_entropy` | `maxsumexp`, `logsumexp`, `total_sum_accum`, `softmax`, `subtract_indexed_outputs`; backward: chained `scale_slice`, `multiply_slice` |
 | `torch_nntile.training.SGD` | `tensor::sgd_step` (fused SGD with momentum) |
 
 PyTorch C-order shapes are converted to TensorGraph storage layout internally.
@@ -90,10 +90,15 @@ Train `DeepReLU.mnist()` on all **60 000** MNIST training images in one batch,
 comparing CPU PyTorch vs `device="nntile"` with the same weight initialization.
 
 Cross-entropy is evaluated on nntile via `torch_nntile.training.cross_entropy`
-(same tensor-op chain as `NNCrossEntropyOp` in libnntile). The scalar loss lives
-on ``device="nntile"``; call ``torch_nntile.execute()`` in graph mode before
-reading it on the host. Optimizer steps use fused ``tensor::sgd_step`` via
-``torch_nntile.training.SGD`` (no per-parameter CPU round-trip).
+(same tensor-op chain as `NNCrossEntropyOp` in libnntile). Logits use **class
+dim last** (`[..., C]`); labels match logits without the class axis (`...`).
+The scalar loss lives on ``device="nntile"``; call ``torch_nntile.execute()`` in
+graph mode before reading it on the host. Backward keeps ``grad_output`` as a
+graph tensor (no host scalar read during recording) and broadcasts it to the
+label shape with one ``scale_slice`` per label dimension, then applies
+``multiply_slice`` along the class axis. Optimizer steps use fused
+``tensor::sgd_step`` via ``torch_nntile.training.SGD`` (no per-parameter CPU
+round-trip).
 
 ```bash
 export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
@@ -107,7 +112,7 @@ Integration test (downloads MNIST, 3 epochs, compares losses and weights):
 pytest -vv -m slow torch_nntile/tests/test_deep_relu_mnist_train.py
 ```
 
-Cross-entropy parity (forward, backward, `ignore_index`):
+Cross-entropy parity (forward, backward, multi-D labels, `ignore_index`):
 
 ```bash
 pytest -vv torch_nntile/tests/test_cross_entropy_parity.py

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -35,6 +35,35 @@ torch_nntile.init_context(ncpu=1, ncuda=0, cpu_fallback=False)
 When `cpu_fallback=False`, unsupported ATen ops raise instead of running on CPU.
 Use this to verify that a model forward uses only nntile kernels.
 
+### Runtime mode: eager vs graph
+
+```python
+# Default: each op records a TensorGraph slice and runs it immediately.
+torch_nntile.init_context(ncpu=1, ncuda=0, cpu_fallback=False)
+
+# Deferred: ops append to one shared TensorGraph until sync.
+torch_nntile.init_context(
+    ncpu=1, ncuda=0, cpu_fallback=False, runtime_mode="graph"
+)
+y = model(x)  # recorded, not executed yet
+torch_nntile.execute()  # explicit flush
+# or: y.cpu() / tensor.to("cpu") / scalar .item() on nntile tensors
+```
+
+In graph mode, forward and backward can stay in one pending graph (StarPU
+resolves dependencies). The graph runs when host-visible data is needed:
+``tensor.cpu()``, ``tensor.to("cpu")``, ``tensor.item()`` on nntile tensors,
+or an explicit ``torch_nntile.execute()``. Copies **to** ``device="nntile"``
+do not flush the graph.
+
+```python
+y = model(x)              # recorded only
+z = y.cpu()               # execute() then copy nntile -> host
+# torch_nntile.execute()  # optional explicit flush
+```
+
+Tests: `pytest -vv torch_nntile/tests/test_graph_execution.py`
+
 ## Phase 3 (DeepReLU example)
 
 Bias-free MLP matching `nntile/examples/deep_relu_forward.cc`:
@@ -72,6 +101,7 @@ ATen kernels on PrivateUse1. Optimizer steps use fused `tensor::sgd_step` via
 ```bash
 export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
 python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5
+python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5 --runtime-mode graph
 ```
 
 Integration test (downloads MNIST, 3 epochs, compares losses and weights):

--- a/torch_nntile/csrc/nntile_add.cpp
+++ b/torch_nntile/csrc/nntile_add.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
 
 #include <ATen/Functions.h>
 #include <ATen/TensorUtils.h>
@@ -66,6 +67,8 @@ void run_add_kernel(
 {
     const float self_scale = 1.0f;
     const float other_scale = alpha.to<float>();
+    pin_graph_op_inputs({self, other});
+    pin_graph_op_output(out, true);
     tensor_add_fp32(
         self_scale,
         self.data_ptr<float>(),

--- a/torch_nntile/csrc/nntile_context.cpp
+++ b/torch_nntile/csrc/nntile_context.cpp
@@ -31,6 +31,7 @@ struct ContextConfig
     int logger = 0;
     int verbose = 0;
     bool cpu_fallback = false;
+    RuntimeMode runtime_mode = RuntimeMode::Eager;
 };
 
 std::mutex g_context_mutex;
@@ -67,7 +68,8 @@ void init_context(
     std::size_t ooc_size,
     int logger,
     int verbose,
-    bool cpu_fallback)
+    bool cpu_fallback,
+    RuntimeMode runtime_mode)
 {
     std::lock_guard<std::mutex> lock(g_context_mutex);
     if (g_context != nullptr)
@@ -89,7 +91,19 @@ void init_context(
     g_context_config.logger = logger;
     g_context_config.verbose = verbose;
     g_context_config.cpu_fallback = cpu_fallback;
+    g_context_config.runtime_mode = runtime_mode;
     g_context_config_locked = true;
+}
+
+RuntimeMode get_runtime_mode()
+{
+    std::lock_guard<std::mutex> lock(g_context_mutex);
+    return g_context_config.runtime_mode;
+}
+
+bool is_graph_mode()
+{
+    return get_runtime_mode() == RuntimeMode::Graph;
 }
 
 bool is_cpu_fallback_enabled()
@@ -158,9 +172,20 @@ void init_context(
     std::size_t /*ooc_size*/,
     int /*logger*/,
     int /*verbose*/,
-    bool /*cpu_fallback*/)
+    bool /*cpu_fallback*/,
+    RuntimeMode /*runtime_mode*/)
 {
     require_libnntile();
+}
+
+RuntimeMode get_runtime_mode()
+{
+    return RuntimeMode::Eager;
+}
+
+bool is_graph_mode()
+{
+    return false;
 }
 
 bool is_cpu_fallback_enabled()

--- a/torch_nntile/csrc/nntile_context.h
+++ b/torch_nntile/csrc/nntile_context.h
@@ -11,6 +11,12 @@
 namespace torch_nntile
 {
 
+enum class RuntimeMode
+{
+    Eager,
+    Graph,
+};
+
 void init_context(
     int ncpu = -1,
     int ncuda = -1,
@@ -19,11 +25,16 @@ void init_context(
     std::size_t ooc_size = 16 * 1024 * 1024,
     int logger = 0,
     int verbose = 0,
-    bool cpu_fallback = true);
+    bool cpu_fallback = true,
+    RuntimeMode runtime_mode = RuntimeMode::Eager);
 
 bool is_context_initialized();
 
 bool is_cpu_fallback_enabled();
+
+RuntimeMode get_runtime_mode();
+
+bool is_graph_mode();
 
 void ensure_nntile_context();
 

--- a/torch_nntile/csrc/nntile_cross_entropy.cpp
+++ b/torch_nntile/csrc/nntile_cross_entropy.cpp
@@ -102,10 +102,6 @@ at::Tensor cross_entropy_backward(
     TORCH_CHECK(
         is_nntile_device(grad_output.device()),
         "nntile cross_entropy_backward: grad_output must be on device nntile");
-    TORCH_CHECK(
-        target.dim() == 1,
-        "nntile cross_entropy_backward: deferred grad_output broadcast "
-        "requires 1-D labels (batch,) for now");
     at::Tensor grad_logits = at::empty_like(logits);
     at::Tensor grad_row = at::empty(target.sizes(), logits.options());
     pin_graph_op_inputs({logits, target, grad_output});

--- a/torch_nntile/csrc/nntile_cross_entropy.cpp
+++ b/torch_nntile/csrc/nntile_cross_entropy.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
 
 #include <ATen/Functions.h>
 #include <ATen/TensorUtils.h>
@@ -73,14 +74,16 @@ at::Tensor cross_entropy_forward(
     at::Tensor loss = at::empty(
         {},
         at::TensorOptions().dtype(at::kFloat).device(at::kCPU));
-    const float value = tensor_cross_entropy_forward_fp32(
+    pin_graph_op_inputs({logits, target});
+    pin_graph_op_output(loss, true);
+    tensor_cross_entropy_forward_fp32(
         logits.data_ptr<float>(),
         logits.sizes(),
         target.data_ptr<std::int64_t>(),
         target.sizes(),
         ignore_index,
-        reduction_is_mean(reduction));
-    *loss.data_ptr<float>() = value;
+        reduction_is_mean(reduction),
+        loss.data_ptr<float>());
     return loss;
 }
 
@@ -100,6 +103,8 @@ at::Tensor cross_entropy_backward(
         "nntile cross_entropy_backward expects scalar grad_output");
     at::Tensor grad_logits = at::empty_like(logits);
     const float grad_scale = grad_output.item<float>();
+    pin_graph_op_inputs({logits, target});
+    pin_graph_op_output(grad_logits, true);
     tensor_cross_entropy_backward_fp32(
         logits.data_ptr<float>(),
         logits.sizes(),

--- a/torch_nntile/csrc/nntile_cross_entropy.cpp
+++ b/torch_nntile/csrc/nntile_cross_entropy.cpp
@@ -71,9 +71,7 @@ at::Tensor cross_entropy_forward(
         reduction == 1 || reduction == 2,
         "nntile cross_entropy supports reduction mean (1) or sum (2) only");
 
-    at::Tensor loss = at::empty(
-        {},
-        at::TensorOptions().dtype(at::kFloat).device(at::kCPU));
+    at::Tensor loss = at::empty({}, logits.options().dtype(at::kFloat));
     pin_graph_op_inputs({logits, target});
     pin_graph_op_output(loss, true);
     tensor_cross_entropy_forward_fp32(
@@ -101,16 +99,24 @@ at::Tensor cross_entropy_backward(
     TORCH_CHECK(
         grad_output.numel() == 1,
         "nntile cross_entropy_backward expects scalar grad_output");
+    TORCH_CHECK(
+        is_nntile_device(grad_output.device()),
+        "nntile cross_entropy_backward: grad_output must be on device nntile");
+    TORCH_CHECK(
+        target.dim() == 1,
+        "nntile cross_entropy_backward: deferred grad_output broadcast "
+        "requires 1-D labels (batch,) for now");
     at::Tensor grad_logits = at::empty_like(logits);
-    const float grad_scale = grad_output.item<float>();
-    pin_graph_op_inputs({logits, target});
+    at::Tensor grad_row = at::empty(target.sizes(), logits.options());
+    pin_graph_op_inputs({logits, target, grad_output});
     pin_graph_op_output(grad_logits, true);
     tensor_cross_entropy_backward_fp32(
         logits.data_ptr<float>(),
         logits.sizes(),
         target.data_ptr<std::int64_t>(),
         target.sizes(),
-        grad_scale,
+        grad_output.data_ptr<float>(),
+        grad_row.data_ptr<float>(),
         grad_logits.data_ptr<float>(),
         ignore_index,
         reduction_is_mean(reduction));

--- a/torch_nntile/csrc/nntile_executor.cpp
+++ b/torch_nntile/csrc/nntile_executor.cpp
@@ -604,7 +604,7 @@ void tensor_linear_backward_weight_fp32(
     require_libnntile("linear_backward_weight");
 }
 
-float tensor_cross_entropy_forward_fp32(
+void tensor_cross_entropy_forward_fp32(
     const float * /*logits_data*/,
     c10::IntArrayRef /*logits_shape*/,
     const std::int64_t * /*labels_data*/,
@@ -614,7 +614,6 @@ float tensor_cross_entropy_forward_fp32(
     float * /*loss_data*/)
 {
     require_libnntile("cross_entropy_forward");
-    return 0.0f;
 }
 
 void tensor_cross_entropy_backward_fp32(

--- a/torch_nntile/csrc/nntile_executor.cpp
+++ b/torch_nntile/csrc/nntile_executor.cpp
@@ -420,6 +420,35 @@ void tensor_cross_entropy_backward_fp32(
         ignore_index,
         mean_reduction);
 
+    auto broadcast_grad_output_to_row = [&](
+        nntile::TensorGraph::TensorNode *grad_output_node,
+        nntile::TensorGraph::TensorNode *grad_row_node,
+        nntile::TensorGraph &graph,
+        const std::vector<nntile::Index> &labels_graph_shape)
+    {
+        nntile::TensorGraph::TensorNode *src_node = grad_output_node;
+        for (std::size_t dim = 0; dim < labels_graph_shape.size(); ++dim)
+        {
+            nntile::TensorGraph::TensorNode *dst_node = grad_row_node;
+            if (dim + 1 < labels_graph_shape.size())
+            {
+                std::vector<nntile::Index> dst_shape(
+                    labels_graph_shape.begin(),
+                    labels_graph_shape.begin() +
+                        static_cast<std::ptrdiff_t>(dim) + 1);
+                dst_node = graph.data(dst_shape, nntile::DataType::FP32)
+                               ->set_name("grad_output_broadcast");
+                track_graph_node(dst_node);
+            }
+            nntile::tensor::scale_slice(
+                static_cast<nntile::Scalar>(1.0),
+                src_node,
+                dst_node,
+                static_cast<nntile::Index>(dim));
+            src_node = dst_node;
+        }
+    };
+
     auto *logits_node = get_or_create_data_node(
         const_cast<float *>(logits_data),
         logits_graph,
@@ -451,12 +480,12 @@ void tensor_cross_entropy_backward_fp32(
         graph.data(maxsumexp_graph, nntile::DataType::FP32)
             ->set_name("maxsumexp");
 
-    // Broadcast scalar grad_output into per-batch row scales without host read.
-    nntile::tensor::scale_slice(
-        static_cast<nntile::Scalar>(1.0),
+    // Broadcast scalar grad_output to labels shape via chained scale_slice.
+    broadcast_grad_output_to_row(
         grad_output_node,
         grad_row_node,
-        static_cast<nntile::Index>(0));
+        graph,
+        labels_graph);
 
     nntile::tensor::clear(maxsumexp_node);
     nntile::tensor::maxsumexp(

--- a/torch_nntile/csrc/nntile_executor.cpp
+++ b/torch_nntile/csrc/nntile_executor.cpp
@@ -21,6 +21,8 @@
 #include <nntile/tensor/ops/relu.hh>
 #include <nntile/tensor/ops/relu_backward.hh>
 #include <nntile/tensor/ops/sgd_step.hh>
+#include <nntile/tensor/ops/multiply_slice.hh>
+#include <nntile/tensor/ops/scale_slice.hh>
 #include <nntile/tensor/ops/softmax.hh>
 #include <nntile/tensor/ops/subtract_indexed_outputs.hh>
 #include <nntile/tensor/ops/total_sum_accum.hh>
@@ -399,7 +401,8 @@ void tensor_cross_entropy_backward_fp32(
     c10::IntArrayRef logits_shape,
     const std::int64_t *labels_data,
     c10::IntArrayRef labels_shape,
-    float grad_output,
+    const float *grad_output_data,
+    float *grad_row_data,
     float *grad_logits_data,
     std::int64_t ignore_index,
     bool mean_reduction)
@@ -411,13 +414,11 @@ void tensor_cross_entropy_backward_fp32(
     const std::vector<nntile::Index> maxsumexp_graph =
         maxsumexp_graph_shape(logits_graph);
     const nntile::Index class_axis = class_graph_axis(logits_shape);
-    const float scale =
-        cross_entropy_scale(
-            labels_data,
-            labels_shape,
-            ignore_index,
-            mean_reduction)
-        * grad_output;
+    const float ce_scale = cross_entropy_scale(
+        labels_data,
+        labels_shape,
+        ignore_index,
+        mean_reduction);
 
     auto *logits_node = get_or_create_data_node(
         const_cast<float *>(logits_data),
@@ -429,6 +430,16 @@ void tensor_cross_entropy_backward_fp32(
         labels_graph,
         nntile::DataType::INT64,
         true);
+    auto *grad_output_node = get_or_create_data_node(
+        const_cast<float *>(grad_output_data),
+        {},
+        nntile::DataType::FP32,
+        true);
+    auto *grad_row_node = get_or_create_data_node(
+        grad_row_data,
+        labels_graph,
+        nntile::DataType::FP32,
+        false);
     auto *grad_logits_node = get_or_create_data_node(
         grad_logits_data,
         logits_graph,
@@ -439,6 +450,13 @@ void tensor_cross_entropy_backward_fp32(
     auto *maxsumexp_node =
         graph.data(maxsumexp_graph, nntile::DataType::FP32)
             ->set_name("maxsumexp");
+
+    // Broadcast scalar grad_output into per-batch row scales without host read.
+    nntile::tensor::scale_slice(
+        static_cast<nntile::Scalar>(1.0),
+        grad_output_node,
+        grad_row_node,
+        static_cast<nntile::Index>(0));
 
     nntile::tensor::clear(maxsumexp_node);
     nntile::tensor::maxsumexp(
@@ -451,13 +469,18 @@ void tensor_cross_entropy_backward_fp32(
         maxsumexp_node,
         logits_node,
         grad_logits_node,
-        static_cast<nntile::Scalar>(scale),
+        static_cast<nntile::Scalar>(ce_scale),
         class_axis);
     nntile::tensor::subtract_indexed_outputs(
-        static_cast<nntile::Scalar>(scale),
+        static_cast<nntile::Scalar>(ce_scale),
         labels_node,
         grad_logits_node,
         static_cast<nntile::Index>(ignore_index));
+    nntile::tensor::multiply_slice(
+        static_cast<nntile::Scalar>(1.0),
+        grad_row_node,
+        grad_logits_node,
+        class_axis);
 
     register_data_node(grad_logits_data, grad_logits_node);
     maybe_execute_after_record();
@@ -621,7 +644,8 @@ void tensor_cross_entropy_backward_fp32(
     c10::IntArrayRef /*logits_shape*/,
     const std::int64_t * /*labels_data*/,
     c10::IntArrayRef /*labels_shape*/,
-    float /*grad_output*/,
+    const float * /*grad_output_data*/,
+    float * /*grad_row_data*/,
     float * /*grad_logits_data*/,
     std::int64_t /*ignore_index*/,
     bool /*mean_reduction*/)

--- a/torch_nntile/csrc/nntile_executor.cpp
+++ b/torch_nntile/csrc/nntile_executor.cpp
@@ -7,11 +7,12 @@
 #include "nntile_executor.h"
 
 #include "nntile_context.h"
+#include "nntile_graph_recorder.h"
+#include "nntile_graph_recorder_impl.h"
 
 #ifdef TORCH_NNTILE_USE_LIBNNTILE
 
 #include <nntile/base_types.hh>
-#include <nntile/runtime.hh>
 #include <nntile/tensor/ops/add.hh>
 #include <nntile/tensor/ops/clear.hh>
 #include <nntile/tensor/ops/gemm.hh>
@@ -23,12 +24,8 @@
 #include <nntile/tensor/ops/softmax.hh>
 #include <nntile/tensor/ops/subtract_indexed_outputs.hh>
 #include <nntile/tensor/ops/total_sum_accum.hh>
-#include <nntile/tile/graph.hh>
 
-#include <cstring>
 #include <stdexcept>
-#include <string>
-#include <utility>
 #include <vector>
 
 namespace torch_nntile
@@ -48,56 +45,6 @@ std::vector<nntile::Index> pytorch_shape_to_graph(c10::IntArrayRef shape)
     return graph_shape;
 }
 
-nntile::Index graph_numel(const std::vector<nntile::Index> &graph_shape)
-{
-    nntile::Index nelems = 1;
-    for (const nntile::Index dim : graph_shape)
-    {
-        nelems *= dim;
-    }
-    return nelems;
-}
-
-void run_graph_output(
-    const char *graph_name,
-    nntile::TensorGraph::TensorNode *out_node,
-    const std::vector<std::pair<nntile::TensorGraph::TensorNode *, const float *>>
-        &inputs,
-    float *out_data,
-    const std::vector<nntile::Index> &out_graph_shape)
-{
-    ensure_nntile_context();
-
-    nntile::TileGraph tile_graph =
-        nntile::TileGraph::from_tensor_graph(*out_node->graph());
-    nntile::Runtime runtime(tile_graph);
-    runtime.compile();
-
-    const std::size_t expected =
-        static_cast<std::size_t>(graph_numel(out_graph_shape));
-    out_node->mark_input(true);
-
-    for (const auto &[node, data] : inputs)
-    {
-        const nntile::Index count = graph_numel(node->shape());
-        runtime.bind_data(node, data, static_cast<std::size_t>(count));
-    }
-    runtime.bind_data(out_node, out_data, expected);
-    runtime.execute();
-    runtime.wait();
-
-    const std::vector<float> result = runtime.get_output<float>(out_node);
-    if (result.size() != expected)
-    {
-        throw std::runtime_error(
-            std::string(graph_name) + ": output size mismatch");
-    }
-    if (result.data() != out_data)
-    {
-        std::memcpy(out_data, result.data(), expected * sizeof(float));
-    }
-}
-
 } // namespace
 
 void tensor_add_fp32(
@@ -111,27 +58,24 @@ void tensor_add_fp32(
     const std::vector<nntile::Index> graph_shape =
         pytorch_shape_to_graph(pytorch_shape);
 
-    nntile::TensorGraph graph("torch_add");
-    auto *x_node =
-        graph.data(graph_shape, nntile::DataType::FP32)->set_name("x");
-    auto *y_node =
-        graph.data(graph_shape, nntile::DataType::FP32)->set_name("y");
-    x_node->mark_input(true);
-    y_node->mark_input(true);
+    auto *x_node = get_or_create_data_node(
+        const_cast<float *>(x_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+    auto *y_node = get_or_create_data_node(
+        const_cast<float *>(y_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
 
     auto *z_node = nntile::tensor::add(
         static_cast<nntile::Scalar>(alpha),
         x_node,
         static_cast<nntile::Scalar>(beta),
         y_node)->set_name("z");
-    z_node->mark_output(true);
-
-    run_graph_output(
-        "torch_add",
-        z_node,
-        {{x_node, x_data}, {y_node, y_data}},
-        out_data,
-        graph_shape);
+    register_data_node(out_data, z_node);
+    maybe_execute_after_record();
 }
 
 void tensor_linear_fp32(
@@ -146,16 +90,17 @@ void tensor_linear_fp32(
         pytorch_shape_to_graph(input_shape);
     const std::vector<nntile::Index> weight_graph =
         pytorch_shape_to_graph(weight_shape);
-    const std::vector<nntile::Index> out_graph =
-        pytorch_shape_to_graph(out_shape);
 
-    nntile::TensorGraph graph("torch_linear");
-    auto *input_node =
-        graph.data(input_graph, nntile::DataType::FP32)->set_name("input");
-    auto *weight_node =
-        graph.data(weight_graph, nntile::DataType::FP32)->set_name("weight");
-    input_node->mark_input(true);
-    weight_node->mark_input(true);
+    auto *input_node = get_or_create_data_node(
+        const_cast<float *>(input_data),
+        input_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *weight_node = get_or_create_data_node(
+        const_cast<float *>(weight_data),
+        weight_graph,
+        nntile::DataType::FP32,
+        true);
 
     auto *out_node = nntile::tensor::gemm(
         input_node,
@@ -165,14 +110,8 @@ void tensor_linear_fp32(
         true,
         static_cast<nntile::Index>(1),
         static_cast<nntile::Index>(0))->set_name("output");
-    out_node->mark_output(true);
-
-    run_graph_output(
-        "torch_linear",
-        out_node,
-        {{input_node, input_data}, {weight_node, weight_data}},
-        out_data,
-        out_graph);
+    register_data_node(out_data, out_node);
+    maybe_execute_after_record();
 }
 
 void tensor_relu_fp32(
@@ -183,20 +122,15 @@ void tensor_relu_fp32(
     const std::vector<nntile::Index> graph_shape =
         pytorch_shape_to_graph(pytorch_shape);
 
-    nntile::TensorGraph graph("torch_relu");
-    auto *src_node =
-        graph.data(graph_shape, nntile::DataType::FP32)->set_name("src");
-    src_node->mark_input(true);
+    auto *src_node = get_or_create_data_node(
+        const_cast<float *>(input_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
 
     auto *dst_node = nntile::tensor::relu(src_node)->set_name("dst");
-    dst_node->mark_output(true);
-
-    run_graph_output(
-        "torch_relu",
-        dst_node,
-        {{src_node, input_data}},
-        out_data,
-        graph_shape);
+    register_data_node(out_data, dst_node);
+    maybe_execute_after_record();
 }
 
 void tensor_relu_backward_fp32(
@@ -208,43 +142,26 @@ void tensor_relu_backward_fp32(
     const std::vector<nntile::Index> graph_shape =
         pytorch_shape_to_graph(pytorch_shape);
 
-    nntile::TensorGraph graph("torch_relu_backward");
-    auto *x_node =
-        graph.data(graph_shape, nntile::DataType::FP32)->set_name("x");
-    auto *dy_node =
-        graph.data(graph_shape, nntile::DataType::FP32)->set_name("dy");
-    auto *dx_node =
-        graph.data(graph_shape, nntile::DataType::FP32)->set_name("dx");
-    x_node->mark_input(true);
-    dy_node->mark_input(true);
-    dx_node->mark_input(true);
-    dx_node->mark_output(true);
+    auto *x_node = get_or_create_data_node(
+        const_cast<float *>(x_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+    auto *dy_node = get_or_create_data_node(
+        const_cast<float *>(dy_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+    auto *dx_node = get_or_create_data_node(
+        dx_data,
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
 
     nntile::tensor::clear(dx_node);
     nntile::tensor::relu_backward(x_node, dy_node, dx_node);
-
-    ensure_nntile_context();
-
-    nntile::TileGraph tile_graph =
-        nntile::TileGraph::from_tensor_graph(graph);
-    nntile::Runtime runtime(tile_graph);
-    runtime.compile();
-
-    const nntile::Index count = graph_numel(graph_shape);
-    std::vector<float> dx_init(static_cast<std::size_t>(count), 0.0f);
-    runtime.bind_data(x_node, x_data, static_cast<std::size_t>(count));
-    runtime.bind_data(dy_node, dy_data, static_cast<std::size_t>(count));
-    runtime.bind_data(dx_node, dx_init.data(), static_cast<std::size_t>(count));
-    runtime.execute();
-    runtime.wait();
-
-    const std::vector<float> result = runtime.get_output<float>(dx_node);
-    const std::size_t expected = static_cast<std::size_t>(count);
-    if (result.size() != expected)
-    {
-        throw std::runtime_error("torch_relu_backward: output size mismatch");
-    }
-    std::memcpy(dx_data, result.data(), expected * sizeof(float));
+    register_data_node(dx_data, dx_node);
+    maybe_execute_after_record();
 }
 
 void tensor_mm_fp32(
@@ -259,16 +176,17 @@ void tensor_mm_fp32(
         pytorch_shape_to_graph(a_shape);
     const std::vector<nntile::Index> b_graph =
         pytorch_shape_to_graph(b_shape);
-    const std::vector<nntile::Index> out_graph =
-        pytorch_shape_to_graph(out_shape);
 
-    nntile::TensorGraph graph("torch_mm");
-    auto *a_node =
-        graph.data(a_graph, nntile::DataType::FP32)->set_name("a");
-    auto *b_node =
-        graph.data(b_graph, nntile::DataType::FP32)->set_name("b");
-    a_node->mark_input(true);
-    b_node->mark_input(true);
+    auto *a_node = get_or_create_data_node(
+        const_cast<float *>(a_data),
+        a_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *b_node = get_or_create_data_node(
+        const_cast<float *>(b_data),
+        b_graph,
+        nntile::DataType::FP32,
+        true);
 
     auto *out_node = nntile::tensor::gemm(
         a_node,
@@ -278,14 +196,8 @@ void tensor_mm_fp32(
         false,
         static_cast<nntile::Index>(1),
         static_cast<nntile::Index>(0))->set_name("out");
-    out_node->mark_output(true);
-
-    run_graph_output(
-        "torch_mm",
-        out_node,
-        {{a_node, a_data}, {b_node, b_data}},
-        out_data,
-        out_graph);
+    register_data_node(out_data, out_node);
+    maybe_execute_after_record();
 }
 
 void tensor_linear_backward_input_fp32(
@@ -300,16 +212,17 @@ void tensor_linear_backward_input_fp32(
         pytorch_shape_to_graph(grad_out_shape);
     const std::vector<nntile::Index> weight_graph =
         pytorch_shape_to_graph(weight_shape);
-    const std::vector<nntile::Index> grad_input_graph =
-        pytorch_shape_to_graph(grad_input_shape);
 
-    nntile::TensorGraph graph("torch_linear_backward_input");
-    auto *grad_out_node = graph.data(grad_out_graph, nntile::DataType::FP32)
-                              ->set_name("grad_out");
-    auto *weight_node =
-        graph.data(weight_graph, nntile::DataType::FP32)->set_name("weight");
-    grad_out_node->mark_input(true);
-    weight_node->mark_input(true);
+    auto *grad_out_node = get_or_create_data_node(
+        const_cast<float *>(grad_out_data),
+        grad_out_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *weight_node = get_or_create_data_node(
+        const_cast<float *>(weight_data),
+        weight_graph,
+        nntile::DataType::FP32,
+        true);
 
     auto *grad_input_node = nntile::tensor::gemm(
         grad_out_node,
@@ -319,14 +232,8 @@ void tensor_linear_backward_input_fp32(
         false,
         static_cast<nntile::Index>(1),
         static_cast<nntile::Index>(0))->set_name("grad_input");
-    grad_input_node->mark_output(true);
-
-    run_graph_output(
-        "torch_linear_backward_input",
-        grad_input_node,
-        {{grad_out_node, grad_out_data}, {weight_node, weight_data}},
-        grad_input_data,
-        grad_input_graph);
+    register_data_node(grad_input_data, grad_input_node);
+    maybe_execute_after_record();
 }
 
 void tensor_linear_backward_weight_fp32(
@@ -341,16 +248,17 @@ void tensor_linear_backward_weight_fp32(
         pytorch_shape_to_graph(grad_out_shape);
     const std::vector<nntile::Index> input_graph =
         pytorch_shape_to_graph(input_shape);
-    const std::vector<nntile::Index> grad_weight_graph =
-        pytorch_shape_to_graph(grad_weight_shape);
 
-    nntile::TensorGraph graph("torch_linear_backward_weight");
-    auto *grad_out_node = graph.data(grad_out_graph, nntile::DataType::FP32)
-                              ->set_name("grad_out");
-    auto *input_node =
-        graph.data(input_graph, nntile::DataType::FP32)->set_name("input");
-    grad_out_node->mark_input(true);
-    input_node->mark_input(true);
+    auto *grad_out_node = get_or_create_data_node(
+        const_cast<float *>(grad_out_data),
+        grad_out_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *input_node = get_or_create_data_node(
+        const_cast<float *>(input_data),
+        input_graph,
+        nntile::DataType::FP32,
+        true);
 
     auto *grad_weight_node = nntile::tensor::gemm(
         grad_out_node,
@@ -360,14 +268,8 @@ void tensor_linear_backward_weight_fp32(
         false,
         static_cast<nntile::Index>(1),
         static_cast<nntile::Index>(0))->set_name("grad_weight");
-    grad_weight_node->mark_output(true);
-
-    run_graph_output(
-        "torch_linear_backward_weight",
-        grad_weight_node,
-        {{grad_out_node, grad_out_data}, {input_node, input_data}},
-        grad_weight_data,
-        grad_weight_graph);
+    register_data_node(grad_weight_data, grad_weight_node);
+    maybe_execute_after_record();
 }
 
 namespace
@@ -427,13 +329,14 @@ float cross_entropy_scale(
 
 } // namespace
 
-float tensor_cross_entropy_forward_fp32(
+void tensor_cross_entropy_forward_fp32(
     const float *logits_data,
     c10::IntArrayRef logits_shape,
     const std::int64_t *labels_data,
     c10::IntArrayRef labels_shape,
     std::int64_t ignore_index,
-    bool mean_reduction)
+    bool mean_reduction,
+    float *loss_data)
 {
     const std::vector<nntile::Index> logits_graph =
         pytorch_shape_to_graph(logits_shape);
@@ -448,22 +351,28 @@ float tensor_cross_entropy_forward_fp32(
         ignore_index,
         mean_reduction);
 
-    nntile::TensorGraph graph("torch_cross_entropy_forward");
-    auto *logits_node =
-        graph.data(logits_graph, nntile::DataType::FP32)->set_name("logits");
-    auto *labels_node = graph.data(labels_graph, nntile::DataType::INT64)
-                              ->set_name("labels");
+    auto *logits_node = get_or_create_data_node(
+        const_cast<float *>(logits_data),
+        logits_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *labels_node = get_or_create_data_node(
+        const_cast<std::int64_t *>(labels_data),
+        labels_graph,
+        nntile::DataType::INT64,
+        true);
+    auto *loss_node = get_or_create_data_node(
+        loss_data,
+        {},
+        nntile::DataType::FP32,
+        true);
+
+    auto &graph = *logits_node->graph();
     auto *maxsumexp_node =
         graph.data(maxsumexp_graph, nntile::DataType::FP32)
             ->set_name("maxsumexp");
     auto *logsumexp_node =
         graph.data(labels_graph, nntile::DataType::FP32)->set_name("logsumexp");
-    auto *loss_node = graph.data({}, nntile::DataType::FP32)->set_name("loss");
-
-    logits_node->mark_input(true);
-    labels_node->mark_input(true);
-    loss_node->mark_input(true);
-    loss_node->mark_output(true);
 
     nntile::tensor::clear(maxsumexp_node);
     nntile::tensor::maxsumexp(
@@ -481,35 +390,8 @@ float tensor_cross_entropy_forward_fp32(
         loss_node,
         static_cast<nntile::Index>(ignore_index));
 
-    ensure_nntile_context();
-
-    nntile::TileGraph tile_graph =
-        nntile::TileGraph::from_tensor_graph(graph);
-    nntile::Runtime runtime(tile_graph);
-    runtime.compile();
-
-    const nntile::Index logits_count = graph_numel(logits_graph);
-    const nntile::Index labels_count = graph_numel(labels_graph);
-    float loss_init = 0.0f;
-    runtime.bind_data(
-        logits_node,
-        logits_data,
-        static_cast<std::size_t>(logits_count));
-    runtime.bind_data(
-        labels_node,
-        labels_data,
-        static_cast<std::size_t>(labels_count));
-    runtime.bind_data(loss_node, &loss_init, 1);
-    runtime.execute();
-    runtime.wait();
-
-    const std::vector<float> result = runtime.get_output<float>(loss_node);
-    if (result.size() != 1)
-    {
-        throw std::runtime_error(
-            "torch_cross_entropy_forward: expected scalar loss");
-    }
-    return result[0];
+    register_data_node(loss_data, loss_node);
+    maybe_execute_after_record();
 }
 
 void tensor_cross_entropy_backward_fp32(
@@ -537,22 +419,26 @@ void tensor_cross_entropy_backward_fp32(
             mean_reduction)
         * grad_output;
 
-    nntile::TensorGraph graph("torch_cross_entropy_backward");
-    auto *logits_node =
-        graph.data(logits_graph, nntile::DataType::FP32)->set_name("logits");
-    auto *labels_node = graph.data(labels_graph, nntile::DataType::INT64)
-                              ->set_name("labels");
+    auto *logits_node = get_or_create_data_node(
+        const_cast<float *>(logits_data),
+        logits_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *labels_node = get_or_create_data_node(
+        const_cast<std::int64_t *>(labels_data),
+        labels_graph,
+        nntile::DataType::INT64,
+        true);
+    auto *grad_logits_node = get_or_create_data_node(
+        grad_logits_data,
+        logits_graph,
+        nntile::DataType::FP32,
+        true);
+
+    auto &graph = *logits_node->graph();
     auto *maxsumexp_node =
         graph.data(maxsumexp_graph, nntile::DataType::FP32)
             ->set_name("maxsumexp");
-    auto *grad_logits_node =
-        graph.data(logits_graph, nntile::DataType::FP32)
-            ->set_name("grad_logits");
-
-    logits_node->mark_input(true);
-    labels_node->mark_input(true);
-    grad_logits_node->mark_input(true);
-    grad_logits_node->mark_output(true);
 
     nntile::tensor::clear(maxsumexp_node);
     nntile::tensor::maxsumexp(
@@ -573,40 +459,8 @@ void tensor_cross_entropy_backward_fp32(
         grad_logits_node,
         static_cast<nntile::Index>(ignore_index));
 
-    ensure_nntile_context();
-
-    nntile::TileGraph tile_graph =
-        nntile::TileGraph::from_tensor_graph(graph);
-    nntile::Runtime runtime(tile_graph);
-    runtime.compile();
-
-    const nntile::Index logits_count = graph_numel(logits_graph);
-    const nntile::Index labels_count = graph_numel(labels_graph);
-    std::vector<float> grad_init(static_cast<std::size_t>(logits_count), 0.0f);
-    runtime.bind_data(
-        logits_node,
-        logits_data,
-        static_cast<std::size_t>(logits_count));
-    runtime.bind_data(
-        labels_node,
-        labels_data,
-        static_cast<std::size_t>(labels_count));
-    runtime.bind_data(
-        grad_logits_node,
-        grad_init.data(),
-        static_cast<std::size_t>(logits_count));
-    runtime.execute();
-    runtime.wait();
-
-    const std::vector<float> result =
-        runtime.get_output<float>(grad_logits_node);
-    const std::size_t expected = static_cast<std::size_t>(logits_count);
-    if (result.size() != expected)
-    {
-        throw std::runtime_error(
-            "torch_cross_entropy_backward: output size mismatch");
-    }
-    std::memcpy(grad_logits_data, result.data(), expected * sizeof(float));
+    register_data_node(grad_logits_data, grad_logits_node);
+    maybe_execute_after_record();
 }
 
 void tensor_sgd_step_fp32(
@@ -623,21 +477,22 @@ void tensor_sgd_step_fp32(
 {
     const std::vector<nntile::Index> graph_shape =
         pytorch_shape_to_graph(pytorch_shape);
-    const nntile::Index nelems = graph_numel(graph_shape);
 
-    nntile::TensorGraph graph("torch_sgd_step");
-    auto *grad_node =
-        graph.data(graph_shape, nntile::DataType::FP32)->set_name("grad");
-    auto *velocity_node =
-        graph.data(graph_shape, nntile::DataType::FP32)->set_name("velocity");
-    auto *param_node =
-        graph.data(graph_shape, nntile::DataType::FP32)->set_name("param");
-
-    grad_node->mark_input(true);
-    velocity_node->mark_input(true);
-    param_node->mark_input(true);
-    velocity_node->mark_output(true);
-    param_node->mark_output(true);
+    auto *grad_node = get_or_create_data_node(
+        const_cast<float *>(grad_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+    auto *velocity_node = get_or_create_data_node(
+        velocity_data,
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+    auto *param_node = get_or_create_data_node(
+        param_data,
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
 
     nntile::tensor::sgd_step(
         static_cast<nntile::Index>(num_iter),
@@ -650,39 +505,9 @@ void tensor_sgd_step_fp32(
         velocity_node,
         param_node);
 
-    ensure_nntile_context();
-
-    nntile::TileGraph tile_graph =
-        nntile::TileGraph::from_tensor_graph(graph);
-    nntile::Runtime runtime(tile_graph);
-    runtime.compile();
-
-    runtime.bind_data(
-        grad_node,
-        grad_data,
-        static_cast<std::size_t>(nelems));
-    runtime.bind_data(
-        velocity_node,
-        velocity_data,
-        static_cast<std::size_t>(nelems));
-    runtime.bind_data(
-        param_node,
-        param_data,
-        static_cast<std::size_t>(nelems));
-    runtime.execute();
-    runtime.wait();
-
-    const std::vector<float> velocity_out =
-        runtime.get_output<float>(velocity_node);
-    const std::vector<float> param_out =
-        runtime.get_output<float>(param_node);
-    const std::size_t expected = static_cast<std::size_t>(nelems);
-    if (velocity_out.size() != expected || param_out.size() != expected)
-    {
-        throw std::runtime_error("torch_sgd_step: output size mismatch");
-    }
-    std::memcpy(velocity_data, velocity_out.data(), expected * sizeof(float));
-    std::memcpy(param_data, param_out.data(), expected * sizeof(float));
+    register_data_node(velocity_data, velocity_node);
+    register_data_node(param_data, param_node);
+    maybe_execute_after_record();
 }
 
 } // namespace torch_nntile
@@ -785,7 +610,8 @@ float tensor_cross_entropy_forward_fp32(
     const std::int64_t * /*labels_data*/,
     c10::IntArrayRef /*labels_shape*/,
     std::int64_t /*ignore_index*/,
-    bool /*mean_reduction*/)
+    bool /*mean_reduction*/,
+    float * /*loss_data*/)
 {
     require_libnntile("cross_entropy_forward");
     return 0.0f;

--- a/torch_nntile/csrc/nntile_executor.h
+++ b/torch_nntile/csrc/nntile_executor.h
@@ -76,7 +76,8 @@ void tensor_cross_entropy_backward_fp32(
     c10::IntArrayRef logits_shape,
     const std::int64_t *labels_data,
     c10::IntArrayRef labels_shape,
-    float grad_output,
+    const float *grad_output_data,
+    float *grad_row_data,
     float *grad_logits_data,
     std::int64_t ignore_index,
     bool mean_reduction);

--- a/torch_nntile/csrc/nntile_executor.h
+++ b/torch_nntile/csrc/nntile_executor.h
@@ -62,13 +62,14 @@ void tensor_linear_backward_weight_fp32(
     float *grad_weight_data,
     c10::IntArrayRef grad_weight_shape);
 
-float tensor_cross_entropy_forward_fp32(
+void tensor_cross_entropy_forward_fp32(
     const float *logits_data,
     c10::IntArrayRef logits_shape,
     const std::int64_t *labels_data,
     c10::IntArrayRef labels_shape,
     std::int64_t ignore_index,
-    bool mean_reduction);
+    bool mean_reduction,
+    float *loss_data);
 
 void tensor_cross_entropy_backward_fp32(
     const float *logits_data,

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -384,45 +384,16 @@ void maybe_execute_after_record()
 {
 }
 
-nntile::TensorGraph &recorder_graph()
-{
-    require_libnntile();
-}
-
-nntile::TensorGraph::TensorNode *get_or_create_data_node(
-    void * /*data_ptr*/,
-    const std::vector<nntile::Index> & /*shape*/,
-    nntile::DataType /*dtype*/,
-    bool /*mark_as_input*/)
-{
-    require_libnntile();
-}
-
-void register_data_node(
-    void * /*data_ptr*/,
-    nntile::TensorGraph::TensorNode * /*node*/)
-{
-    require_libnntile();
-}
-
-nntile::TensorGraph::TensorNode *lookup_data_node(void * /*data_ptr*/)
-{
-    require_libnntile();
-}
-
 void pin_tensor_for_graph(const at::Tensor & /*tensor*/)
 {
-    require_libnntile();
 }
 
 void pin_graph_op_inputs(const std::vector<at::Tensor> & /*inputs*/)
 {
-    require_libnntile();
 }
 
 void pin_graph_op_output(const at::Tensor & /*output*/, bool /*pin_output*/)
 {
-    require_libnntile();
 }
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -316,6 +316,12 @@ nntile::TensorGraph::TensorNode *lookup_data_node(void *data_ptr)
     return found->second.node;
 }
 
+void track_graph_node(nntile::TensorGraph::TensorNode *node)
+{
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    track_node(node);
+}
+
 void pin_tensor_for_graph(const at::Tensor &tensor)
 {
     if (!is_graph_mode())

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -1,0 +1,430 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_graph_recorder.cpp
+ */
+
+#include "nntile_graph_recorder.h"
+#include "nntile_graph_recorder_impl.h"
+
+#include "nntile_context.h"
+
+#include <ATen/Tensor.h>
+
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
+
+#include <nntile/runtime.hh>
+#include <nntile/tensor/graph.hh>
+#include <nntile/tile/graph.hh>
+
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+struct MappedTensor
+{
+    nntile::TensorGraph::TensorNode *node = nullptr;
+    nntile::DataType dtype = nntile::DataType::FP32;
+    std::size_t count = 0;
+    //! Copy runtime result into the PyTorch storage after execute.
+    bool needs_host_copy = false;
+    //! Bind PyTorch storage before execute (inputs and final outputs only).
+    bool bind_at_execute = false;
+    //! User/parameter inputs that must stay bound across multiple ops.
+    bool is_persistent_input = false;
+};
+
+std::mutex g_recorder_mutex;
+std::unique_ptr<nntile::TensorGraph> g_graph;
+std::unordered_map<void *, MappedTensor> g_tensor_nodes;
+std::unordered_set<nntile::TensorGraph::TensorNode *> g_all_nodes;
+std::vector<at::Tensor> g_pinned_tensors;
+
+void track_node(nntile::TensorGraph::TensorNode *node)
+{
+    if (node != nullptr)
+    {
+        g_all_nodes.insert(node);
+    }
+}
+
+nntile::Index graph_numel(const std::vector<nntile::Index> &graph_shape)
+{
+    nntile::Index nelems = 1;
+    for (const nntile::Index dim : graph_shape)
+    {
+        nelems *= dim;
+    }
+    return nelems;
+}
+
+void copy_output_if_needed(
+    nntile::Runtime &runtime,
+    const MappedTensor &mapped,
+    void *data_ptr)
+{
+    const std::size_t count = mapped.count;
+    if (count == 0 || !mapped.node->is_output())
+    {
+        return;
+    }
+    switch (mapped.dtype)
+    {
+    case nntile::DataType::FP32:
+    {
+        const std::vector<float> result =
+            runtime.get_output<float>(mapped.node);
+        if (result.size() != count)
+        {
+            throw std::runtime_error(
+                "torch_nntile execute: output size mismatch");
+        }
+        if (result.data() != data_ptr)
+        {
+            std::memcpy(data_ptr, result.data(), count * sizeof(float));
+        }
+        break;
+    }
+    case nntile::DataType::INT64:
+    {
+        const std::vector<std::int64_t> result =
+            runtime.get_output<std::int64_t>(mapped.node);
+        if (result.size() != count)
+        {
+            throw std::runtime_error(
+                "torch_nntile execute: output size mismatch");
+        }
+        if (result.data() != data_ptr)
+        {
+            std::memcpy(
+                data_ptr,
+                result.data(),
+                count * sizeof(std::int64_t));
+        }
+        break;
+    }
+    default:
+        throw std::runtime_error(
+            "torch_nntile graph recorder: unsupported output dtype");
+    }
+}
+
+void copy_host_visible_outputs(
+    nntile::Runtime &runtime,
+    const void * /*preferred_ptr*/)
+{
+    for (auto &[data_ptr, mapped] : g_tensor_nodes)
+    {
+        if (!mapped.needs_host_copy)
+        {
+            continue;
+        }
+        copy_output_if_needed(runtime, mapped, data_ptr);
+    }
+}
+
+void reset_recorder_locked()
+{
+    g_graph.reset();
+    g_tensor_nodes.clear();
+    g_all_nodes.clear();
+    g_pinned_tensors.clear();
+}
+
+void execute_pending_graph_locked()
+{
+    if (g_graph == nullptr || g_graph->num_ops() == 0)
+    {
+        return;
+    }
+
+    ensure_nntile_context();
+
+    // Mark every recorded node as output so DCE cannot drop it.
+    for (nntile::TensorGraph::TensorNode *node : g_all_nodes)
+    {
+        node->mark_output(true);
+    }
+
+    nntile::TileGraph tile_graph =
+        nntile::TileGraph::from_tensor_graph(*g_graph);
+    nntile::Runtime runtime(tile_graph);
+    runtime.compile();
+
+    // Bind only storages that are still live (inputs and leaf outputs).
+    // Intermediate buffers may already be freed by PyTorch.
+    for (const auto &[data_ptr, mapped] : g_tensor_nodes)
+    {
+        if (!mapped.bind_at_execute)
+        {
+            continue;
+        }
+        mapped.node->mark_input(true);
+        const std::size_t count = mapped.count;
+        switch (mapped.dtype)
+        {
+        case nntile::DataType::FP32:
+            runtime.bind_data(
+                mapped.node,
+                static_cast<const float *>(data_ptr),
+                count);
+            break;
+        case nntile::DataType::INT64:
+            runtime.bind_data(
+                mapped.node,
+                static_cast<const std::int64_t *>(data_ptr),
+                count);
+            break;
+        default:
+            throw std::runtime_error(
+                "torch_nntile execute: unsupported bind dtype");
+        }
+    }
+
+    runtime.execute();
+    runtime.wait();
+
+    copy_host_visible_outputs(runtime, nullptr);
+
+    reset_recorder_locked();
+}
+
+} // namespace
+
+bool has_pending_graph()
+{
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    return g_graph != nullptr && g_graph->num_ops() > 0;
+}
+
+void require_no_pending_graph(const char *op_name)
+{
+    if (!is_graph_mode())
+    {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    if (g_graph != nullptr && g_graph->num_ops() > 0)
+    {
+        throw std::runtime_error(
+            std::string("torch_nntile: pending graph must be flushed with "
+                        "torch_nntile.execute() before ") +
+            op_name);
+    }
+}
+
+void execute_pending_graph()
+{
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    execute_pending_graph_locked();
+}
+
+void maybe_execute_after_record()
+{
+    if (get_runtime_mode() == RuntimeMode::Eager)
+    {
+        execute_pending_graph();
+    }
+}
+
+nntile::TensorGraph &recorder_graph()
+{
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    if (g_graph == nullptr)
+    {
+        g_graph = std::make_unique<nntile::TensorGraph>("torch_nntile");
+    }
+    return *g_graph;
+}
+
+nntile::TensorGraph::TensorNode *get_or_create_data_node(
+    void *data_ptr,
+    const std::vector<nntile::Index> &shape,
+    nntile::DataType dtype,
+    bool mark_as_input)
+{
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    if (g_graph == nullptr)
+    {
+        g_graph = std::make_unique<nntile::TensorGraph>("torch_nntile");
+    }
+
+    const auto found = g_tensor_nodes.find(data_ptr);
+    if (found != g_tensor_nodes.end())
+    {
+        // Intermediate op output fed into a later op: keep the node for DCE
+        // but stop binding/copying through storage PyTorch may free or reuse.
+        if (!found->second.is_persistent_input && found->second.needs_host_copy)
+        {
+            found->second.bind_at_execute = false;
+            found->second.needs_host_copy = false;
+        }
+        track_node(found->second.node);
+        return found->second.node;
+    }
+
+    auto *node = g_graph->data(shape, dtype);
+    if (mark_as_input)
+    {
+        node->mark_input(true);
+    }
+    track_node(node);
+    g_tensor_nodes[data_ptr] = MappedTensor{
+        node,
+        dtype,
+        static_cast<std::size_t>(graph_numel(shape)),
+        false,
+        mark_as_input,
+        mark_as_input};
+    return node;
+}
+
+void register_data_node(
+    void *data_ptr,
+    nntile::TensorGraph::TensorNode *node)
+{
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    node->mark_output(true);
+    track_node(node);
+    g_tensor_nodes[data_ptr] = MappedTensor{
+        node,
+        node->dtype(),
+        static_cast<std::size_t>(node->nelems()),
+        true,
+        true,
+        false};
+}
+
+nntile::TensorGraph::TensorNode *lookup_data_node(void *data_ptr)
+{
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    const auto found = g_tensor_nodes.find(data_ptr);
+    if (found == g_tensor_nodes.end())
+    {
+        return nullptr;
+    }
+    return found->second.node;
+}
+
+void pin_tensor_for_graph(const at::Tensor &tensor)
+{
+    if (!is_graph_mode())
+    {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    g_pinned_tensors.push_back(tensor);
+}
+
+void pin_graph_op_inputs(const std::vector<at::Tensor> &inputs)
+{
+    if (!is_graph_mode())
+    {
+        return;
+    }
+    for (const at::Tensor &tensor : inputs)
+    {
+        pin_tensor_for_graph(tensor);
+    }
+}
+
+void pin_graph_op_output(const at::Tensor &output, bool pin_output)
+{
+    if (!is_graph_mode() || !pin_output)
+    {
+        return;
+    }
+    pin_tensor_for_graph(output);
+}
+
+} // namespace torch_nntile
+
+#else
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+[[noreturn]] void require_libnntile()
+{
+    throw std::runtime_error(
+        "torch_nntile graph recorder requires libnntile "
+        "(rebuild with NNTILE_BUILD_DIR set)");
+}
+
+} // namespace
+
+bool has_pending_graph()
+{
+    return false;
+}
+
+void require_no_pending_graph(const char * /*op_name*/)
+{
+}
+
+void execute_pending_graph()
+{
+    require_libnntile();
+}
+
+void maybe_execute_after_record()
+{
+}
+
+nntile::TensorGraph &recorder_graph()
+{
+    require_libnntile();
+}
+
+nntile::TensorGraph::TensorNode *get_or_create_data_node(
+    void * /*data_ptr*/,
+    const std::vector<nntile::Index> & /*shape*/,
+    nntile::DataType /*dtype*/,
+    bool /*mark_as_input*/)
+{
+    require_libnntile();
+}
+
+void register_data_node(
+    void * /*data_ptr*/,
+    nntile::TensorGraph::TensorNode * /*node*/)
+{
+    require_libnntile();
+}
+
+nntile::TensorGraph::TensorNode *lookup_data_node(void * /*data_ptr*/)
+{
+    require_libnntile();
+}
+
+void pin_tensor_for_graph(const at::Tensor & /*tensor*/)
+{
+    require_libnntile();
+}
+
+void pin_graph_op_inputs(const std::vector<at::Tensor> & /*inputs*/)
+{
+    require_libnntile();
+}
+
+void pin_graph_op_output(const at::Tensor & /*output*/, bool /*pin_output*/)
+{
+    require_libnntile();
+}
+
+} // namespace torch_nntile
+
+#endif

--- a/torch_nntile/csrc/nntile_graph_recorder.h
+++ b/torch_nntile/csrc/nntile_graph_recorder.h
@@ -1,0 +1,20 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_graph_recorder.h
+ */
+
+#pragma once
+
+namespace torch_nntile
+{
+
+bool has_pending_graph();
+
+void require_no_pending_graph(const char *op_name);
+
+void execute_pending_graph();
+
+void maybe_execute_after_record();
+
+} // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_graph_recorder_impl.h
+++ b/torch_nntile/csrc/nntile_graph_recorder_impl.h
@@ -47,6 +47,8 @@ void register_data_node(
 
 nntile::TensorGraph::TensorNode *lookup_data_node(void *data_ptr);
 
+void track_graph_node(nntile::TensorGraph::TensorNode *node);
+
 #endif // TORCH_NNTILE_USE_LIBNNTILE
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_graph_recorder_impl.h
+++ b/torch_nntile/csrc/nntile_graph_recorder_impl.h
@@ -7,10 +7,12 @@
 
 #pragma once
 
+#include <vector>
+
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
 #include <nntile/dtype.hh>
 #include <nntile/tensor/graph.hh>
-
-#include <vector>
+#endif
 
 namespace at
 {
@@ -19,6 +21,17 @@ class Tensor;
 
 namespace torch_nntile
 {
+
+//! Keep tensor storage alive until execute() (CUDA record_stream analog).
+void pin_tensor_for_graph(const at::Tensor &tensor);
+
+//! Pin op inputs and user-held outputs. Do not pin backward return buffers
+//! that autograd will steal into leaf .grad (extra refs block stealing).
+void pin_graph_op_inputs(const std::vector<at::Tensor> &inputs);
+
+void pin_graph_op_output(const at::Tensor &output, bool is_user_visible);
+
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
 
 nntile::TensorGraph &recorder_graph();
 
@@ -34,13 +47,6 @@ void register_data_node(
 
 nntile::TensorGraph::TensorNode *lookup_data_node(void *data_ptr);
 
-//! Keep tensor storage alive until execute() (CUDA record_stream analog).
-void pin_tensor_for_graph(const at::Tensor &tensor);
-
-//! Pin op inputs and user-held outputs. Do not pin backward return buffers
-//! that autograd will steal into leaf .grad (extra refs block stealing).
-void pin_graph_op_inputs(const std::vector<at::Tensor> &inputs);
-
-void pin_graph_op_output(const at::Tensor &output, bool is_user_visible);
+#endif // TORCH_NNTILE_USE_LIBNNTILE
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_graph_recorder_impl.h
+++ b/torch_nntile/csrc/nntile_graph_recorder_impl.h
@@ -1,0 +1,46 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_graph_recorder_impl.h
+ * Internal graph recording helpers (libnntile TensorGraph).
+ */
+
+#pragma once
+
+#include <nntile/dtype.hh>
+#include <nntile/tensor/graph.hh>
+
+#include <vector>
+
+namespace at
+{
+class Tensor;
+}
+
+namespace torch_nntile
+{
+
+nntile::TensorGraph &recorder_graph();
+
+nntile::TensorGraph::TensorNode *get_or_create_data_node(
+    void *data_ptr,
+    const std::vector<nntile::Index> &shape,
+    nntile::DataType dtype,
+    bool mark_as_input);
+
+void register_data_node(
+    void *data_ptr,
+    nntile::TensorGraph::TensorNode *node);
+
+nntile::TensorGraph::TensorNode *lookup_data_node(void *data_ptr);
+
+//! Keep tensor storage alive until execute() (CUDA record_stream analog).
+void pin_tensor_for_graph(const at::Tensor &tensor);
+
+//! Pin op inputs and user-held outputs. Do not pin backward return buffers
+//! that autograd will steal into leaf .grad (extra refs block stealing).
+void pin_graph_op_inputs(const std::vector<at::Tensor> &inputs);
+
+void pin_graph_op_output(const at::Tensor &output, bool is_user_visible);
+
+} // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_kernels.cpp
+++ b/torch_nntile/csrc/nntile_kernels.cpp
@@ -6,6 +6,7 @@
 
 #include "nntile_allocator.h"
 #include "nntile_context.h"
+#include "nntile_graph_recorder.h"
 
 #include <ATen/EmptyTensor.h>
 #include <ATen/InferSize.h>
@@ -222,6 +223,11 @@ at::Tensor copy_from(
     bool /*non_blocking*/)
 {
     check_copy_devices(self, dst);
+    if (is_nntile_device(self.device()) && dst.is_cpu())
+    {
+        require_no_pending_graph(
+            "copy nntile tensor to CPU (call torch_nntile.execute() first)");
+    }
     at::Tensor mutable_dst = dst;
     memcpy_tensors(self, mutable_dst);
     return dst;
@@ -242,6 +248,9 @@ at::Scalar local_scalar_dense(const at::Tensor &self)
         is_nntile_device(self.device()),
         "_local_scalar_dense: expected nntile");
     TORCH_CHECK(self.numel() > 0, "Cannot convert empty tensor to scalar");
+    require_no_pending_graph(
+        "read a scalar from an nntile tensor "
+        "(call torch_nntile.execute() first)");
     return tensor_to_scalar(self);
 }
 

--- a/torch_nntile/csrc/nntile_kernels.cpp
+++ b/torch_nntile/csrc/nntile_kernels.cpp
@@ -89,7 +89,71 @@ at::Scalar tensor_to_scalar(const at::Tensor &self)
     return at::Scalar();
 }
 
+void fill_tensor(at::Tensor &self, const at::Scalar &value)
+{
+    TORCH_CHECK(
+        is_nntile_device(self.device()),
+        "fill_: expected nntile tensor");
+    TORCH_CHECK(self.is_contiguous(), "fill_: requires contiguous tensor");
+    const int64_t nelems = self.numel();
+    if (nelems == 0)
+    {
+        return;
+    }
+    switch (self.scalar_type())
+    {
+    case at::ScalarType::Float:
+    {
+        const float fill_value = value.to<float>();
+        float *data = self.data_ptr<float>();
+        for (int64_t i = 0; i < nelems; ++i)
+        {
+            data[i] = fill_value;
+        }
+        break;
+    }
+    case at::ScalarType::Double:
+    {
+        const double fill_value = value.to<double>();
+        double *data = self.data_ptr<double>();
+        for (int64_t i = 0; i < nelems; ++i)
+        {
+            data[i] = fill_value;
+        }
+        break;
+    }
+    case at::ScalarType::Int:
+    {
+        const int32_t fill_value = value.to<int32_t>();
+        int32_t *data = self.data_ptr<int32_t>();
+        for (int64_t i = 0; i < nelems; ++i)
+        {
+            data[i] = fill_value;
+        }
+        break;
+    }
+    case at::ScalarType::Long:
+    {
+        const int64_t fill_value = value.to<int64_t>();
+        int64_t *data = self.data_ptr<int64_t>();
+        for (int64_t i = 0; i < nelems; ++i)
+        {
+            data[i] = fill_value;
+        }
+        break;
+    }
+    default:
+        TORCH_CHECK(false, "fill_: unsupported dtype on nntile");
+    }
+}
+
 } // namespace
+
+at::Tensor &fill_scalar(at::Tensor &self, const at::Scalar &value)
+{
+    fill_tensor(self, value);
+    return self;
+}
 
 at::Tensor empty_memory_format(
     at::IntArrayRef size,
@@ -333,6 +397,7 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
     m.impl("_copy_from", TORCH_FN(torch_nntile::copy_from));
     m.impl("_copy_from_and_resize", TORCH_FN(torch_nntile::copy_from_and_resize));
     m.impl("_local_scalar_dense", TORCH_FN(torch_nntile::local_scalar_dense));
+    m.impl("fill_.Scalar", TORCH_FN(torch_nntile::fill_scalar));
     m.impl("set_.source_Tensor", TORCH_FN(torch_nntile::set_source_tensor));
     m.impl("set_.source_Storage", TORCH_FN(torch_nntile::set_source_storage));
     m.impl(

--- a/torch_nntile/csrc/nntile_linear.cpp
+++ b/torch_nntile/csrc/nntile_linear.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
 
 #include <ATen/Functions.h>
 #include <ATen/TensorUtils.h>
@@ -73,6 +74,8 @@ void run_linear(
     const at::Tensor &weight,
     at::Tensor &output)
 {
+    pin_graph_op_inputs({input, weight});
+    pin_graph_op_output(output, true);
     tensor_linear_fp32(
         input.data_ptr<float>(),
         input.sizes(),
@@ -137,6 +140,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> linear_backward(
     if (output_mask[0])
     {
         grad_input = at::empty_like(input);
+        pin_graph_op_inputs({grad_output, weight});
+        pin_graph_op_output(grad_input, false);
         tensor_linear_backward_input_fp32(
             grad_output.data_ptr<float>(),
             grad_output.sizes(),
@@ -148,6 +153,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> linear_backward(
     if (output_mask[1])
     {
         grad_weight = at::empty_like(weight);
+        pin_graph_op_inputs({grad_output, input});
+        pin_graph_op_output(grad_weight, false);
         tensor_linear_backward_weight_fp32(
             grad_output.data_ptr<float>(),
             grad_output.sizes(),

--- a/torch_nntile/csrc/nntile_mm.cpp
+++ b/torch_nntile/csrc/nntile_mm.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
 
 #include <ATen/Functions.h>
 #include <ATen/TensorUtils.h>
@@ -57,6 +58,8 @@ at::Tensor make_mm_output(const at::Tensor &self, const at::Tensor &mat2)
 
 void run_mm(const at::Tensor &self, const at::Tensor &mat2, at::Tensor &out)
 {
+    pin_graph_op_inputs({self, mat2});
+    pin_graph_op_output(out, true);
     tensor_mm_fp32(
         self.data_ptr<float>(),
         self.sizes(),

--- a/torch_nntile/csrc/nntile_module.cpp
+++ b/torch_nntile/csrc/nntile_module.cpp
@@ -55,7 +55,7 @@ bool buffer_equal_cpu(const at::Tensor &nntile_tensor, const at::Tensor &cpu_ten
         nntile_tensor.device().type() == c10::DeviceType::PrivateUse1,
         "buffer_equal_cpu expects nntile tensor as first argument");
     TORCH_CHECK(cpu_tensor.is_cpu(), "buffer_equal_cpu expects CPU tensor");
-    // Host read: .cpu() runs execute() in graph mode before copying off-device.
+    // Host read: graph mode requires execute() before nntile -> CPU copy.
     at::Tensor lhs = nntile_tensor.contiguous().cpu();
     at::Tensor rhs = cpu_tensor.contiguous();
     return lhs.equal(rhs);

--- a/torch_nntile/csrc/nntile_module.cpp
+++ b/torch_nntile/csrc/nntile_module.cpp
@@ -9,8 +9,14 @@
 #include <c10/core/Device.h>
 #include <c10/core/DeviceType.h>
 
+#include <algorithm>
+#include <cctype>
+#include <stdexcept>
+#include <string>
+
 #include "nntile_context.h"
 #include "nntile_cross_entropy.h"
+#include "nntile_graph_recorder.h"
 #include "nntile_sgd_step.h"
 
 namespace torch_nntile
@@ -49,9 +55,53 @@ bool buffer_equal_cpu(const at::Tensor &nntile_tensor, const at::Tensor &cpu_ten
         nntile_tensor.device().type() == c10::DeviceType::PrivateUse1,
         "buffer_equal_cpu expects nntile tensor as first argument");
     TORCH_CHECK(cpu_tensor.is_cpu(), "buffer_equal_cpu expects CPU tensor");
+    // Host read: .cpu() runs execute() in graph mode before copying off-device.
     at::Tensor lhs = nntile_tensor.contiguous().cpu();
     at::Tensor rhs = cpu_tensor.contiguous();
     return lhs.equal(rhs);
+}
+
+RuntimeMode parse_runtime_mode(const std::string &mode)
+{
+    std::string lowered = mode;
+    std::transform(
+        lowered.begin(),
+        lowered.end(),
+        lowered.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    if (lowered == "eager")
+    {
+        return RuntimeMode::Eager;
+    }
+    if (lowered == "graph")
+    {
+        return RuntimeMode::Graph;
+    }
+    throw std::runtime_error(
+        "torch_nntile.init_context runtime_mode must be 'eager' or 'graph'");
+}
+
+void init_context_py(
+    int ncpu,
+    int ncuda,
+    int ooc_enabled,
+    const std::string &ooc_path,
+    std::size_t ooc_size,
+    int logger,
+    int verbose,
+    bool cpu_fallback,
+    const std::string &runtime_mode)
+{
+    init_context(
+        ncpu,
+        ncuda,
+        ooc_enabled,
+        ooc_path.c_str(),
+        ooc_size,
+        logger,
+        verbose,
+        cpu_fallback,
+        parse_runtime_mode(runtime_mode));
 }
 
 } // namespace torch_nntile
@@ -71,7 +121,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         "Compare nntile tensor to CPU tensor");
     m.def(
         "init_context",
-        &torch_nntile::init_context,
+        &torch_nntile::init_context_py,
         "Configure StarPU workers before the first nntile op",
         py::arg("ncpu") = -1,
         py::arg("ncuda") = -1,
@@ -80,7 +130,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         py::arg("ooc_size") = 16 * 1024 * 1024,
         py::arg("logger") = 0,
         py::arg("verbose") = 0,
-        py::arg("cpu_fallback") = true);
+        py::arg("cpu_fallback") = true,
+        py::arg("runtime_mode") = "eager");
     m.def(
         "is_cpu_fallback_enabled",
         &torch_nntile::is_cpu_fallback_enabled,
@@ -101,6 +152,18 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         "restore_where",
         &torch_nntile::restore_where,
         "Restore default StarPU codelet worker placement");
+    m.def(
+        "execute",
+        &torch_nntile::execute_pending_graph,
+        "Compile and run the pending TensorGraph (graph mode)");
+    m.def(
+        "has_pending_graph",
+        &torch_nntile::has_pending_graph,
+        "Whether a deferred TensorGraph is waiting for execute()");
+    m.def(
+        "is_graph_mode",
+        &torch_nntile::is_graph_mode,
+        "Whether runtime_mode is graph");
     m.def(
         "cross_entropy_forward",
         &torch_nntile::cross_entropy_forward,

--- a/torch_nntile/csrc/nntile_relu.cpp
+++ b/torch_nntile/csrc/nntile_relu.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
 
 #include <ATen/Functions.h>
 #include <ATen/TensorUtils.h>
@@ -47,6 +48,8 @@ void check_relu_input(
 
 void run_relu(const at::Tensor &self, at::Tensor &out)
 {
+    pin_graph_op_inputs({self});
+    pin_graph_op_output(out, true);
     tensor_relu_fp32(
         self.data_ptr<float>(),
         out.data_ptr<float>(),

--- a/torch_nntile/csrc/nntile_sgd_step.cpp
+++ b/torch_nntile/csrc/nntile_sgd_step.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
 
 #include <ATen/TensorUtils.h>
 
@@ -66,6 +67,7 @@ void sgd_step(
 {
     check_sgd_step_tensors(param, grad, velocity);
     TORCH_CHECK(num_iter >= 1, "nntile sgd_step: num_iter must be >= 1");
+    pin_graph_op_inputs({param, grad, velocity});
     tensor_sgd_step_fp32(
         num_iter,
         static_cast<float>(momentum),

--- a/torch_nntile/csrc/nntile_threshold_backward.cpp
+++ b/torch_nntile/csrc/nntile_threshold_backward.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
 
 #include <ATen/Functions.h>
 #include <ATen/TensorUtils.h>
@@ -53,6 +54,8 @@ at::Tensor threshold_backward(
         threshold.to<double>() == 0.0,
         "nntile threshold_backward supports ReLU only (threshold=0)");
     at::Tensor grad_input = at::empty_like(self);
+    pin_graph_op_inputs({self, grad_output});
+    pin_graph_op_output(grad_input, true);
     tensor_relu_backward_fp32(
         self.data_ptr<float>(),
         grad_output.data_ptr<float>(),

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -7,10 +7,10 @@
 
 """Full-batch MNIST training with DeepReLU on CPU and device=\"nntile\".
 
-Cross-entropy is evaluated on CPU (see ``torch_nntile.training``) because
-libnntile cross-entropy is an ``NNGraph`` composite not yet exposed as PyTorch
-ATen ops. Model forward/backward still uses nntile ``gemm`` / ``relu`` kernels
-when ``cpu_fallback=False``.
+Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
+(same tensor-op chain as ``NNCrossEntropyOp`` in libnntile). The scalar loss lives
+on ``device="nntile"``; call ``torch_nntile.execute()`` in graph mode before
+reading it on the host.
 
 Example::
 

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -8,8 +8,9 @@
 """Full-batch MNIST training with DeepReLU on CPU and device=\"nntile\".
 
 Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
-(same tensor-op chain as ``NNCrossEntropyOp`` in libnntile). The scalar loss lives
-on ``device="nntile"``; call ``torch_nntile.execute()`` in graph mode before
+(same tensor-op chain as ``NNCrossEntropyOp`` in libnntile). Logits are
+``[batch, classes]`` (class dim last). The scalar loss lives on
+``device="nntile"``; call ``torch_nntile.execute()`` in graph mode before
 reading it on the host.
 
 Example::

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -102,6 +102,12 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--hidden-dim", type=int, default=256)
     parser.add_argument("--depth", type=int, default=5)
+    parser.add_argument(
+        "--runtime-mode",
+        choices=("eager", "graph"),
+        default="eager",
+        help="torch_nntile runtime mode (default: eager)",
+    )
     parser.add_argument("--output-dir", default="deep_relu_mnist_runs")
     args = parser.parse_args()
 
@@ -111,7 +117,15 @@ def main() -> None:
             "Set NNTILE_BUILD_DIR and reinstall."
         )
 
-    torch_nntile.init_context(ncpu=1, ncuda=0, verbose=0, cpu_fallback=False)
+    torch_nntile.init_context(
+        ncpu=1,
+        ncuda=0,
+        verbose=0,
+        cpu_fallback=False,
+        runtime_mode=args.runtime_mode,
+    )
+
+    print(f"Runtime mode: {args.runtime_mode}")
 
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -22,6 +22,7 @@ CSRC = [
     "csrc/nntile_hooks.cpp",
     "csrc/nntile_module.cpp",
     "csrc/nntile_context.cpp",
+    "csrc/nntile_graph_recorder.cpp",
     "csrc/nntile_executor.cpp",
     "csrc/nntile_add.cpp",
     "csrc/nntile_linear.cpp",

--- a/torch_nntile/tests/test_cross_entropy_parity.py
+++ b/torch_nntile/tests/test_cross_entropy_parity.py
@@ -72,6 +72,33 @@ def test_cross_entropy_backward_matches_cpu():
     assert torch.allclose(grad_nnt, grad_cpu, rtol=1e-4, atol=1e-4)
 
 
+def test_cross_entropy_backward_multidim_labels_matches_cpu():
+    torch.manual_seed(4)
+    b1, b2, classes = 3, 4, 5
+    # nntile: class dim is last; PyTorch CE expects (N, C, ...).
+    logits_pytorch = torch.randn(
+        b1, classes, b2, dtype=torch.float32, requires_grad=True
+    )
+    target = torch.randint(0, classes, (b1, b2))
+
+    loss_cpu = F.cross_entropy(logits_pytorch, target, reduction="mean")
+    loss_cpu.backward()
+    grad_cpu = logits_pytorch.grad.detach()
+
+    logits_nnt = (
+        logits_pytorch.detach()
+        .permute(0, 2, 1)
+        .contiguous()
+        .to("nntile")
+        .requires_grad_(True)
+    )
+    loss_nnt = cross_entropy(logits_nnt, target, reduction="mean")
+    loss_nnt.backward()
+    grad_nnt = logits_nnt.grad.cpu().permute(0, 2, 1).contiguous()
+
+    assert torch.allclose(grad_nnt, grad_cpu, rtol=1e-4, atol=1e-4)
+
+
 def test_cross_entropy_ignore_index_matches_cpu():
     torch.manual_seed(3)
     batch, classes = 5, 3

--- a/torch_nntile/tests/test_graph_execution.py
+++ b/torch_nntile/tests/test_graph_execution.py
@@ -1,0 +1,194 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_graph_execution.py
+# Graph (non-eager) runtime mode for torch_nntile.
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from torch_nntile import _C
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+_PKG_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run_graph_subprocess(script: str) -> None:
+    env = dict(**__import__("os").environ)
+    repo = Path(__file__).resolve().parents[2]
+    build_lib = repo / "build" / "nntile"
+    starpu_lib = "/opt/starpu/lib"
+    ld = env.get("LD_LIBRARY_PATH", "")
+    for part in (str(build_lib), starpu_lib):
+        if part not in ld.split(":"):
+            ld = f"{part}:{ld}" if ld else part
+    env["LD_LIBRARY_PATH"] = ld
+    env["PYTHONPATH"] = f"{_PKG_ROOT}:{env.get('PYTHONPATH', '')}"
+    proc = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"subprocess failed ({proc.returncode})\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+
+def test_graph_mode_deferred_until_execute():
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+        x = torch.randn(2, 3).to("nntile")
+        w = torch.randn(4, 3).to("nntile")
+        h = torch.nn.functional.linear(x, w, None)
+        assert torch_nntile.has_pending_graph()
+        y = torch.nn.functional.relu(h)
+        assert torch_nntile.has_pending_graph()
+        torch_nntile.execute()
+        assert not torch_nntile.has_pending_graph()
+        """
+    )
+
+
+def test_cpu_copy_requires_execute():
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch_nntile
+        import pytest
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+        x = torch.randn(2, 3).to("nntile")
+        w = torch.randn(4, 3).to("nntile")
+        y = torch.nn.functional.relu(torch.nn.functional.linear(x, w, None))
+        assert torch_nntile.has_pending_graph()
+        with pytest.raises(RuntimeError, match="torch_nntile.execute"):
+            y.cpu()
+        torch_nntile.execute()
+        y_cpu = y.cpu()
+        assert y_cpu.shape == (2, 4)
+        """
+    )
+
+
+def test_to_nntile_does_not_execute():
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+        x = x_cpu = torch.randn(2, 3)
+        x = x_cpu.to("nntile")
+        w = torch.randn(4, 3).to("nntile")
+        _ = torch.nn.functional.linear(x, w, None)
+        assert torch_nntile.has_pending_graph()
+        """
+    )
+
+
+def test_graph_forward_matches_cpu():
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch_nntile
+        from torch_nntile.models import DeepReLU
+
+        torch.manual_seed(0)
+        model_cpu = DeepReLU.tiny()
+        model_cpu.init_kaiming_uniform_(seed=42)
+        x_cpu = torch.randn(32, model_cpu.input_dim)
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+        model_graph = DeepReLU.tiny().to("nntile")
+        model_graph.load_state_dict(model_cpu.state_dict())
+        with torch.no_grad():
+            y_graph = model_graph(x_cpu.to("nntile"))
+            assert torch_nntile.has_pending_graph()
+            torch_nntile.execute()
+            y_graph = y_graph.cpu()
+
+        y_ref = model_cpu(x_cpu)
+        assert torch.allclose(y_graph, y_ref, rtol=1e-4, atol=1e-4)
+        """
+    )
+
+
+def test_graph_backward_without_mid_execute():
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+
+        x_cpu = torch.tensor([[1.0, -2.0, 0.5], [0.0, 3.0, -1.0]], requires_grad=True)
+        w_cpu = torch.tensor(
+            [[0.25, -0.5, 1.0], [2.0, 0.0, -1.0]], requires_grad=True
+        )
+        y_cpu = torch.nn.functional.relu(x_cpu @ w_cpu.t())
+        y_cpu.backward(torch.ones_like(y_cpu))
+
+        x_nnt = x_cpu.detach().to("nntile").requires_grad_(True)
+        w_nnt = w_cpu.detach().to("nntile").requires_grad_(True)
+        y_nnt = torch.nn.functional.relu(
+            torch.nn.functional.linear(x_nnt, w_nnt, None)
+        )
+        assert torch_nntile.has_pending_graph()
+        y_nnt.backward(torch.ones(y_nnt.shape, device="cpu").to("nntile"))
+        assert torch_nntile.has_pending_graph()
+        torch_nntile.execute()
+        gx = x_nnt.grad.cpu()
+        gw = w_nnt.grad.cpu()
+        assert torch.allclose(gx, x_cpu.grad, rtol=1e-4, atol=1e-4)
+        assert torch.allclose(gw, w_cpu.grad, rtol=1e-4, atol=1e-4)
+        """
+    )
+
+
+def test_execute_idempotent_on_empty():
+    _run_graph_subprocess(
+        """
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+        assert not torch_nntile.has_pending_graph()
+        torch_nntile.execute()
+        torch_nntile.execute()
+        """
+    )

--- a/torch_nntile/tests/test_graph_execution.py
+++ b/torch_nntile/tests/test_graph_execution.py
@@ -228,9 +228,10 @@ def test_graph_cross_entropy_backward_and_sgd():
         assert torch_nntile.has_pending_graph()
         SGD([w_nnt], lr=0.1).step()
         assert torch_nntile.has_pending_graph()
+        assert loss_nnt.device.type == "nntile"
         torch_nntile.execute()
         assert not torch_nntile.has_pending_graph()
-        assert torch.allclose(loss_nnt.detach(), loss_ref, rtol=1e-4, atol=1e-4)
+        assert torch.allclose(loss_nnt.detach().cpu(), loss_ref, rtol=1e-4, atol=1e-4)
         assert torch.allclose(w_nnt.detach().cpu(), w_after_ref, rtol=1e-4, atol=1e-4)
         """
     )
@@ -263,6 +264,33 @@ def test_train_full_batch_step_graph_mode():
         after = clone_model_weights(model)
         max_delta = max((before[k] - after[k]).abs().max().item() for k in before)
         assert max_delta > 0.0
+        """
+    )
+
+
+def test_graph_nntile_loss_backward_without_scalar_read():
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch_nntile
+        from torch_nntile.training import cross_entropy
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+
+        logits_cpu = torch.randn(8, 5)
+        target = torch.randint(0, 5, (8,))
+        logits_nnt = logits_cpu.to("nntile").requires_grad_(True)
+        loss = cross_entropy(logits_nnt, target, reduction="mean")
+        assert loss.device.type == "nntile"
+        assert torch_nntile.has_pending_graph()
+        loss.backward()
+        assert torch_nntile.has_pending_graph()
+        torch_nntile.execute()
+        ref = torch.nn.functional.cross_entropy(logits_cpu, target, reduction="mean")
+        assert torch.allclose(loss.detach().cpu(), ref, rtol=1e-4, atol=1e-4)
         """
     )
 

--- a/torch_nntile/tests/test_graph_execution.py
+++ b/torch_nntile/tests/test_graph_execution.py
@@ -192,3 +192,95 @@ def test_execute_idempotent_on_empty():
         torch_nntile.execute()
         """
     )
+
+
+def test_graph_cross_entropy_backward_and_sgd():
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch_nntile
+        from torch_nntile.training import SGD, cross_entropy
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+
+        torch.manual_seed(0)
+        batch, classes, features = 4, 3, 5
+        w_cpu = torch.randn(classes, features)
+        x_cpu = torch.randn(batch, features)
+        target = torch.randint(0, classes, (batch,))
+
+        w_ref = w_cpu.clone().requires_grad_(True)
+        logits_ref = x_cpu @ w_ref.t()
+        loss_ref = torch.nn.functional.cross_entropy(logits_ref, target)
+        loss_ref.backward()
+        torch.optim.SGD([w_ref], lr=0.1).step()
+        w_after_ref = w_ref.detach().clone()
+
+        w_nnt = w_cpu.detach().to("nntile").requires_grad_(True)
+        x_nnt = x_cpu.to("nntile")
+        logits_nnt = torch.nn.functional.linear(x_nnt, w_nnt, None)
+        loss_nnt = cross_entropy(logits_nnt, target, reduction="mean")
+        assert torch_nntile.has_pending_graph()
+        loss_nnt.backward()
+        assert torch_nntile.has_pending_graph()
+        SGD([w_nnt], lr=0.1).step()
+        assert torch_nntile.has_pending_graph()
+        torch_nntile.execute()
+        assert not torch_nntile.has_pending_graph()
+        assert torch.allclose(loss_nnt.detach(), loss_ref, rtol=1e-4, atol=1e-4)
+        assert torch.allclose(w_nnt.detach().cpu(), w_after_ref, rtol=1e-4, atol=1e-4)
+        """
+    )
+
+
+def test_train_full_batch_step_graph_mode():
+    _run_graph_subprocess(
+        """
+        import math
+
+        import torch
+        import torch_nntile
+        from torch_nntile.models import DeepReLU
+        from torch_nntile.training import clone_model_weights, train_full_batch_step
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+
+        model_cpu = DeepReLU.tiny()
+        model_cpu.init_kaiming_uniform_(seed=42)
+        model = DeepReLU.tiny().to("nntile")
+        model.load_state_dict(model_cpu.state_dict())
+        before = clone_model_weights(model)
+        x = torch.randn(8, model.input_dim).to("nntile")
+        y = torch.randint(0, model.output_dim, (8,))
+        loss = train_full_batch_step(model, x, y, learning_rate=0.1)
+        assert math.isfinite(loss)
+        after = clone_model_weights(model)
+        max_delta = max((before[k] - after[k]).abs().max().item() for k in before)
+        assert max_delta > 0.0
+        """
+    )
+
+
+def test_eager_mode_runs_immediately():
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="eager"
+        )
+        torch_nntile.restrict_cpu()
+        a = torch.tensor([1.0, 2.0], device="nntile")
+        b = torch.tensor([3.0, 4.0], device="nntile")
+        z = a + b
+        assert not torch_nntile.has_pending_graph()
+        assert torch.allclose(z.cpu(), torch.tensor([4.0, 6.0]))
+        """
+    )

--- a/torch_nntile/torch_nntile/__init__.py
+++ b/torch_nntile/torch_nntile/__init__.py
@@ -68,8 +68,14 @@ def init_context(
     verbose: int = 0,
     *,
     cpu_fallback: bool = True,
+    runtime_mode: str = "eager",
 ) -> None:
-    """Configure StarPU workers before the first libnntile-backed op."""
+    """Configure StarPU workers before the first libnntile-backed op.
+
+    ``runtime_mode`` is ``"eager"`` (compile and run each op immediately) or
+    ``"graph"`` (record ops into a shared TensorGraph; call :func:`execute`
+    to compile and run the pending graph).
+    """
     _C.init_context(
         ncpu,
         ncuda,
@@ -79,7 +85,21 @@ def init_context(
         logger,
         verbose,
         cpu_fallback,
+        runtime_mode,
     )
+
+
+def execute() -> None:
+    """Compile and run the pending TensorGraph (graph mode only)."""
+    _C.execute()
+
+
+def is_graph_mode() -> bool:
+    return _C.is_graph_mode()
+
+
+def has_pending_graph() -> bool:
+    return _C.has_pending_graph()
 
 
 def is_context_initialized() -> bool:
@@ -109,6 +129,9 @@ __all__ = [
     "device",
     "_C",
     "init_context",
+    "execute",
+    "is_graph_mode",
+    "has_pending_graph",
     "is_context_initialized",
     "is_cpu_fallback_enabled",
     "restrict_cpu",

--- a/torch_nntile/torch_nntile/__init__.py
+++ b/torch_nntile/torch_nntile/__init__.py
@@ -90,7 +90,11 @@ def init_context(
 
 
 def execute() -> None:
-    """Compile and run the pending TensorGraph (graph mode only)."""
+    """Compile and run the pending TensorGraph, then reset the recorder.
+
+    Required in graph mode before reading nntile tensor data on the host.
+    No-op when the pending graph is empty (including in eager mode).
+    """
     _C.execute()
 
 

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -7,7 +7,10 @@
 """Utilities for training on the nntile device.
 
 Cross-entropy uses libnntile tensor ops (``maxsumexp``, ``logsumexp``,
-``total_sum_accum``, ``softmax``, ``subtract_indexed_outputs``).
+``total_sum_accum``, ``softmax``, ``subtract_indexed_outputs``). Logits must
+have the class dimension last (``[..., C]``); labels match logits without that
+axis. Backward broadcasts scalar ``grad_output`` with chained ``scale_slice``
+(one per label dimension), then ``multiply_slice`` along the class axis.
 
 SGD uses the fused ``tensor::sgd_step`` kernel (momentum, weight decay,
 Nesterov), mirroring ``nntile::optim::SGD`` in the main package.
@@ -63,7 +66,12 @@ def cross_entropy(
     reduction: str = "mean",
     ignore_index: int = -100,
 ) -> torch.Tensor:
-    """Cross-entropy on ``device='nntile'`` via libnntile tensor ops."""
+    """Cross-entropy on ``device='nntile'`` via libnntile tensor ops.
+
+    ``logits`` shape ``[..., C]`` (class dim last). ``target`` is int64 with
+    shape matching logits without ``C``. Supports ``reduction='mean'`` or
+    ``'sum'`` and ``ignore_index`` (default ``-100``).
+    """
     if logits.device.type != "nntile":
         raise ValueError("cross_entropy expects nntile logits")
     if reduction == "mean":

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -20,6 +20,7 @@ from typing import Iterable
 import torch
 import torch.nn.functional as F
 
+import torch_nntile
 from torch_nntile import _C
 
 # torch.nn._reduction: none=0, mean=1, sum=2
@@ -241,6 +242,8 @@ def train_full_batch_step(
         loss = cross_entropy(logits, targets)
         loss.backward()
         _nntile_optimizer_for(model, learning_rate).step()
+        if torch_nntile.is_graph_mode():
+            torch_nntile.execute()
         return float(loss.detach().cpu().item())
 
     loss = F.cross_entropy(logits, targets)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **graph runtime mode** to `torch_nntile`: ops append to a shared libnntile `TensorGraph` and compile/run only when the user calls `torch_nntile.execute()`. Also moves cross-entropy loss and backward onto nntile with graph-safe `grad_output` handling.

## Graph runtime API

```python
torch_nntile.init_context(..., runtime_mode="graph")
y = model(x)
loss.backward()
torch_nntile.execute()  # compile + run + reset
y_cpu = y.cpu()         # safe after execute
```

- **Eager** (default): each op records and runs immediately.
- **Graph**: forward + backward stay in one pending graph until `execute()`.
- Host reads from nntile tensors (`.cpu()`, `.item()`) require `execute()` first in graph mode.
- `train_full_batch_step` calls `execute()` automatically in graph mode before returning loss.

## Nntile-native cross-entropy

- Loss scalar on `device="nntile"` (not CPU).
- Backward records `grad_output` as a graph tensor — no `.item()` during recording.
- **Grad broadcast:** chained `scale_slice` (one per label dimension) then `multiply_slice` along the class axis.
- Supports multi-D labels (`target` shape matches logits without class dim; class dim is **last** on logits).
- `fill_.Scalar` on nntile so `loss.backward()` can create `ones_like(loss)`.

## Tests

- `test_graph_execution.py` — 10 tests (deferred execute, host-read guards, CE+SGD, training step).
- `test_cross_entropy_parity.py` — forward/backward, multi-D labels, `ignore_index`.
- Stub-build CI fix: guard libnntile includes in `nntile_graph_recorder_impl.h`.

## Docs

- `torch_nntile/README.md` — graph mode, CE shapes, backward op chain.
- `torch_nntile/training.py` — module and `cross_entropy` docstrings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e4190e2-66fd-4cd0-93b8-2229c1b5225c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e4190e2-66fd-4cd0-93b8-2229c1b5225c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

