### PR TITLE
torch_nntile: axis-group naming and tiling API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ and end-to-end training examples.
 | Inference, gateway, Telegram bot | [inference/README.md](inference/README.md) |
 | SGOC scheduler (limited VRAM, single GPU) | [sgoc/README.md](sgoc/README.md) |
 | NNTile Graph API (work in progress) | [graph-wip.md](graph-wip.md) |
+| PyTorch `device="nntile"` (torch_nntile) | [torch_nntile.md](torch_nntile.md) |
 
 ## Documentation map
 
@@ -31,6 +32,7 @@ docs/
   build/README.md           Build, CMake, Docker, testing
   cpp/README.md             C++ kernel / starpu / tile / tensor
   graph-wip.md              NNTile Graph API status
+  torch_nntile.md           PyTorch device="nntile", axis-group tiling
   sgoc/README.md            SGOC StarPU scheduler
   inference/README.md       Inference, nntile_gateway, nntile_tgbot
   python/

--- a/docs/graph-wip.md
+++ b/docs/graph-wip.md
@@ -33,6 +33,17 @@ End-to-end training of BERT, GPT-2, Llama, T5, and similar models uses the
 - **Generators:** `generate_round_robin_execution_schedule`,
   `generate_affinity_batch_execution_schedule` (same JSON schema).
 
+## torch_nntile (PyTorch bridge)
+
+[`torch_nntile`](../torch_nntile/) exposes `device="nntile"` for PyTorch models.
+When linked against `libnntile`, ops record into `TensorGraph` and run through
+`Runtime`. In **graph mode**, you can name axis groups and set tiling before
+`torch_nntile.execute()` — the same `AxisDescriptor` model as C++ graph
+training.
+
+See [torch_nntile.md](torch_nntile.md) for API reference, MNIST example, and
+comparison with C++ `name_gpt2_training_axis_groups` / `tiling.json`.
+
 ## SGOC is not the Graph API
 
 The **SGOC** scheduler ([sgoc/README.md](sgoc/README.md)) is a StarPU scheduling

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -1,0 +1,173 @@
+# torch_nntile
+
+PyTorch **PrivateUse1** backend registered as `device="nntile"`. When built
+against `libnntile`, selected ops record into a shared `TensorGraph`, lower to
+`TileGraph`, and run through `Runtime` (StarPU).
+
+Package README: [`torch_nntile/README.md`](../torch_nntile/README.md).
+
+## Install
+
+Build NNTile first (see [build/README.md](build/README.md)), then:
+
+```bash
+export NNTILE_BUILD_DIR=$PWD/build
+export NNTILE_SOURCE_DIR=$PWD
+export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+CXX=g++ pip install -e ./torch_nntile --no-build-isolation
+```
+
+## Runtime modes
+
+| Mode | Behavior |
+|------|----------|
+| `eager` (default) | Each op records a micro-graph and runs it immediately |
+| `graph` | Ops append to one `TensorGraph` until `torch_nntile.execute()` |
+
+```python
+import torch
+import torch_nntile
+
+torch_nntile.init_context(ncpu=4, ncuda=0, cpu_fallback=False, runtime_mode="graph")
+x = torch.randn(32, 128).to("nntile")
+y = model(x)
+loss.backward()
+torch_nntile.execute()  # required before .cpu() / .item() on nntile tensors
+```
+
+Training helper `torch_nntile.training.train_full_batch_step` calls `execute()`
+automatically in graph mode.
+
+## Axis-group naming and tiling
+
+Tiling in NNTile is defined on **shared axis groups** (`AxisDescriptor` in C++),
+not on individual `torch.Tensor` storage. The workflow mirrors GPT-2 graph
+training (`name_gpt2_training_axis_groups` + `apply_flat_tiling_spec`):
+
+1. **Name** selected dimensions of a tensor (partial naming is OK).
+2. Record forward/backward into the pending graph (ops merge related axes).
+3. **Set tiling** by axis group name.
+4. Optionally **inspect** axis groups before lowering.
+5. **`execute()`** — tiling is applied, then `TileGraph::from_tensor_graph`.
+
+### API
+
+| Function | Description |
+|----------|-------------|
+| `set_axis_group_name(tensor, {dim: name, ...})` | Name axis groups for listed tensor dimensions. Names propagate through merged groups. |
+| `set_axis_group_tiling(name, tile_sizes)` | `tile_sizes` is `int` (uniform) or `list[int]` (heterogeneous; must sum to extent). Stored until `execute()`. |
+| `format_axis_groups()` | Return a string summary of pending graph axis groups (like C++ `TensorGraph::to_string`). |
+| `print_axis_groups()` | Print that summary to stdout. Shows `pending_tile=` when tiling is registered but not yet applied. |
+
+**Graph mode required** for axis-group tiling across a full training step.
+
+### Minimal example
+
+```python
+torch_nntile.init_context(ncpu=2, runtime_mode="graph", cpu_fallback=False)
+
+x = torch.randn(4, 128).to("nntile")
+torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
+
+logits = model(x)  # ops merge axes across the network
+
+torch_nntile.set_axis_group_tiling("batch", [1, 1, 2])
+torch_nntile.set_axis_group_tiling("features", 64)
+torch_nntile.print_axis_groups()
+torch_nntile.execute()
+```
+
+Example `format_axis_groups()` / `print_axis_groups()` output:
+
+```text
+Pending TensorGraph: data=24, ops=12, axis_groups=4, tiled=0/4
+Axis groups:
+  extent=4 name='batch' pending_tile=1,1,2 members=8
+  extent=128 name='features' pending_tile=64 members=6
+  extent=256 members=4
+  extent=10 name='classes' members=2
+```
+
+After `execute()`, the recorder resets; call `format_axis_groups()` only while a
+graph is pending (`has_pending_graph()`).
+
+### Training helper hooks
+
+`train_full_batch_step` accepts optional hooks for graph-mode nntile training:
+
+```python
+from torch_nntile.training import train_full_batch_step
+
+def name_axis_groups(x, logits):
+    torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
+    torch_nntile.set_axis_group_name(logits, {1: "classes"})
+
+loss = train_full_batch_step(
+    model,
+    x,
+    labels,
+    lr=0.1,
+    name_axis_groups=name_axis_groups,
+    axis_group_tiling={"batch": [15000, 15000, 15000, 15000, 15000]},
+    print_axis_groups=True,  # once, before execute
+)
+```
+
+Models such as `DeepReLU` do **not** assign axis names internally; the caller or
+example script provides naming.
+
+## DeepReLU MNIST example
+
+[`torch_nntile/examples/train_deep_relu_mnist.py`](../torch_nntile/examples/train_deep_relu_mnist.py)
+trains `DeepReLU.mnist()` on the full MNIST training set (60k batch), comparing
+CPU PyTorch vs `device="nntile"`.
+
+Axis groups used by the example:
+
+| Name | Tensor / dim | Extent (MNIST) |
+|------|----------------|----------------|
+| `batch` | input `x` dim 0, logits dim 0 | 60000 |
+| `features` | input `x` dim 1 | 784 |
+| `classes` | logits dim 1 | 10 |
+
+Naming is defined in the example:
+
+```python
+def name_mnist_axis_groups(x, logits):
+    torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
+    torch_nntile.set_axis_group_name(logits, {1: "classes"})
+```
+
+CLI:
+
+```bash
+export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
+python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5
+python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5 --runtime-mode graph
+python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5 \
+  --print-axis-groups \
+  --axis-tiling batch=15000,15000,15000,15000,15000
+```
+
+`--axis-tiling` and `--print-axis-groups` switch to graph mode automatically.
+
+## Tests
+
+```bash
+export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
+pytest -vv torch_nntile/tests/test_axis_group_tiling.py
+pytest -vv torch_nntile/tests/test_graph_execution.py
+pytest -vv torch_nntile/tests/test_deep_relu_parity.py
+```
+
+## Relation to C++ graph API
+
+| C++ (GPT-2 graph training) | torch_nntile |
+|----------------------------|--------------|
+| `name_gpt2_training_axis_groups(...)` | `set_axis_group_name(tensor, {...})` per tensor |
+| `apply_flat_tiling_spec` / `tiling.json` | `set_axis_group_tiling(name, sizes)` |
+| `TensorGraph::to_string()` axis section | `format_axis_groups()` / `print_axis_groups()` |
+| `TileGraph::from_tensor_graph` + `Runtime` | `execute()` |
+
+For full-model JSON tiling (GPT-2), use the Python `nntile` package and
+`apply_gpt2_tiling_json` — see [graph-wip.md](graph-wip.md).

