### PR TITLE
Fix torch_nntile graph CUDA sync and multi-epoch training.

### DIFF
--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -132,34 +132,124 @@ example script provides naming.
 trains `DeepReLU.mnist()` on the full MNIST training set (60k batch), comparing
 CPU PyTorch vs `device="nntile"`.
 
+Default model: **5 linear layers** (`--depth 5`), **4 hidden blocks** with output
+width `--hidden-dim 256` (784→256, then three 256→256, then 256→10 logits).
+
 Axis groups used by the example:
 
-| Name | Tensor / dim | Extent (MNIST) |
-|------|----------------|----------------|
-| `batch` | input `x` dim 0, logits dim 0 | 60000 |
-| `features` | input `x` dim 1 | 784 |
-| `classes` | logits dim 1 | 10 |
+| Name | Meaning | Extent (MNIST defaults) |
+|------|---------|-------------------------|
+| `batch` | input / logits batch dim | 60000 |
+| `features` | flattened image dim | 784 |
+| `hidden` | hidden MLP width (`--hidden-dim`) on weights, grads, velocities | 256 |
+| `classes` | logits class dim | 10 |
 
-Naming is defined in the example:
+There are **four** separate `hidden` axis groups in the graph (one per hidden
+linear output). The example names them explicitly on each linear weight, grad,
+and SGD velocity matrix row/column of size `hidden_dim`.
 
-```python
-def name_mnist_axis_groups(x, logits):
-    torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
-    torch_nntile.set_axis_group_name(logits, {1: "classes"})
-```
-
-CLI:
+### Prerequisites
 
 ```bash
 export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
-python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5
-python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5 --runtime-mode graph
-python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5 \
-  --print-axis-groups \
-  --axis-tiling batch=15000,15000,15000,15000,15000
+# editable install with libnntile linked (see torch_nntile/README.md)
 ```
 
