### PR TITLE
Fix wheel auditing issue on Darwin

### DIFF
--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -102,6 +102,8 @@ def _nntile_extension_kwargs() -> dict:
     library_dirs: list[str] = []
     libraries: list[str] = []
     extra_link_args: list[str] = []
+    if sys.platform == "darwin":
+        extra_link_args.append("-Wl,-rpath,@loader_path/../torch/lib")
 
     if nntile_build is not None:
         nntile_lib_dir = nntile_build / "nntile"

--- a/torch_nntile/tools/repair_wheel_macos.sh
+++ b/torch_nntile/tools/repair_wheel_macos.sh
@@ -13,10 +13,12 @@ export DYLD_LIBRARY_PATH="${build_dir}/nntile:${starpu_prefix}/lib${DYLD_LIBRARY
 
 mkdir -p "${dest_dir}"
 
+# PyTorch dylibs are provided by the torch dependency and resolved via rpath.
 delocate-wheel \
     --exclude /torch/ \
     --exclude libtorch \
     --exclude libc10 \
+    --ignore-missing-dependencies \
     --require-archs "${require_archs}" \
     -w "${dest_dir}" \
     -v \


### PR DESCRIPTION
The issue is caused by `delocate` package that fails to discover and filter PyTorch native dependencies.