--- a/nntile/examples/README.md
+++ b/nntile/examples/README.md
@@ -11,6 +11,7 @@ incremental training phases) and small Llama / GPT-2 workflows.
 - `gpt2_config_json.hh` — `load_gpt2_config_json` / `save_gpt2_config_json` (HF + NNTile keys).
 - `tiling_config_json.hh` — `load_tiling_json` / `save_tiling_json` (`default` + `layers` in `tiling.json`).
 - `gpt2_axis_naming.hh` — name axis groups for GPT-2 graph training before applying tiling.
+- PyTorch bridge: `torch_nntile.set_axis_group_name` / `set_axis_group_tiling` — same axis-group model from `device="nntile"` (see [docs/torch_nntile.md](../../docs/torch_nntile.md)).
 - `t5_config_json.hh` — `load_t5_config_json` / `save_t5_config_json` for T5 graph examples.
 - `gptneo_config_json.hh` — load/save for examples; HF `attention_types` parsing lives in `include/nntile/model/gptneo/gptneo_config_json.hh`.
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -61,6 +61,29 @@ before returning the scalar loss.
 
 Tests: `pytest -vv torch_nntile/tests/test_graph_execution.py`
 
+### Axis-group naming and tiling (graph mode)
+
+Tiling is configured on named **axis groups** in the recorded `TensorGraph`
+(mirroring the C++ `AxisDescriptor` workflow). Name dimensions from a tensor,
+then set tile sizes by group name before ``execute()``:
+
+```python
+torch_nntile.init_context(
+    ncpu=4, ncuda=0, cpu_fallback=False, runtime_mode="graph"
+)
+x = torch.randn(4, 128).to("nntile")
+torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
+y = model(x)
+torch_nntile.set_axis_group_tiling("batch", [1, 1, 2])
+torch_nntile.execute()
+```
+
+``DeepReLU`` names ``batch``, ``features``, and ``classes`` in ``forward()``.
+The MNIST example accepts ``--axis-tiling NAME=SIZES`` (repeatable); tiling
+switches to graph mode automatically.
+
+Tests: `pytest -vv torch_nntile/tests/test_axis_group_tiling.py`
+
 ## Phase 3 (DeepReLU example)
 
 Bias-free MLP matching `nntile/examples/deep_relu_forward.cc`:
@@ -104,6 +127,8 @@ round-trip).
 export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
 python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5
 python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5 --runtime-mode graph
+python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5 \
+  --axis-tiling batch=15000,15000,15000,15000,15000
 ```
 
 Integration test (downloads MNIST, 3 epochs, compares losses and weights):

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -78,9 +78,18 @@ torch_nntile.set_axis_group_tiling("batch", [1, 1, 2])
 torch_nntile.execute()
 ```
 
-``DeepReLU`` names ``batch``, ``features``, and ``classes`` in ``forward()``.
-The MNIST example accepts ``--axis-tiling NAME=SIZES`` (repeatable); tiling
-switches to graph mode automatically.
+``DeepReLU`` does not assign axis names; name groups from your script or
+training helper, then set tiling before ``execute()``:
+
+```python
+torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
+torch_nntile.set_axis_group_tiling("batch", [1, 1, 2])
+torch_nntile.print_axis_groups()  # like C++ TensorGraph::to_string axis section
+torch_nntile.execute()
+```
+
+The MNIST example defines ``name_mnist_axis_groups`` and accepts
+``--axis-tiling NAME=SIZES`` plus ``--print-axis-groups``.
 
 Tests: `pytest -vv torch_nntile/tests/test_axis_group_tiling.py`
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -63,9 +63,18 @@ Tests: `pytest -vv torch_nntile/tests/test_graph_execution.py`
 
 ### Axis-group naming and tiling (graph mode)
 
+Full reference: [docs/torch_nntile.md](../docs/torch_nntile.md).
+
 Tiling is configured on named **axis groups** in the recorded `TensorGraph`
 (mirroring the C++ `AxisDescriptor` workflow). Name dimensions from a tensor,