-`--axis-tiling` and `--print-axis-groups` switch to graph mode automatically.
+StarPU worker counts come from the environment (`STARPU_NCPU`, `STARPU_NCUDA`).
+The script calls `init_context(ncpu=-1, ncuda=-1, …)` so those env vars apply.
+
+### CPU workers only
+
+Use CPU StarPU workers for the nntile path (reference PyTorch path always runs
+on CPU tensors):
+
+```bash
+STARPU_NCPU=4 STARPU_NCUDA=0 \
+  python torch_nntile/examples/train_deep_relu_mnist.py \
+    --runtime-mode graph \
+    --epochs 5
+```
+
+Optional graph tiling and axis-group dump:
+
+```bash
+STARPU_NCPU=4 STARPU_NCUDA=0 \
+  python torch_nntile/examples/train_deep_relu_mnist.py \
+    --runtime-mode graph \
+    --epochs 5 \
+    --print-axis-groups \
+    --axis-tiling batch=15000,15000,15000,15000 \
+    --axis-tiling features=392,392 \
+    --axis-tiling hidden=128,128
+```
+
+**Expected tail output (CPU workers, graph mode, 5 epochs):**
+
+```
+Loss comparison (cpu vs nntile):
+  epoch 1: cpu=2.302172  nntile=2.302172  diff=2.384e-07
+  epoch 2: cpu=2.302079  nntile=2.302080  diff=4.768e-07
+  epoch 3: cpu=2.301987  nntile=2.301987  diff=0.000e+00
+  epoch 4: cpu=2.301894  nntile=2.301895  diff=4.768e-07
+  epoch 5: cpu=2.301802  nntile=2.301802  diff=0.000e+00
+
+Final weight max |cpu - nntile| = 1.118e-08
+```
+
+Per-epoch loss diffs at or below **~1e-6** are typical on CPU.
+
+### CUDA workers only
+
+Pin nntile kernels to CUDA workers (`--restrict-cuda`):
+
+```bash
+STARPU_NCPU=0 STARPU_NCUDA=2 \
+  python torch_nntile/examples/train_deep_relu_mnist.py \
+    --runtime-mode graph \
+    --restrict-cuda \
+    --epochs 5 \
+    --axis-tiling batch=15000,15000,15000,15000 \
+    --axis-tiling features=392,392 \
+    --axis-tiling hidden=128,128
+```
+
+**Expected tail output (CUDA workers, graph mode, 5 epochs, with tiling above):**
+
+```
+Loss comparison (cpu vs nntile):
+  epoch 1: cpu=2.302172  nntile=2.302095  diff=7.701e-05
+  epoch 2: cpu=2.302079  nntile=2.301964  diff=1.152e-04
+  epoch 3: cpu=2.301987  nntile=2.301834  diff=1.538e-04
+  epoch 4: cpu=2.301894  nntile=2.301818  diff=7.653e-05
+  epoch 5: cpu=2.301802  nntile=2.301495  diff=3.073e-04
+
+Final weight max |cpu - nntile| = 1.583e-08
+```
+
+On CUDA, per-epoch **loss** diffs of order **1e-4** are normal (cuBLAS / TF32 /
+reduction order vs CPU reference). **Weights** should still match to **~1e-8**.
+Call `torch_nntile.wait()` before reading losses on the host; the example shuts
+down StarPU cleanly in a `finally` block.
+
+### Useful flags
+
+| Flag | Purpose |
+|------|---------|
+| `--runtime-mode graph` | Record full step, then `compile_graph()` + `run()` |
+| `--restrict-cuda` | `restrict_cuda()` — CUDA workers only |
+| `--verbose` | Verbose StarPU / NNTile context logging |
+| `--hidden-dim`, `--depth` | Model size (default 256, 5) |
+| `--axis-tiling NAME=SIZES` | Repeatable; auto-switches to graph mode |
+| `--print-axis-groups` | Dump axis groups after epoch 1 (graph mode) |
+
+`--axis-tiling` and `--print-axis-groups` switch to graph mode automatically if
+omitted from `--runtime-mode`.
+
+Integration test (downloads MNIST, 3 epochs, CPU workers):
+
+```bash
+pytest -vv -m slow torch_nntile/tests/test_deep_relu_mnist_train.py
+```
 
 ## Tests
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -92,15 +92,11 @@ torch_nntile.run()
 ```
 
 Models do **not** assign axis names internally. The MNIST example defines
-``name_mnist_axis_groups`` and passes it to ``train_full_batch_step``:
+``name_mnist_axis_groups`` (batch, features, classes, and ``hidden`` on each
+linear weight/grad/velocity) and passes it to ``train_full_batch_step``.
 
-```python
-def name_mnist_axis_groups(x, logits):
-    torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
-    torch_nntile.set_axis_group_name(logits, {1: "classes"})
-```
-
-CLI: ``--axis-tiling NAME=SIZES`` (repeatable), ``--print-axis-groups``.
+CLI: ``--axis-tiling NAME=SIZES`` (repeatable), ``--print-axis-groups``,
+``--restrict-cuda``, ``--verbose``.
 
 Tests: `pytest -vv torch_nntile/tests/test_axis_group_tiling.py`
 
@@ -143,17 +139,31 @@ label shape with one ``scale_slice`` per label dimension, then applies
 ``tensor::sgd_step`` via ``torch_nntile.training.SGD`` (no per-parameter CPU
 round-trip).
 
-Axis naming (`batch`, `features`, `classes`) is in the example script — see
-[docs/torch_nntile.md](../docs/torch_nntile.md).
+Axis naming (`batch`, `features`, `hidden`, `classes`) is in the example script — see
+[docs/torch_nntile.md](../docs/torch_nntile.md) for full run instructions and
+expected output.
 
 ```bash
 export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