-then set tile sizes by group name before ``execute()``:
+then set tile sizes by group name before ``execute()``.
+
+| API | Purpose |
+|-----|---------|
+| `set_axis_group_name(tensor, {dim: name})` | Name axis groups (partial dims OK) |
+| `set_axis_group_tiling(name, tile_sizes)` | Uniform `int` or heterogeneous `list` |
+| `format_axis_groups()` | String summary of pending axis groups |
+| `print_axis_groups()` | Print summary (includes `pending_tile=` before execute) |
 
 ```python
 torch_nntile.init_context(
@@ -73,23 +82,22 @@ torch_nntile.init_context(
 )
 x = torch.randn(4, 128).to("nntile")
 torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
-y = model(x)
+logits = model(x)
 torch_nntile.set_axis_group_tiling("batch", [1, 1, 2])
+torch_nntile.print_axis_groups()
 torch_nntile.execute()
 ```
 
-``DeepReLU`` does not assign axis names; name groups from your script or
-training helper, then set tiling before ``execute()``:
+Models do **not** assign axis names internally. The MNIST example defines
+``name_mnist_axis_groups`` and passes it to ``train_full_batch_step``:
 
 ```python
-torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
-torch_nntile.set_axis_group_tiling("batch", [1, 1, 2])
-torch_nntile.print_axis_groups()  # like C++ TensorGraph::to_string axis section
-torch_nntile.execute()
+def name_mnist_axis_groups(x, logits):
+    torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
+    torch_nntile.set_axis_group_name(logits, {1: "classes"})
 ```
 
-The MNIST example defines ``name_mnist_axis_groups`` and accepts
-``--axis-tiling NAME=SIZES`` plus ``--print-axis-groups``.
+CLI: ``--axis-tiling NAME=SIZES`` (repeatable), ``--print-axis-groups``.
 
 Tests: `pytest -vv torch_nntile/tests/test_axis_group_tiling.py`
 
@@ -132,11 +140,15 @@ label shape with one ``scale_slice`` per label dimension, then applies
 ``tensor::sgd_step`` via ``torch_nntile.training.SGD`` (no per-parameter CPU
 round-trip).
 
+Axis naming (`batch`, `features`, `classes`) is in the example script — see
+[docs/torch_nntile.md](../docs/torch_nntile.md).
+
 ```bash
 export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
 python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5
 python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5 --runtime-mode graph
 python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5 \
+  --print-axis-groups \
   --axis-tiling batch=15000,15000,15000,15000,15000
 ```
 

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -15,6 +15,7 @@
 
 #include <nntile/runtime.hh>
 #include <nntile/tensor/graph.hh>
+#include <nntile/tensor/tiling_spec_json.hh>
 #include <nntile/tile/graph.hh>
 
 #include <cstring>
@@ -49,6 +50,82 @@ std::unique_ptr<nntile::TensorGraph> g_graph;
 std::unordered_map<void *, MappedTensor> g_tensor_nodes;
 std::unordered_set<nntile::TensorGraph::TensorNode *> g_all_nodes;
 std::vector<at::Tensor> g_pinned_tensors;
+std::unordered_map<void *, std::unordered_map<int, std::string>> g_axis_name_hints;
+std::unordered_map<std::string, std::vector<nntile::Index>> g_axis_tiling_by_name;
+
+void assign_axis_group_name(nntile::AxisDescriptor *axis, const std::string &name)
+{
+    if (axis == nullptr)
+    {
+        throw std::runtime_error(
+            "torch_nntile set_axis_group_name: invalid axis");
+    }
+    if (!axis->name.empty() && axis->name != name)
+    {
+        throw std::runtime_error(
+            "torch_nntile set_axis_group_name: axis group already named '" +
+            axis->name + "', cannot rename to '" + name + "'");
+    }
+    axis->name = name;
+}
+
+void apply_axis_name_hints_locked(void *data_ptr, nntile::TensorGraph::TensorNode *node)
+{
+    const auto hints = g_axis_name_hints.find(data_ptr);
+    if (hints == g_axis_name_hints.end())
+    {
+        return;
+    }
+    for (const auto &[dim, name] : hints->second)
+    {
+        if (dim < 0 || dim >= node->ndim())
+        {
+            throw std::runtime_error(
+                "torch_nntile set_axis_group_name: dimension out of range");
+        }
+        assign_axis_group_name(node->axis(dim), name);
+    }
+}
+
+void apply_pending_axis_tiling_locked()
+{
+    if (g_graph == nullptr || g_axis_tiling_by_name.empty())
+    {
+        return;
+    }
+
+    std::unordered_map<std::string, nntile::AxisDescriptor *> named_groups;
+    for (nntile::AxisDescriptor *axis : g_graph->axis_groups())
+    {
+        if (axis == nullptr || axis->name.empty())
+        {
+            continue;
+        }
+        const auto found = named_groups.find(axis->name);
+        if (found != named_groups.end() && found->second != axis)
+        {
+            throw std::runtime_error(
+                "torch_nntile set_axis_group_tiling: duplicate axis group name '" +
+                axis->name + "'");
+        }
+        named_groups.emplace(axis->name, axis);
+    }
+
+    for (const auto &[name, pattern] : g_axis_tiling_by_name)
+    {
+        const auto found = named_groups.find(name);
+        if (found == named_groups.end())
+        {
+            throw std::runtime_error(
+                "torch_nntile set_axis_group_tiling: unknown axis group '" +
+                name + "'");
+        }
+        nntile::AxisDescriptor *axis = found->second;
+        const std::vector<nntile::Index> resolved =
+            nntile::tile_sizes_for_axis_extent(pattern, axis->extent);
+        nntile::apply_tiling_to_axis(axis, resolved);
+    }
+}
 
 void track_node(nntile::TensorGraph::TensorNode *node)
 {
@@ -139,6 +216,8 @@ void reset_recorder_locked()
     g_tensor_nodes.clear();
     g_all_nodes.clear();
     g_pinned_tensors.clear();
+    g_axis_name_hints.clear();
+    g_axis_tiling_by_name.clear();
 }
 
 void execute_pending_graph_locked()
@@ -155,6 +234,8 @@ void execute_pending_graph_locked()
     {
         node->mark_output(true);
     }
+
+    apply_pending_axis_tiling_locked();
 
     nntile::TileGraph tile_graph =
         nntile::TileGraph::from_tensor_graph(*g_graph);
@@ -278,6 +359,7 @@ nntile::TensorGraph::TensorNode *get_or_create_data_node(
     {
         node->mark_input(true);
     }
+    apply_axis_name_hints_locked(data_ptr, node);
     track_node(node);
     g_tensor_nodes[data_ptr] = MappedTensor{
         node,
@@ -353,6 +435,61 @@ void pin_graph_op_output(const at::Tensor &output, bool pin_output)
     pin_tensor_for_graph(output);
 }
 
+void set_axis_group_name(
+    void *data_ptr,
+    int ndim,
+    const std::unordered_map<int, std::string> &names)
+{
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    for (const auto &[dim, name] : names)
+    {
+        if (dim < 0 || dim >= ndim)
+        {
+            throw std::runtime_error(
+                "torch_nntile set_axis_group_name: dimension out of range");
+        }
+        if (name.empty())
+        {
+            throw std::runtime_error(
+                "torch_nntile set_axis_group_name: name must be non-empty");
+        }
+
+        nntile::TensorGraph::TensorNode *node = nullptr;
+        const auto found = g_tensor_nodes.find(data_ptr);
+        if (found != g_tensor_nodes.end())
+        {
+            node = found->second.node;
+        }
+        if (node != nullptr)
+        {
+            assign_axis_group_name(node->axis(dim), name);
+        }
+        else
+        {
+            g_axis_name_hints[data_ptr][dim] = name;
+        }
+    }
+}
+
+void set_axis_group_tiling(
+    const std::string &name,
+    const std::vector<std::int64_t> &tile_sizes)
+{
+    if (name.empty())
+    {
+        throw std::runtime_error(
+            "torch_nntile set_axis_group_tiling: name must be non-empty");
+    }
+    if (tile_sizes.empty())
+    {
+        throw std::runtime_error(
+            "torch_nntile set_axis_group_tiling: tile_sizes must be non-empty");
+    }
+    std::vector<nntile::Index> pattern(tile_sizes.begin(), tile_sizes.end());
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    g_axis_tiling_by_name[name] = std::move(pattern);
+}
+
 } // namespace torch_nntile
 
 #else
@@ -400,6 +537,21 @@ void pin_graph_op_inputs(const std::vector<at::Tensor> & /*inputs*/)
 
 void pin_graph_op_output(const at::Tensor & /*output*/, bool /*pin_output*/)
 {
+}
+
+void set_axis_group_name(
+    void * /*data_ptr*/,
+    int /*ndim*/,
+    const std::unordered_map<int, std::string> & /*names*/)
+{
+    require_libnntile();
+}
+
+void set_axis_group_tiling(
+    const std::string & /*name*/,
+    const std::vector<std::int64_t> & /*tile_sizes*/)
+{
+    require_libnntile();
 }
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -14,9 +14,19 @@
 #ifdef TORCH_NNTILE_USE_LIBNNTILE
 
 #include <nntile/runtime.hh>
+#include <nntile/tensor/axis_descriptor.hh>
 #include <nntile/tensor/graph.hh>
-#include <nntile/tensor/tiling_spec_json.hh>
 #include <nntile/tile/graph.hh>
+
+namespace nntile
+{
+void apply_tiling_to_axis(
+    AxisDescriptor *ad,
+    const std::vector<Index> &sizes);
+std::vector<Index> tile_sizes_for_axis_extent(
+    const std::vector<Index> &pattern,
+    Index extent);
+} // namespace nntile
 
 #include <cstring>
 #include <memory>

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -31,6 +31,7 @@ std::vector<Index> tile_sizes_for_axis_extent(
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -500,6 +501,104 @@ void set_axis_group_tiling(
     g_axis_tiling_by_name[name] = std::move(pattern);
 }
 
+std::string format_pending_tile_sizes(
+    const std::vector<nntile::Index> &sizes)
+{
+    if (sizes.empty())
+    {
+        return "";
+    }
+    if (sizes.size() == 1)
+    {
+        return std::to_string(sizes.front());
+    }
+    std::ostringstream ss;
+    for (size_t i = 0; i < sizes.size(); ++i)
+    {
+        if (i > 0)
+        {
+            ss << ',';
+        }
+        ss << sizes[i];
+    }
+    return ss.str();
+}
+
+std::string format_axis_groups_locked()
+{
+    if (g_graph == nullptr)
+    {
+        return "Axis groups: (no pending graph)\n";
+    }
+
+    const std::vector<nntile::AxisDescriptor *> groups = g_graph->axis_groups();
+    std::size_t tiled = 0;
+    for (const nntile::AxisDescriptor *group : groups)
+    {
+        if (group != nullptr && group->is_tiled())
+        {
+            ++tiled;
+        }
+    }
+
+    std::ostringstream ss;
+    ss << "Pending TensorGraph: data=" << g_graph->num_data()
+       << ", ops=" << g_graph->num_ops() << ", axis_groups=" << groups.size()
+       << ", tiled=" << tiled << '/' << groups.size() << '\n';
+    if (groups.empty())
+    {
+        return ss.str();
+    }
+
+    ss << "Axis groups:\n";
+    for (const nntile::AxisDescriptor *group : groups)
+    {
+        if (group == nullptr)
+        {
+            continue;
+        }
+        ss << "  extent=" << group->extent;
+        if (!group->name.empty())
+        {
+            ss << " name='" << group->name << '\'';
+        }
+        if (group->is_tiled())
+        {
+            ss << " tile=" << group->tile_sizes_to_string();
+        }
+        else if (!group->name.empty())
+        {
+            const auto pending = g_axis_tiling_by_name.find(group->name);
+            if (pending != g_axis_tiling_by_name.end())
+            {
+                ss << " pending_tile=" << format_pending_tile_sizes(pending->second);
+            }
+        }
+        ss << " members=" << group->members.size() << '\n';
+    }
+    return ss.str();
+}
+
+std::string format_axis_groups()
+{
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    return format_axis_groups_locked();
+}
+
+void print_axis_groups()
+{
+    const std::string text = format_axis_groups();
+    if (!text.empty())
+    {
+        std::fputs(text.c_str(), stdout);
+        if (text.back() != '\n')
+        {
+            std::fputc('\n', stdout);
+        }
+        std::fflush(stdout);
+    }
+}
+
 } // namespace torch_nntile
 
 #else