-python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5
-python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5 --runtime-mode graph
-python torch_nntile/examples/train_deep_relu_mnist.py --epochs 5 \
-  --print-axis-groups \
-  --axis-tiling batch=15000,15000,15000,15000,15000
+
+# CPU StarPU workers (nntile path); reference PyTorch path is always CPU
+STARPU_NCPU=4 STARPU_NCUDA=0 \
+  python torch_nntile/examples/train_deep_relu_mnist.py \
+    --runtime-mode graph --epochs 5
+
+# CUDA StarPU workers only
+STARPU_NCPU=0 STARPU_NCUDA=2 \
+  python torch_nntile/examples/train_deep_relu_mnist.py \
+    --runtime-mode graph --restrict-cuda --epochs 5 \
+    --axis-tiling batch=15000,15000,15000,15000 \
+    --axis-tiling features=392,392 \
+    --axis-tiling hidden=128,128
 ```
+
+**Parity expectations:** with CPU workers, per-epoch loss diffs are ~1e-6 or
+smaller. With CUDA workers, **loss** diffs of ~1e-4 are acceptable; **weights**
+should still agree to ~1e-8. See [docs/torch_nntile.md](../docs/torch_nntile.md)
+for sample output.
 
 Integration test (downloads MNIST, 3 epochs, compares losses and weights):
 
@@ -229,6 +239,11 @@ torch_nntile.restore_where()   # default placement again
 `init_context()` must be called before the first libnntile-backed operation
 (e.g. `a + b` on `device="nntile"`). `restrict_cpu()` / `restrict_cuda()` /
 `restore_where()` auto-create the context with defaults if needed.
+
+When CUDA workers are enabled (`STARPU_NCUDA > 0`), use ``--restrict-cuda`` in
+the MNIST example (or call ``restrict_cuda()``) and shut StarPU down at exit.
+The example calls ``torch_nntile.wait()`` and ``torch_nntile.shutdown_context()``
+in a ``finally`` block; ``init_context()`` also registers an ``atexit`` hook.
 
 ## macOS / PyTorch 2.12
 

--- a/torch_nntile/csrc/nntile_context.cpp
+++ b/torch_nntile/csrc/nntile_context.cpp
@@ -6,12 +6,16 @@
 
 #include "nntile_context.h"
 
+#include "nntile_graph_recorder.h"
+
 #include <mutex>
 #include <stdexcept>
 
 #ifdef TORCH_NNTILE_USE_LIBNNTILE
 
 #include <nntile/context.hh>
+
+#include <starpu.h>
 
 #include <memory>
 
@@ -145,6 +149,32 @@ void restore_where()
     g_context->restore_where();
 }
 
+void wait_for_all()
+{
+    std::lock_guard<std::mutex> lock(g_context_mutex);
+    if (g_context == nullptr || !starpu_is_initialized())
+    {
+        return;
+    }
+    starpu_task_wait_for_all();
+}
+
+void shutdown_context()
+{
+    shutdown_recorder();
+    std::lock_guard<std::mutex> lock(g_context_mutex);
+    if (g_context == nullptr)
+    {
+        return;
+    }
+    if (starpu_is_initialized())
+    {
+        starpu_task_wait_for_all();
+    }
+    g_context->shutdown();
+    g_context.reset();
+}
+
 } // namespace torch_nntile
 
 #else
@@ -215,6 +245,14 @@ void restrict_cuda()
 void restore_where()
 {
     require_libnntile();
+}
+
+void wait_for_all()
+{
+}
+
+void shutdown_context()
+{
 }
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_context.h
+++ b/torch_nntile/csrc/nntile_context.h
@@ -44,4 +44,10 @@ void restrict_cuda();
 
 void restore_where();
 
+//! Block until all submitted StarPU tasks finish (including async unregisters).
+void wait_for_all();
+
+//! Shut down libnntile / StarPU and release the context (safe to call repeatedly).
+void shutdown_context();
+
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -118,36 +118,26 @@ void apply_pending_axis_tiling_locked()
         return;
     }
 
-    std::unordered_map<std::string, nntile::AxisDescriptor *> named_groups;
-    for (nntile::AxisDescriptor *axis : g_graph->axis_groups())
-    {
-        if (axis == nullptr || axis->name.empty())
-        {
-            continue;
-        }
-        const auto found = named_groups.find(axis->name);
-        if (found != named_groups.end() && found->second != axis)
-        {
-            throw std::runtime_error(
-                "torch_nntile set_axis_group_tiling: duplicate axis group name '" +
-                axis->name + "'");
-        }
-        named_groups.emplace(axis->name, axis);
-    }
-
     for (const auto &[name, pattern] : g_axis_tiling_by_name)
     {
-        const auto found = named_groups.find(name);
-        if (found == named_groups.end())
+        bool found_any = false;
+        for (nntile::AxisDescriptor *axis : g_graph->axis_groups())
+        {
+            if (axis == nullptr || axis->name != name)
+            {
+                continue;
+            }
+            found_any = true;
+            const std::vector<nntile::Index> resolved =
+                nntile::tile_sizes_for_axis_extent(pattern, axis->extent);
+            nntile::apply_tiling_to_axis(axis, resolved);
+        }
+        if (!found_any)
         {
             throw std::runtime_error(
                 "torch_nntile set_axis_group_tiling: unknown axis group '" +
                 name + "'");
         }
-        nntile::AxisDescriptor *axis = found->second;
-        const std::vector<nntile::Index> resolved =
-            nntile::tile_sizes_for_axis_extent(pattern, axis->extent);
-        nntile::apply_tiling_to_axis(axis, resolved);
     }
 }
 

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -18,6 +18,8 @@
 #include <nntile/tensor/graph.hh>
 #include <nntile/tile/graph.hh>
 
+#include <starpu.h>
+
 namespace nntile
 {
 void apply_tiling_to_axis(
@@ -354,6 +356,14 @@ void clear_pending_graph_after_compile_locked()
     g_axis_tiling_by_name.clear();
 }
 
+void drain_starpu_after_session_teardown()
+{
+    if (starpu_is_initialized())
+    {
+        starpu_task_wait_for_all();
+    }
+}
+
 void compile_graph_locked(bool clear_pending_after = true)
 {
     if (g_graph == nullptr || g_graph->num_ops() == 0)
@@ -374,6 +384,8 @@ void compile_graph_locked(bool clear_pending_after = true)
     auto compiled_tensor_graph = std::move(g_graph);
     nntile::TileGraph tile_graph =
         nntile::TileGraph::from_tensor_graph(*compiled_tensor_graph);
+    g_session.reset();
+    drain_starpu_after_session_teardown();
     g_session = std::make_unique<GraphSession>();
     g_session->tensor_graph = std::move(compiled_tensor_graph);
     g_session->tile_graph =
@@ -435,6 +447,7 @@ void reset_recorder_locked()
     g_axis_tiling_by_name.clear();
     g_session.reset();
     g_persisted_tiles_by_storage.clear();
+    drain_starpu_after_session_teardown();
 }
 
 void execute_pending_graph_locked()
@@ -446,6 +459,20 @@ void execute_pending_graph_locked()
         copy_host_visible_outputs(*g_session->runtime, nullptr);
     }
     clear_pending_graph_after_compile_locked();
+    reset_recorder_locked();
+}
+
+void shutdown_recorder_locked()
+{
+    if (g_graph != nullptr && g_graph->num_ops() > 0)
+    {
+        compile_graph_locked(false);
+        run_graph_locked();
+        if (g_session != nullptr && g_session->runtime != nullptr)
+        {
+            copy_host_visible_outputs(*g_session->runtime, nullptr);
+        }
+    }
     reset_recorder_locked();
 }
 
@@ -495,6 +522,12 @@ void reset_graph_session()
 {
     std::lock_guard<std::mutex> lock(g_recorder_mutex);
     reset_recorder_locked();
+}
+
+void shutdown_recorder()
+{
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    shutdown_recorder_locked();
 }
 
 bool has_graph_session()
@@ -569,6 +602,7 @@ void sync_runtime_to_nntile_storage(void *data_ptr)
     {
         return;
     }
+    g_session->runtime->wait();
     MappedTensor mapped;
     mapped.node = node;
     mapped.dtype = node->dtype();
@@ -616,7 +650,7 @@ nntile::TensorGraph::TensorNode *get_or_create_data_node(
     }
 
     const auto found = g_tensor_nodes.find(data_ptr);
-    if (found != g_tensor_nodes.end())
+    if (found != g_tensor_nodes.end() && found->second.node != nullptr)
     {
         // Intermediate op output fed into a later op: keep the node for DCE
         // but stop binding/copying through storage PyTorch may free or reuse.
@@ -629,8 +663,14 @@ nntile::TensorGraph::TensorNode *get_or_create_data_node(
         return found->second.node;
     }
 
+    const bool is_persistent =
+        found != g_tensor_nodes.end() && found->second.is_persistent_input;
+    const bool bind_at_execute =
+        (found != g_tensor_nodes.end() && found->second.bind_at_execute) ||
+        mark_as_input;
+
     auto *node = g_graph->data(shape, dtype);
-    if (mark_as_input)
+    if (mark_as_input || is_persistent)
     {
         node->mark_input(true);
     }
@@ -641,8 +681,8 @@ nntile::TensorGraph::TensorNode *get_or_create_data_node(
         dtype,
         static_cast<std::size_t>(graph_numel(shape)),
         false,
-        mark_as_input,
-        mark_as_input};
+        bind_at_execute,
+        is_persistent || mark_as_input};
     return node;
 }
 

--- a/torch_nntile/csrc/nntile_graph_recorder.h
+++ b/torch_nntile/csrc/nntile_graph_recorder.h
@@ -26,6 +26,8 @@ void run_graph();
 
 void reset_graph_session();
 
+void shutdown_recorder();
+
 bool has_graph_session();
 
 void sync_nntile_storage_to_runtime(void *data_ptr);

--- a/torch_nntile/csrc/nntile_kernels.cpp
+++ b/torch_nntile/csrc/nntile_kernels.cpp
@@ -299,6 +299,7 @@ at::Tensor copy_from(
             }
             if (has_graph_session())
             {
+                wait_for_all();
                 sync_runtime_to_nntile_storage(
                     self.storage().data_ptr().get());
             }
@@ -336,6 +337,7 @@ at::Scalar local_scalar_dense(const at::Tensor &self)
     require_no_pending_graph(
         "read a scalar from an nntile tensor "
         "(call torch_nntile.compile_graph() and torch_nntile.run() first)");
+    wait_for_all();
     return tensor_to_scalar(self);
 }
 

--- a/torch_nntile/csrc/nntile_module.cpp
+++ b/torch_nntile/csrc/nntile_module.cpp
@@ -228,6 +228,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         &torch_nntile::restore_where,
         "Restore default StarPU codelet worker placement");
     m.def(
+        "wait_for_all",
+        &torch_nntile::wait_for_all,
+        "Block until all submitted StarPU tasks finish");
+    m.def(
+        "shutdown_context",
+        &torch_nntile::shutdown_context,
+        "Shut down libnntile / StarPU (safe to call repeatedly)");
+    m.def(
         "execute",
         &torch_nntile::execute_pending_graph,
         "Compile, run, and reset the pending TensorGraph (legacy graph mode)");

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -203,78 +203,82 @@ def main() -> None:
         runtime_mode = "graph"
 
     torch_nntile.init_context(
-        ncpu=1,
-        ncuda=0,
-        verbose=0,
+        ncpu=-1,
+        ncuda=-1,
+        verbose=1,
         cpu_fallback=False,
         runtime_mode=runtime_mode,
     )
 
-    print(f"Runtime mode: {runtime_mode}")
-    if axis_group_tiling:
-        print(f"Axis-group tiling: {axis_group_tiling}")
+    try:
+        print(f"Runtime mode: {runtime_mode}")
+        if axis_group_tiling:
+            print(f"Axis-group tiling: {axis_group_tiling}")
 
-    output_dir = Path(args.output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
+        output_dir = Path(args.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
 
-    print("Loading MNIST training set (60 000 images, single batch)...")
-    images, labels = load_mnist_full_batch(args.data_dir)
-    print(f"  images {tuple(images.shape)}, labels {tuple(labels.shape)}")
+        print("Loading MNIST training set (60 000 images, single batch)...")
+        images, labels = load_mnist_full_batch(args.data_dir)
+        print(f"  images {tuple(images.shape)}, labels {tuple(labels.shape)}")
 
-    model_cpu, model_nnt = build_models(
-        seed=args.seed,
-        hidden_dim=args.hidden_dim,
-        depth=args.depth,
-    )
-
-    init_cpu = clone_model_weights(model_cpu)
-    init_nnt = clone_model_weights(model_nnt)
-    init_delta = max_weight_delta(init_cpu, init_nnt)
-    print(f"Initial weight max |cpu - nntile| = {init_delta:.3e} (expect 0)")
-
-    print("\nTraining on CPU...")
-    cpu_losses = train_on_device(
-        model_cpu,
-        images,
-        labels,
-        device="cpu",
-        epochs=args.epochs,
-        learning_rate=args.lr,
-    )
-
-    print("\nTraining on nntile...")
-    nnt_losses = train_on_device(
-        model_nnt,
-        images,
-        labels,
-        device="nntile",
-        epochs=args.epochs,
-        learning_rate=args.lr,
-        axis_group_tiling=axis_group_tiling or None,
-        print_axis_groups=args.print_axis_groups,
-    )
-
-    cpu_path = output_dir / "deep_relu_mnist_cpu.pt"
-    nnt_path = output_dir / "deep_relu_mnist_nntile.pt"
-    torch.save(model_cpu.state_dict(), cpu_path)
-    torch.save(clone_model_weights(model_nnt), nnt_path)
-
-    final_cpu = clone_model_weights(model_cpu)
-    final_nnt = clone_model_weights(model_nnt)
-    weight_delta = max_weight_delta(final_cpu, final_nnt)
-
-    print("\nLoss comparison (cpu vs nntile):")
-    for epoch, (loss_cpu, loss_nnt) in enumerate(
-        zip(cpu_losses, nnt_losses), start=1
-    ):
-        print(
-            f"  epoch {epoch}: cpu={loss_cpu:.6f}  nntile={loss_nnt:.6f}  "
-            f"diff={abs(loss_cpu - loss_nnt):.3e}"
+        model_cpu, model_nnt = build_models(
+            seed=args.seed,
+            hidden_dim=args.hidden_dim,
+            depth=args.depth,
         )
 
-    print(f"\nFinal weight max |cpu - nntile| = {weight_delta:.3e}")
-    print(f"Saved CPU model to {cpu_path}")
-    print(f"Saved nntile model (CPU tensors) to {nnt_path}")
+        init_cpu = clone_model_weights(model_cpu)
+        init_nnt = clone_model_weights(model_nnt)
+        init_delta = max_weight_delta(init_cpu, init_nnt)
+        print(f"Initial weight max |cpu - nntile| = {init_delta:.3e} (expect 0)")
+
+        print("\nTraining on CPU...")
+        cpu_losses = train_on_device(
+            model_cpu,
+            images,
+            labels,
+            device="cpu",
+            epochs=args.epochs,
+            learning_rate=args.lr,
+        )
+
+        print("\nTraining on nntile...")
+        nnt_losses = train_on_device(
+            model_nnt,
+            images,
+            labels,
+            device="nntile",
+            epochs=args.epochs,
+            learning_rate=args.lr,
+            axis_group_tiling=axis_group_tiling or None,
+            print_axis_groups=args.print_axis_groups,
+        )
+
+        cpu_path = output_dir / "deep_relu_mnist_cpu.pt"
+        nnt_path = output_dir / "deep_relu_mnist_nntile.pt"
+        torch.save(model_cpu.state_dict(), cpu_path)
+        torch.save(clone_model_weights(model_nnt), nnt_path)
+
+        final_cpu = clone_model_weights(model_cpu)
+        final_nnt = clone_model_weights(model_nnt)
+        weight_delta = max_weight_delta(final_cpu, final_nnt)
+
+        print("\nLoss comparison (cpu vs nntile):")
+        for epoch, (loss_cpu, loss_nnt) in enumerate(
+            zip(cpu_losses, nnt_losses), start=1
+        ):
+            print(
+                f"  epoch {epoch}: cpu={loss_cpu:.6f}  nntile={loss_nnt:.6f}  "
+                f"diff={abs(loss_cpu - loss_nnt):.3e}"
+            )
+
+        print(f"\nFinal weight max |cpu - nntile| = {weight_delta:.3e}")
+        print(f"Saved CPU model to {cpu_path}")
+        print(f"Saved nntile model (CPU tensors) to {nnt_path}")
+    finally:
+        torch_nntile.wait()
+        torch_nntile.shutdown_context()
 
 
 if __name__ == "__main__":

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -17,18 +17,29 @@ Axis-group naming and tiling (optional) are configured in this script:
 
 - ``batch`` — input/logits batch dimension
 - ``features`` — flattened image dimension (784)
+- ``hidden`` — hidden MLP width (``--hidden-dim``); named on each linear
+  weight/grad/velocity matrix row or column of that size
 - ``classes`` — output logits dimension (10)
 
-Example with batch tiling in graph mode::
+Example with batch and hidden tiling in graph mode::
 
     export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
+    STARPU_NCPU=0 STARPU_NCUDA=2 \\
     python torch_nntile/examples/train_deep_relu_mnist.py \\
         --runtime-mode graph \\
-        --print-axis-groups \\
-        --axis-tiling batch=15000,15000,15000,15000,15000
+        --restrict-cuda \\
+        --epochs 5 \\
+        --axis-tiling batch=15000,15000,15000,15000 \\
+        --axis-tiling features=392,392 \\
+        --axis-tiling hidden=128,128
+
+Run instructions and expected CPU vs CUDA output:
+``docs/torch_nntile.md`` (DeepReLU MNIST example section).
 """
 
 from __future__ import annotations
+
+from typing import Callable
 
 import argparse
 import sys
@@ -100,10 +111,40 @@ def build_axis_group_tiling(
     return tiling
 
 
-def name_mnist_axis_groups(x: torch.Tensor, logits: torch.Tensor) -> None:
+def _name_hidden_on_matrix(tensor: torch.Tensor, hidden_dim: int) -> None:
+    """Tag matrix rows/cols of size ``hidden_dim`` with the ``hidden`` axis group."""
+    if tensor.ndim != 2:
+        return
+    out_features, in_features = tensor.shape
+    names: dict[int, str] = {}
+    if out_features == hidden_dim:
+        names[0] = "hidden"
+    if in_features == hidden_dim:
+        names[1] = "hidden"
+    if names:
+        torch_nntile.set_axis_group_name(tensor, names)
+
+
+def name_mnist_axis_groups(
+    model: torch.nn.Module,
+    x: torch.Tensor,
+    logits: torch.Tensor,
+    *,
+    hidden_dim: int,
+) -> None:
     """Name axis groups for DeepReLU MNIST training on nntile."""
     torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
     torch_nntile.set_axis_group_name(logits, {1: "classes"})
+    for module in model.modules():
+        if not isinstance(module, torch.nn.Linear):
+            continue
+        _name_hidden_on_matrix(module.weight, hidden_dim)
+        if module.weight.grad is not None:
+            _name_hidden_on_matrix(module.weight.grad, hidden_dim)
+    optimizer = getattr(model, "_nntile_optimizer", None)
+    if optimizer is not None:
+        for velocity in optimizer._velocity.values():
+            _name_hidden_on_matrix(velocity, hidden_dim)
 
 
 def build_models(
@@ -129,6 +170,7 @@ def train_on_device(
     device: str,
     epochs: int,
     learning_rate: float,
+    hidden_dim: int,
     axis_group_tiling: dict[str, list[int]] | None = None,
     print_axis_groups: bool = False,
 ) -> list[float]:
@@ -143,13 +185,21 @@ def train_on_device(
         y = labels
 
     losses: list[float] = []
+    name_axis_groups: (
+        Callable[[torch.Tensor, torch.Tensor], None] | None
+    ) = None
+    if device == "nntile":
+
+        def name_axis_groups(x: torch.Tensor, logits: torch.Tensor) -> None:
+            name_mnist_axis_groups(model, x, logits, hidden_dim=hidden_dim)
+
     for epoch in range(epochs):
         loss = train_full_batch_step(
             model,
             x,
             y,
             learning_rate,
-            name_axis_groups=name_mnist_axis_groups if device == "nntile" else None,
+            name_axis_groups=name_axis_groups,
             axis_group_tiling=axis_group_tiling if device == "nntile" else None,
             print_axis_groups=print_axis_groups and device == "nntile" and epoch == 0,
         )
@@ -178,14 +228,24 @@ def main() -> None:
         default=[],
         metavar="NAME=SIZES",
         help=(
-            "Axis-group tiling for nntile, e.g. batch=15000,15000,15000,15000,15000 "
-            "or features=392,392. Repeat for multiple groups."
+            "Axis-group tiling for nntile, e.g. batch=15000,15000,15000,15000 "
+            "or features=392,392 or hidden=128,128. Repeat for multiple groups."
         ),
     )
     parser.add_argument(
         "--print-axis-groups",
         action="store_true",
         help="Print axis groups after the first nntile training step (graph mode)",
+    )
+    parser.add_argument(
+        "--restrict-cuda",
+        action="store_true",
+        help="Pin nntile kernels to CUDA workers (requires ncuda > 0)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose StarPU / NNTile context logging",
     )
     parser.add_argument("--output-dir", default="deep_relu_mnist_runs")
     args = parser.parse_args()
@@ -205,15 +265,20 @@ def main() -> None:
     torch_nntile.init_context(
         ncpu=-1,
         ncuda=-1,
-        verbose=1,
+        verbose=int(args.verbose),
         cpu_fallback=False,
         runtime_mode=runtime_mode,
     )
+    if args.restrict_cuda:
+        torch_nntile.restrict_cuda()
 
     try:
         print(f"Runtime mode: {runtime_mode}")
+        if args.restrict_cuda:
+            print("Worker placement: CUDA only (restrict_cuda)")
         if axis_group_tiling:
             print(f"Axis-group tiling: {axis_group_tiling}")
+        print(f"DeepReLU hidden_dim={args.hidden_dim} depth={args.depth}")
 
         output_dir = Path(args.output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -241,6 +306,7 @@ def main() -> None:
             device="cpu",
             epochs=args.epochs,
             learning_rate=args.lr,
+            hidden_dim=args.hidden_dim,
         )
 
         print("\nTraining on nntile...")
@@ -251,6 +317,7 @@ def main() -> None:
             device="nntile",
             epochs=args.epochs,
             learning_rate=args.lr,
+            hidden_dim=args.hidden_dim,
             axis_group_tiling=axis_group_tiling or None,
             print_axis_groups=args.print_axis_groups,
         )

--- a/torch_nntile/tests/test_axis_group_tiling.py
+++ b/torch_nntile/tests/test_axis_group_tiling.py
@@ -106,12 +106,25 @@ def test_deep_relu_axis_groups_with_explicit_naming():
         logits = model(x)
         torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
         torch_nntile.set_axis_group_name(logits, {1: "classes"})
+        for module in model.modules():
+            if not isinstance(module, torch.nn.Linear):
+                continue
+            w = module.weight
+            names = {}
+            if w.shape[0] == 256:
+                names[0] = "hidden"
+            if w.shape[1] == 256:
+                names[1] = "hidden"
+            if names:
+                torch_nntile.set_axis_group_name(w, names)
         info = torch_nntile.format_axis_groups()
         assert "name='batch'" in info
         assert "name='features'" in info
         assert "name='classes'" in info
+        assert "name='hidden'" in info
         torch_nntile.set_axis_group_tiling("batch", [4, 4])
         torch_nntile.set_axis_group_tiling("features", 64)
+        torch_nntile.set_axis_group_tiling("hidden", 128)
         torch_nntile.execute()
         assert logits.shape == (8, 10)
         """

--- a/torch_nntile/tests/test_context_restrict.py
+++ b/torch_nntile/tests/test_context_restrict.py
@@ -30,6 +30,10 @@ def test_restrict_restore_roundtrip():
     torch_nntile.restore_where()
 
 
+def test_wait_for_all():
+    torch_nntile.wait_for_all()
+
+
 def test_init_context_after_first_op_raises():
     import torch
 

--- a/torch_nntile/tests/test_graph_execution.py
+++ b/torch_nntile/tests/test_graph_execution.py
@@ -269,6 +269,37 @@ def test_train_full_batch_step_graph_mode():
     )
 
 
+def test_train_full_batch_step_graph_mode_multi_epoch():
+    """compile_graph() clears pending nodes; epoch 2 must recreate data nodes."""
+    _run_graph_subprocess(
+        """
+        import math
+
+        import torch
+        import torch_nntile
+        from torch_nntile.models import DeepReLU
+        from torch_nntile.training import train_full_batch_step
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+
+        model_cpu = DeepReLU.tiny()
+        model_cpu.init_kaiming_uniform_(seed=42)
+        model = DeepReLU.tiny().to("nntile")
+        model.load_state_dict(model_cpu.state_dict())
+        x = torch.randn(8, model.input_dim).to("nntile")
+        y = torch.randint(0, model.output_dim, (8,)).to("nntile")
+        losses = [
+            train_full_batch_step(model, x, y, learning_rate=0.1)
+            for _ in range(3)
+        ]
+        assert all(math.isfinite(loss) for loss in losses)
+        """
+    )
+
+
 def test_graph_nntile_loss_backward_without_scalar_read():
     _run_graph_subprocess(
         """

--- a/torch_nntile/torch_nntile/__init__.py
+++ b/torch_nntile/torch_nntile/__init__.py
@@ -8,11 +8,28 @@
 
 from __future__ import annotations
 
+import atexit
+
 import torch
 
 from . import _C  # noqa: F401 — loads kernels and allocator
 
 _registered = False
+_atexit_shutdown_registered = False
+
+
+def _register_shutdown_atexit() -> None:
+    global _atexit_shutdown_registered
+    if _atexit_shutdown_registered:
+        return
+    atexit.register(_shutdown_on_exit)
+    _atexit_shutdown_registered = True
+
+
+def _shutdown_on_exit() -> None:
+    if is_context_initialized():
+        wait()
+        shutdown_context()
 
 
 class _NntileBackendModule:
@@ -87,6 +104,7 @@ def init_context(
         cpu_fallback,
         runtime_mode,
     )
+    _register_shutdown_atexit()
 
 
 def execute() -> None:
@@ -148,6 +166,28 @@ def restore_where() -> None:
     _C.restore_where()
 
 
+def wait() -> None:
+    """Block until all submitted StarPU tasks finish (``starpu_task_wait_for_all``).
+
+    Call before host readout (``.to("cpu")``) or :func:`shutdown_context`.
+    Required for clean CUDA teardown when ``ncuda > 0``.
+    """
+    _C.wait_for_all()
+
+
+wait_for_all = wait
+
+
+def shutdown_context() -> None:
+    """Shut down libnntile / StarPU and release the global context.
+
+    Flushes any pending TensorGraph and graph session, waits for workers, then
+    calls ``Context::shutdown``. Safe to call multiple times. An ``atexit`` hook
+    registered by :func:`init_context` runs the same teardown automatically.
+    """
+    _C.shutdown_context()
+
+
 def set_axis_group_name(tensor: torch.Tensor, names: dict[int, str]) -> None:
     """Name TensorGraph axis groups for selected dimensions of a tensor.
 
@@ -196,6 +236,9 @@ __all__ = [
     "restrict_cpu",
     "restrict_cuda",
     "restore_where",
+    "wait",
+    "wait_for_all",
+    "shutdown_context",
     "set_axis_group_name",
     "set_axis_group_tiling",
     "format_axis_groups",

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -268,7 +268,10 @@ def train_full_batch_step(
         if torch_nntile.is_graph_mode():
             torch_nntile.compile_graph()
             torch_nntile.run()
-        return float(loss.to("cpu").item())
+
+        torch_nntile.wait()
+        loss_cpu = loss.to("cpu")
+        return float(loss_cpu.item())
 
     loss = F.cross_entropy(logits, targets)
     loss.backward()

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -251,11 +251,11 @@ def train_full_batch_step(
 
     logits = model(inputs)
     if inputs.device.type == "nntile":
-        if name_axis_groups is not None:
-            name_axis_groups(inputs, logits)
         loss = cross_entropy(logits, targets)
         loss.backward()
         _nntile_optimizer_for(model, learning_rate).step()
+        if name_axis_groups is not None:
+            name_axis_groups(inputs, logits)
         if axis_group_tiling is not None:
             if not torch_nntile.is_graph_mode():
                 raise RuntimeError(


### PR DESCRIPTION
Restore wait/shutdown_context for clean StarPU teardown, drain async tile unregisters after session replacement, sync before host readout, and recreate data nodes when compile_graph clears persistent mappings.