@@ -560,6 +659,17 @@ void set_axis_group_name(
 void set_axis_group_tiling(
     const std::string & /*name*/,
     const std::vector<std::int64_t> & /*tile_sizes*/)
+{
+    require_libnntile();
+}
+
+std::string format_axis_groups()
+{
+    require_libnntile();
+    return {};
+}
+
+void print_axis_groups()
 {
     require_libnntile();
 }

--- a/torch_nntile/csrc/nntile_graph_recorder.h
+++ b/torch_nntile/csrc/nntile_graph_recorder.h
@@ -6,6 +6,11 @@
 
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 namespace torch_nntile
 {
 
@@ -16,5 +21,14 @@ void require_no_pending_graph(const char *op_name);
 void execute_pending_graph();
 
 void maybe_execute_after_record();
+
+void set_axis_group_name(
+    void *data_ptr,
+    int ndim,
+    const std::unordered_map<int, std::string> &names);
+
+void set_axis_group_tiling(
+    const std::string &name,
+    const std::vector<std::int64_t> &tile_sizes);
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_graph_recorder.h
+++ b/torch_nntile/csrc/nntile_graph_recorder.h
@@ -31,4 +31,8 @@ void set_axis_group_tiling(
     const std::string &name,
     const std::vector<std::int64_t> &tile_sizes);
 
+std::string format_axis_groups();
+
+void print_axis_groups();
+
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_graph_recorder_impl.h
+++ b/torch_nntile/csrc/nntile_graph_recorder_impl.h
@@ -7,9 +7,12 @@
 
 #pragma once
 
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #ifdef TORCH_NNTILE_USE_LIBNNTILE
+#include <nntile/base_types.hh>
 #include <nntile/dtype.hh>
 #include <nntile/tensor/graph.hh>
 #endif

--- a/torch_nntile/csrc/nntile_module.cpp
+++ b/torch_nntile/csrc/nntile_module.cpp
@@ -11,13 +11,20 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "nntile_context.h"
 #include "nntile_cross_entropy.h"
 #include "nntile_graph_recorder.h"
 #include "nntile_sgd_step.h"
+
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
+#include <nntile/base_types.hh>
+#endif
 
 namespace torch_nntile
 {
@@ -104,6 +111,73 @@ void init_context_py(
         parse_runtime_mode(runtime_mode));
 }
 
+std::vector<std::int64_t> parse_tile_sizes_py(const py::object &tile_sizes)
+{
+    if (py::isinstance<py::int_>(tile_sizes))
+    {
+        const std::int64_t value = tile_sizes.cast<std::int64_t>();
+        if (value <= 0)
+        {
+            throw std::runtime_error(
+                "torch_nntile.set_axis_group_tiling: tile size must be positive");
+        }
+        return {value};
+    }
+    if (py::isinstance<py::list>(tile_sizes) ||
+        py::isinstance<py::tuple>(tile_sizes))
+    {
+        std::vector<std::int64_t> sizes;
+        for (const py::handle item : tile_sizes)
+        {
+            const std::int64_t value = py::cast<std::int64_t>(item);
+            if (value <= 0)
+            {
+                throw std::runtime_error(
+                    "torch_nntile.set_axis_group_tiling: tile size must be "
+                    "positive");
+            }
+            sizes.push_back(value);
+        }
+        if (sizes.empty())
+        {
+            throw std::runtime_error(
+                "torch_nntile.set_axis_group_tiling: tile_sizes must be "
+                "non-empty");
+        }
+        return sizes;
+    }
+    throw std::runtime_error(
+        "torch_nntile.set_axis_group_tiling: tile_sizes must be int or "
+        "sequence of ints");
+}
+
+void set_axis_group_name_py(
+    const at::Tensor &tensor,
+    const py::dict &names)
+{
+    TORCH_CHECK(
+        tensor.device().type() == c10::DeviceType::PrivateUse1,
+        "set_axis_group_name expects an nntile tensor");
+    std::unordered_map<int, std::string> parsed;
+    for (const auto &item : names)
+    {
+        const int dim = py::cast<int>(item.first);
+        const std::string name = py::cast<std::string>(item.second);
+        parsed.emplace(dim, name);
+    }
+    set_axis_group_name(
+        tensor.storage().data_ptr().get(),
+        static_cast<int>(tensor.dim()),
+        parsed);
+}
+
+void set_axis_group_tiling_py(
+    const std::string &name,
+    const py::object &tile_sizes)
+{
+    set_axis_group_tiling(name, parse_tile_sizes_py(tile_sizes));
+}
+
 } // namespace torch_nntile
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
@@ -164,6 +238,18 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         "is_graph_mode",
         &torch_nntile::is_graph_mode,
         "Whether runtime_mode is graph");
+    m.def(
+        "set_axis_group_name",
+        &torch_nntile::set_axis_group_name_py,
+        "Name TensorGraph axis groups for selected tensor dimensions",
+        py::arg("tensor"),
+        py::arg("names"));
+    m.def(
+        "set_axis_group_tiling",
+        &torch_nntile::set_axis_group_tiling_py,
+        "Set tiling for a named axis group before execute()",
+        py::arg("name"),
+        py::arg("tile_sizes"));
     m.def(
         "cross_entropy_forward",
         &torch_nntile::cross_entropy_forward,

--- a/torch_nntile/csrc/nntile_module.cpp
+++ b/torch_nntile/csrc/nntile_module.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
+#include <cstdio>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -250,6 +251,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         "Set tiling for a named axis group before execute()",
         py::arg("name"),
         py::arg("tile_sizes"));
+    m.def(
+        "format_axis_groups",
+        &torch_nntile::format_axis_groups,
+        "Format pending TensorGraph axis groups (like C++ TensorGraph::to_string)");
+    m.def(
+        "print_axis_groups",
+        &torch_nntile::print_axis_groups,
+        "Print pending TensorGraph axis groups to stdout");
     m.def(
         "cross_entropy_forward",
         &torch_nntile::cross_entropy_forward,

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -13,10 +13,18 @@ Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
 ``device="nntile"``; call ``torch_nntile.execute()`` in graph mode before
 reading it on the host.
 
-Example::
+Axis-group tiling (optional) uses names assigned inside :class:`DeepReLU`:
+
+- ``batch`` — input/logits batch dimension
+- ``features`` — flattened image dimension (784)
+- ``classes`` — output logits dimension (10)
+
+Example with batch tiling in graph mode::
 
     export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
-    python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5
+    python torch_nntile/examples/train_deep_relu_mnist.py \\
+        --runtime-mode graph \\
+        --axis-tiling batch=15000,15000,15000,15000,15000
 """
 
 from __future__ import annotations
@@ -57,6 +65,40 @@ def load_mnist_full_batch(
     return images, labels
 
 
+def parse_axis_tiling_arg(spec: str) -> tuple[str, list[int]]:
+    """Parse ``name=size`` or ``name=size,size,...``."""
+    if "=" not in spec:
+        raise argparse.ArgumentTypeError(
+            f"axis tiling must be NAME=SIZES, got {spec!r}"
+        )
+    name, sizes_text = spec.split("=", 1)
+    name = name.strip()
+    if not name:
+        raise argparse.ArgumentTypeError("axis group name must be non-empty")
+    sizes: list[int] = []
+    for part in sizes_text.split(","):
+        part = part.strip()
+        if not part:
+            raise argparse.ArgumentTypeError(
+                f"invalid tile size list in {spec!r}"
+            )
+        value = int(part)
+        if value <= 0:
+            raise argparse.ArgumentTypeError("tile sizes must be positive")
+        sizes.append(value)
+    return name, sizes
+
+
+def build_axis_group_tiling(
+    specs: list[str],
+) -> dict[str, list[int]]:
+    tiling: dict[str, list[int]] = {}
+    for spec in specs:
+        name, sizes = parse_axis_tiling_arg(spec)
+        tiling[name] = sizes
+    return tiling
+
+
 def build_models(
     seed: int,
     hidden_dim: int,
@@ -80,6 +122,7 @@ def train_on_device(
     device: str,
     epochs: int,
     learning_rate: float,
+    axis_group_tiling: dict[str, list[int]] | None = None,
 ) -> list[float]:
     if device == "nntile":
         x = images.to("nntile")
@@ -89,7 +132,13 @@ def train_on_device(
 
     losses: list[float] = []
     for epoch in range(epochs):
-        loss = train_full_batch_step(model, x, y, learning_rate)
+        loss = train_full_batch_step(
+            model,
+            x,
+            y,
+            learning_rate,
+            axis_group_tiling=axis_group_tiling if device == "nntile" else None,
+        )
         losses.append(loss)
         print(f"[{device}] epoch {epoch + 1}/{epochs}  loss={loss:.6f}")
     return losses
@@ -109,6 +158,16 @@ def main() -> None:
         default="eager",
         help="torch_nntile runtime mode (default: eager)",
     )
+    parser.add_argument(
+        "--axis-tiling",
+        action="append",
+        default=[],
+        metavar="NAME=SIZES",
+        help=(
+            "Axis-group tiling for nntile, e.g. batch=15000,15000,15000,15000,15000 "
+            "or features=392,392. Repeat for multiple groups."
+        ),
+    )
     parser.add_argument("--output-dir", default="deep_relu_mnist_runs")
     args = parser.parse_args()
 
@@ -118,15 +177,23 @@ def main() -> None:
             "Set NNTILE_BUILD_DIR and reinstall."
         )
 
+    axis_group_tiling = build_axis_group_tiling(args.axis_tiling)
+    runtime_mode = args.runtime_mode
+    if axis_group_tiling and runtime_mode != "graph":
+        print("Axis tiling requested; switching runtime mode to graph.")
+        runtime_mode = "graph"
+
     torch_nntile.init_context(
         ncpu=1,
         ncuda=0,
         verbose=0,
         cpu_fallback=False,
-        runtime_mode=args.runtime_mode,
+        runtime_mode=runtime_mode,
     )
 
-    print(f"Runtime mode: {args.runtime_mode}")
+    print(f"Runtime mode: {runtime_mode}")
+    if axis_group_tiling:
+        print(f"Axis-group tiling: {axis_group_tiling}")
 
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -164,6 +231,7 @@ def main() -> None:
         device="nntile",
         epochs=args.epochs,
         learning_rate=args.lr,
+        axis_group_tiling=axis_group_tiling or None,
     )
 
     cpu_path = output_dir / "deep_relu_mnist_cpu.pt"

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -13,7 +13,7 @@ Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
 ``device="nntile"``; call ``torch_nntile.execute()`` in graph mode before
 reading it on the host.
 
-Axis-group tiling (optional) uses names assigned inside :class:`DeepReLU`:
+Axis-group naming and tiling (optional) are configured in this script:
 
 - ``batch`` — input/logits batch dimension
 - ``features`` — flattened image dimension (784)
@@ -24,6 +24,7 @@ Example with batch tiling in graph mode::
     export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
     python torch_nntile/examples/train_deep_relu_mnist.py \\
         --runtime-mode graph \\
+        --print-axis-groups \\
         --axis-tiling batch=15000,15000,15000,15000,15000
 """
 
@@ -99,6 +100,12 @@ def build_axis_group_tiling(
     return tiling
 
 
+def name_mnist_axis_groups(x: torch.Tensor, logits: torch.Tensor) -> None:
+    """Name axis groups for DeepReLU MNIST training on nntile."""
+    torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
+    torch_nntile.set_axis_group_name(logits, {1: "classes"})
+
+
 def build_models(
     seed: int,
     hidden_dim: int,
@@ -123,6 +130,7 @@ def train_on_device(
     epochs: int,
     learning_rate: float,
     axis_group_tiling: dict[str, list[int]] | None = None,
+    print_axis_groups: bool = False,
 ) -> list[float]:
     if device == "nntile":
         x = images.to("nntile")
@@ -137,7 +145,9 @@ def train_on_device(
             x,
             y,
             learning_rate,
+            name_axis_groups=name_mnist_axis_groups if device == "nntile" else None,
             axis_group_tiling=axis_group_tiling if device == "nntile" else None,
+            print_axis_groups=print_axis_groups and device == "nntile" and epoch == 0,
         )
         losses.append(loss)
         print(f"[{device}] epoch {epoch + 1}/{epochs}  loss={loss:.6f}")
@@ -168,6 +178,11 @@ def main() -> None:
             "or features=392,392. Repeat for multiple groups."
         ),
     )
+    parser.add_argument(
+        "--print-axis-groups",
+        action="store_true",
+        help="Print axis groups after the first nntile training step (graph mode)",
+    )
     parser.add_argument("--output-dir", default="deep_relu_mnist_runs")
     args = parser.parse_args()
 
@@ -179,8 +194,8 @@ def main() -> None:
 
     axis_group_tiling = build_axis_group_tiling(args.axis_tiling)
     runtime_mode = args.runtime_mode
-    if axis_group_tiling and runtime_mode != "graph":
-        print("Axis tiling requested; switching runtime mode to graph.")
+    if (axis_group_tiling or args.print_axis_groups) and runtime_mode != "graph":
+        print("Axis groups/tiling require graph mode; switching runtime mode.")
         runtime_mode = "graph"
 
     torch_nntile.init_context(
@@ -232,6 +247,7 @@ def main() -> None:
         epochs=args.epochs,
         learning_rate=args.lr,
         axis_group_tiling=axis_group_tiling or None,
+        print_axis_groups=args.print_axis_groups,
     )
 
     cpu_path = output_dir / "deep_relu_mnist_cpu.pt"

--- a/torch_nntile/tests/test_axis_group_tiling.py
+++ b/torch_nntile/tests/test_axis_group_tiling.py
@@ -91,7 +91,7 @@ def test_axis_group_tiling_invalid_sum_raises():
     )
 
 
-def test_deep_relu_names_axis_groups_in_forward():
+def test_deep_relu_axis_groups_with_explicit_naming():
     _run_subprocess(
         """
         import torch
@@ -104,10 +104,36 @@ def test_deep_relu_names_axis_groups_in_forward():
         model = DeepReLU.tiny().to("nntile")
         x = torch.randn(8, 128).to("nntile")
         logits = model(x)
+        torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
+        torch_nntile.set_axis_group_name(logits, {1: "classes"})
+        info = torch_nntile.format_axis_groups()
+        assert "name='batch'" in info
+        assert "name='features'" in info
+        assert "name='classes'" in info
         torch_nntile.set_axis_group_tiling("batch", [4, 4])
         torch_nntile.set_axis_group_tiling("features", 64)
-        torch_nntile.set_axis_group_tiling("classes", 5)
         torch_nntile.execute()
         assert logits.shape == (8, 10)
+        """
+    )
+
+
+def test_print_axis_groups_shows_pending_tiling():
+    _run_subprocess(
+        """
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        x = torch.randn(4, 8).to("nntile")
+        y = torch.randn(4, 8).to("nntile")
+        torch_nntile.set_axis_group_name(x, {0: "batch"})
+        _ = x + y
+        torch_nntile.set_axis_group_tiling("batch", [1, 1, 2])
+        info = torch_nntile.format_axis_groups()
+        assert "pending_tile=1,1,2" in info
+        torch_nntile.execute()
         """
     )

--- a/torch_nntile/tests/test_axis_group_tiling.py
+++ b/torch_nntile/tests/test_axis_group_tiling.py
@@ -60,11 +60,12 @@ def test_axis_group_tiling_add_graph_mode():
         )
         torch_nntile.restrict_cpu()
         x = torch.randn(4, 8).to("nntile")
+        y = torch.randn(4, 8).to("nntile")
         torch_nntile.set_axis_group_name(x, {0: "batch"})
-        y = x + x
+        z = x + y
         torch_nntile.set_axis_group_tiling("batch", [1, 1, 2])
         torch_nntile.execute()
-        assert torch.allclose(y.cpu(), (x.cpu() * 2.0))
+        assert torch.allclose(z.cpu(), (x.cpu() + y.cpu()))
         """
     )
 
@@ -80,8 +81,9 @@ def test_axis_group_tiling_invalid_sum_raises():
             ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
         )
         x = torch.randn(4, 8).to("nntile")
+        y = torch.randn(4, 8).to("nntile")
         torch_nntile.set_axis_group_name(x, {0: "batch"})
-        _ = x + x
+        _ = x + y
         torch_nntile.set_axis_group_tiling("batch", [1, 1, 1])
         with pytest.raises(RuntimeError, match="sum"):
             torch_nntile.execute()

--- a/torch_nntile/tests/test_axis_group_tiling.py
+++ b/torch_nntile/tests/test_axis_group_tiling.py
@@ -1,0 +1,111 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_axis_group_tiling.py
+# Axis-group naming and tiling for torch_nntile graph recorder.
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import torch
+
+from torch_nntile import _C
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+_PKG_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run_subprocess(script: str) -> None:
+    env = dict(**__import__("os").environ)
+    repo = Path(__file__).resolve().parents[2]
+    build_lib = repo / "build" / "nntile"
+    starpu_lib = "/opt/starpu/lib"
+    ld = env.get("LD_LIBRARY_PATH", "")
+    for part in (str(build_lib), starpu_lib):
+        if part not in ld.split(":"):
+            ld = f"{part}:{ld}" if ld else part
+    env["LD_LIBRARY_PATH"] = ld
+    env["PYTHONPATH"] = f"{_PKG_ROOT}:{env.get('PYTHONPATH', '')}"
+    proc = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"subprocess failed ({proc.returncode})\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+
+def test_axis_group_tiling_add_graph_mode():
+    _run_subprocess(
+        """
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+        x = torch.randn(4, 8).to("nntile")
+        torch_nntile.set_axis_group_name(x, {0: "batch"})
+        y = x + x
+        torch_nntile.set_axis_group_tiling("batch", [1, 1, 2])
+        torch_nntile.execute()
+        assert torch.allclose(y.cpu(), (x.cpu() * 2.0))
+        """
+    )
+
+
+def test_axis_group_tiling_invalid_sum_raises():
+    _run_subprocess(
+        """
+        import pytest
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        x = torch.randn(4, 8).to("nntile")
+        torch_nntile.set_axis_group_name(x, {0: "batch"})
+        _ = x + x
+        torch_nntile.set_axis_group_tiling("batch", [1, 1, 1])
+        with pytest.raises(RuntimeError, match="sum"):
+            torch_nntile.execute()
+        """
+    )
+
+
+def test_deep_relu_names_axis_groups_in_forward():
+    _run_subprocess(
+        """
+        import torch
+        import torch_nntile
+        from torch_nntile.models import DeepReLU
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        model = DeepReLU.tiny().to("nntile")
+        x = torch.randn(8, 128).to("nntile")
+        logits = model(x)
+        torch_nntile.set_axis_group_tiling("batch", [4, 4])
+        torch_nntile.set_axis_group_tiling("features", 64)
+        torch_nntile.set_axis_group_tiling("classes", 5)
+        torch_nntile.execute()
+        assert logits.shape == (8, 10)
+        """
+    )

--- a/torch_nntile/torch_nntile/__init__.py
+++ b/torch_nntile/torch_nntile/__init__.py
@@ -129,6 +129,25 @@ def restore_where() -> None:
     _C.restore_where()
 
 
+def set_axis_group_name(tensor: torch.Tensor, names: dict[int, str]) -> None:
+    """Name TensorGraph axis groups for selected dimensions of a tensor.
+
+  Only the listed dimensions are named; others stay unnamed. Names propagate
+  to merged axis groups when ops combine tensors. Call before
+  :func:`execute` in graph mode.
+  """
+    _C.set_axis_group_name(tensor, names)
+
+
+def set_axis_group_tiling(name: str, tile_sizes: int | list[int] | tuple[int, ...]) -> None:
+    """Set tiling for a named axis group before :func:`execute`.
+
+  ``tile_sizes`` may be a uniform tile size (``int``) or explicit per-tile
+  sizes (``list``/``tuple``) that sum to the axis extent.
+  """
+    _C.set_axis_group_tiling(name, tile_sizes)
+
+
 __all__ = [
     "device",
     "_C",
@@ -141,4 +160,6 @@ __all__ = [
     "restrict_cpu",
     "restrict_cuda",
     "restore_where",
+    "set_axis_group_name",
+    "set_axis_group_tiling",
 ]

--- a/torch_nntile/torch_nntile/__init__.py
+++ b/torch_nntile/torch_nntile/__init__.py
@@ -148,6 +148,19 @@ def set_axis_group_tiling(name: str, tile_sizes: int | list[int] | tuple[int, ..
     _C.set_axis_group_tiling(name, tile_sizes)
 
 
+def format_axis_groups() -> str:
+    """Return axis-group summary for the pending TensorGraph.
+
+  Format matches the axis-group section of C++ ``TensorGraph::to_string``.
+  """
+    return _C.format_axis_groups()
+
+
+def print_axis_groups() -> None:
+    """Print axis-group summary for the pending TensorGraph to stdout."""
+    _C.print_axis_groups()
+
+
 __all__ = [
     "device",
     "_C",
@@ -162,4 +175,6 @@ __all__ = [
     "restore_where",
     "set_axis_group_name",
     "set_axis_group_tiling",
+    "format_axis_groups",
+    "print_axis_groups",
 ]

--- a/torch_nntile/torch_nntile/models/deep_relu.py
+++ b/torch_nntile/torch_nntile/models/deep_relu.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 
+import torch_nntile
+
 
 class DeepReLU(nn.Module):
     """Bias-free deep ReLU network."""
@@ -49,7 +51,15 @@ class DeepReLU(nn.Module):
         self.output_dim = output_dim
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.net(x)
+        if x.device.type == "nntile":
+            torch_nntile.set_axis_group_name(
+                x,
+                {0: "batch", 1: "features"},
+            )
+        out = self.net(x)
+        if out.device.type == "nntile":
+            torch_nntile.set_axis_group_name(out, {1: "classes"})
+        return out
 
     @classmethod
     def tiny(cls) -> DeepReLU:

--- a/torch_nntile/torch_nntile/models/deep_relu.py
+++ b/torch_nntile/torch_nntile/models/deep_relu.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 
-import torch_nntile
-
 
 class DeepReLU(nn.Module):
     """Bias-free deep ReLU network."""
@@ -51,15 +49,7 @@ class DeepReLU(nn.Module):
         self.output_dim = output_dim
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        if x.device.type == "nntile":
-            torch_nntile.set_axis_group_name(
-                x,
-                {0: "batch", 1: "features"},
-            )
-        out = self.net(x)
-        if out.device.type == "nntile":
-            torch_nntile.set_axis_group_name(out, {1: "classes"})
-        return out
+        return self.net(x)
 
     @classmethod
     def tiny(cls) -> DeepReLU:

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -18,7 +18,7 @@ Nesterov), mirroring ``nntile::optim::SGD`` in the main package.
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Mapping
 
 import torch
 import torch.nn.functional as F
@@ -240,6 +240,8 @@ def train_full_batch_step(
     inputs: torch.Tensor,
     targets: torch.Tensor,
     learning_rate: float,
+    *,
+    axis_group_tiling: Mapping[str, int | list[int] | tuple[int, ...]] | None = None,
 ) -> float:
     """One full-batch SGD step; returns scalar loss."""
     for param in model.parameters():
@@ -250,6 +252,13 @@ def train_full_batch_step(
         loss = cross_entropy(logits, targets)
         loss.backward()
         _nntile_optimizer_for(model, learning_rate).step()
+        if axis_group_tiling is not None:
+            if not torch_nntile.is_graph_mode():
+                raise RuntimeError(
+                    "axis_group_tiling requires torch_nntile graph runtime mode"
+                )
+            for name, tile_sizes in axis_group_tiling.items():
+                torch_nntile.set_axis_group_tiling(name, tile_sizes)
         if torch_nntile.is_graph_mode():
             torch_nntile.execute()
         return float(loss.detach().cpu().item())

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -18,7 +18,7 @@ Nesterov), mirroring ``nntile::optim::SGD`` in the main package.
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from typing import Callable, Iterable, Mapping
 
 import torch
 import torch.nn.functional as F
@@ -241,7 +241,9 @@ def train_full_batch_step(
     targets: torch.Tensor,
     learning_rate: float,
     *,
+    name_axis_groups: Callable[[torch.Tensor, torch.Tensor], None] | None = None,
     axis_group_tiling: Mapping[str, int | list[int] | tuple[int, ...]] | None = None,
+    print_axis_groups: bool = False,
 ) -> float:
     """One full-batch SGD step; returns scalar loss."""
     for param in model.parameters():
@@ -249,6 +251,8 @@ def train_full_batch_step(
 
     logits = model(inputs)
     if inputs.device.type == "nntile":
+        if name_axis_groups is not None:
+            name_axis_groups(inputs, logits)
         loss = cross_entropy(logits, targets)
         loss.backward()
         _nntile_optimizer_for(model, learning_rate).step()
@@ -259,6 +263,8 @@ def train_full_batch_step(
                 )
             for name, tile_sizes in axis_group_tiling.items():
                 torch_nntile.set_axis_group_tiling(name, tile_sizes)
+        if print_axis_groups and torch_nntile.is_graph_mode():
+            torch_nntile.print_axis_groups()
         if torch_nntile.is_graph_mode():
             torch_nntile.execute()
         return float(loss.detach().cpu().item())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds axis-group naming and tiling to `torch_nntile`, mirroring the C++ `AxisDescriptor` workflow.

**API:** `set_axis_group_name`, `set_axis_group_tiling`, `format_axis_groups`, `print_axis_groups`

**Example:** MNIST script defines `name_mnist_axis_groups` (not in model); supports `--axis-tiling` and `--print-axis-groups`

**Docs:** [docs/torch_nntile.md](docs/torch_nntile.md) — full API reference, MNIST workflow, C++ mapping

## Tests

```bash
pytest -vv torch_nntile/tests/test_axis_group_tiling.py
```

All 4 tests pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d73fa145-09f6-4991-bdee-e6762c786fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d73fa145-09f6-4991-bdee-e6762c786fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

