### PR TITLE
CUDA Linux and CPU macOS torch_nntile 0.0.1 wheel CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -294,7 +294,7 @@ jobs:
           export LD_LIBRARY_PATH="${PWD}/build/nntile:/opt/starpu/lib:${LD_LIBRARY_PATH:-}"
           export STARPU_SILENT=1 STARPU_FXT_TRACE=0 STARPU_WORKERS_NOBIND=1
           export OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 GOTO_NUM_THREADS=1
-          pip install --break-system-packages torch pytest
+          pip install --break-system-packages 'torch==2.9.1' pytest
           CXX=g++ pip install --break-system-packages \
             -e ./torch_nntile --no-build-isolation --force-reinstall
           pytest -vv --rootdir=. -m 'not slow' torch_nntile/tests/

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -254,7 +254,7 @@ jobs:
         working-directory: /
       - uses: actions/checkout@v6
       - run: |
-          pip install --break-system-packages torch pytest
+          pip install --break-system-packages 'torch==2.9.1' pytest
           CXX=g++ pip install --break-system-packages \
             -e ./torch_nntile --no-build-isolation
           pytest -vv torch_nntile/tests/test_device_stub.py

--- a/.github/workflows/torch-nntile-wheels.yml
+++ b/.github/workflows/torch-nntile-wheels.yml
@@ -1,8 +1,7 @@
 name: torch_nntile wheels
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - graph_api
   workflow_dispatch:
@@ -16,10 +15,17 @@ defaults:
 
 env:
   CIBUILDWHEEL_VERSION: "4.1.0"
+  TORCH_VERSION: "2.9.1"
+  TORCH_CUDA_TAG: "cu128"
+  TORCH_CUDA_INDEX: "https://download.pytorch.org/whl/cu128"
+  TORCH_NNTILE_WHEEL_VERSION: "0.0.1"
+  STARPU_GITHUB_REPO: "nntile/starpu"
+  STARPU_GIT_BRANCH: "master"
+  CMAKE_CUDA_ARCHITECTURES: "70;75;80;86;89;90"
+  TORCH_CUDA_ARCH_LIST: "7.0;7.5;8.0;8.6;8.9;9.0"
 
 jobs:
   build-wheels:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     name: ${{ matrix.identifier }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
@@ -28,15 +34,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            identifier: cp314-manylinux_x86_64
+            identifier: cp312-manylinux_x86_64
+            use_cuda: "1"
           - os: macos-14
-            identifier: cp314-macosx_arm64
+            identifier: cp312-macosx_arm64
+            use_cuda: "0"
     steps:
       - uses: actions/checkout@v6
         if: ${{ env.ACT != 'true' }}
         with:
           persist-credentials: false
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
 
       - name: Configure host paths
         run: |
@@ -52,14 +59,23 @@ jobs:
           echo "TORCH_NNTILE_HOST_WORKSPACE=${host_workspace}" >> "${GITHUB_ENV}"
           echo "TORCH_NNTILE_PACKAGE_DIR=${host_workspace}/torch_nntile" >> "${GITHUB_ENV}"
           echo "TORCH_NNTILE_OUTPUT_DIR=${host_workspace}/wheelhouse" >> "${GITHUB_ENV}"
+          echo "NNTILE_SOURCE_DIR=${host_workspace}" >> "${GITHUB_ENV}"
+          echo "TORCH_NNTILE_USE_CUDA=${{ matrix.use_cuda }}" >> "${GITHUB_ENV}"
 
       - name: Configure Linux source mount
         if: runner.os == 'Linux'
         run: |
           echo "CIBW_CONTAINER_ENGINE=docker; create_args: --volume ${TORCH_NNTILE_HOST_WORKSPACE}:/nntile-repo:ro" >> "${GITHUB_ENV}"
-          echo "CIBW_ENVIRONMENT_PASS_LINUX=NNTILE_SOURCE_DIR NNTILE_BUILD_DIR" >> "${GITHUB_ENV}"
+          echo "CIBW_ENVIRONMENT_PASS_LINUX=NNTILE_SOURCE_DIR NNTILE_BUILD_DIR STARPU_PREFIX TORCH_NNTILE_USE_CUDA TORCH_VERSION TORCH_CUDA_TAG TORCH_CUDA_INDEX CMAKE_CUDA_ARCHITECTURES TORCH_CUDA_ARCH_LIST STARPU_GITHUB_REPO STARPU_GIT_BRANCH TORCH_NNTILE_WHEEL_VERSION" >> "${GITHUB_ENV}"
           echo "NNTILE_SOURCE_DIR=/nntile-repo" >> "${GITHUB_ENV}"
           echo "NNTILE_BUILD_DIR=/tmp/nntile-build/torch_nntile_wheel" >> "${GITHUB_ENV}"
+          echo "STARPU_PREFIX=/opt/starpu" >> "${GITHUB_ENV}"
+
+      - name: Configure macOS build paths
+        if: runner.os == 'macOS'
+        run: |
+          echo "NNTILE_BUILD_DIR=${RUNNER_TEMP}/nntile-build/torch_nntile_wheel" >> "${GITHUB_ENV}"
+          echo "STARPU_PREFIX=${RUNNER_TEMP}/starpu" >> "${GITHUB_ENV}"
 
       - name: Install cibuildwheel
         run: |

--- a/.github/workflows/torch-nntile-wheels.yml
+++ b/.github/workflows/torch-nntile-wheels.yml
@@ -1,6 +1,10 @@
 name: torch_nntile wheels
 
 on:
+  pull_request:
+    types: [closed]
+    branches:
+      - graph_api
   workflow_dispatch:
 
 permissions:
@@ -23,6 +27,7 @@ env:
 
 jobs:
   build-wheels:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     name: ${{ matrix.identifier }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180
@@ -41,6 +46,7 @@ jobs:
         if: ${{ env.ACT != 'true' }}
         with:
           persist-credentials: false
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref }}
 
       - name: Configure host paths
         run: |

--- a/.github/workflows/torch-nntile-wheels.yml
+++ b/.github/workflows/torch-nntile-wheels.yml
@@ -1,9 +1,6 @@
 name: torch_nntile wheels
 
 on:
-  push:
-    branches:
-      - graph_api
   workflow_dispatch:
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,3 +74,4 @@ Uses ruff, isort, and standard pre-commit hooks. Configuration is in
 - **Agent checklist (actionable):** [docs/dev/graph_static_execution_agentic_plan.md](docs/dev/graph_static_execution_agentic_plan.md)
 - **Roadmap:** [docs/dev/graph_static_execution_plan.md](docs/dev/graph_static_execution_plan.md)
 - **Per-task steps:** [docs/dev/graph_static_execution_agentic_plan.md](docs/dev/graph_static_execution_agentic_plan.md)
+- **`torch_nntile` wheels:** built by the `torch_nntile wheels` workflow on merge into `graph_api` or `workflow_dispatch`; see [torch_nntile/README.md](torch_nntile/README.md#prebuilt-wheels-001)

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ and end-to-end training examples.
 | SGOC scheduler (limited VRAM, single GPU) | [sgoc/README.md](sgoc/README.md) |
 | NNTile Graph API (work in progress) | [graph-wip.md](graph-wip.md) |
 | PyTorch `device="nntile"` (torch_nntile) | [torch_nntile.md](torch_nntile.md) |
+| Install prebuilt `torch_nntile` wheel (CI) | [torch_nntile.md#prebuilt-wheels](torch_nntile.md#prebuilt-wheels) |
 
 ## Documentation map
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ and end-to-end training examples.
 ```
 docs/
   README.md                 ← you are here
-  build/README.md           Build, CMake, Docker, testing
+  build/README.md           Build, CMake, Docker, testing, torch_nntile wheel CI
   cpp/README.md             C++ kernel / starpu / tile / tensor
   graph-wip.md              NNTile Graph API status
   torch_nntile.md           PyTorch device="nntile", axis-group tiling

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -169,6 +169,61 @@ Graph API usage and architecture are **not** documented here; see
 - Examples copied to `build/wrappers/python/examples/`
 - No `make install` required for development — set `PYTHONPATH` to the build tree
 
+## torch_nntile wheels (CI)
+
+Prebuilt `torch_nntile` wheels are built by the **`torch_nntile wheels`**
+workflow ([`.github/workflows/torch-nntile-wheels.yml`](../../.github/workflows/torch-nntile-wheels.yml)).
+
+| | |
+|-|-|
+| **Trigger** | Push to `graph_api`, or `workflow_dispatch` |
+| **Not triggered by** | Open PRs on feature branches |
+| **Tooling** | [cibuildwheel](https://cibuildwheel.pypa.io/) 4.1.0 |
+| **Version** | `0.0.1` (`TORCH_NNTILE_WHEEL_VERSION`) |
+
+### Matrix
+
+| Job | Runner | Wheel tag | CUDA |
+|-----|--------|-----------|------|
+| `cp312-manylinux_x86_64` | `ubuntu-24.04` | manylinux x86_64 | Yes (`torch==2.9.1+cu128`) |
+| `cp312-macosx_arm64` | `macos-14` | macOS 14+ arm64 | No (CPU StarPU only) |
+
+Each job uploads one artifact:
+
+- `torch-nntile-wheel-cp312-manylinux_x86_64`
+- `torch-nntile-wheel-cp312-macosx_arm64`
+
+There is no merge job that bundles both platforms into a single artifact.
+
+### Build pipeline
+
+Linux builds run inside a manylinux container with the repo mounted read-only.
+Scripts under [`torch_nntile/tools/`](../../torch_nntile/tools/):
+
+| Script | Role |
+|--------|------|
+| `build_wheel_deps.sh` | StarPU (nntile fork), FXT, libnntile; Linux CUDA / macOS CPU split |
+| `setup_torch_cuda_env.sh` | Linux: `torch==2.9.1+cu128` + `nvidia-cuda-nvcc-cu12`, export `CUDA_HOME` |
+| `repair_wheel_linux.sh` | `auditwheel repair`; bundle `libstarpu` + `libnntile`; exclude NVIDIA driver libs |
+| `repair_wheel_macos.sh` | `delocate-wheel`; macOS 14+ arm64 |
+| `smoke_test_wheel.py` | cibuildwheel `test-command` |
+
+PyTorch itself is **not** bundled; wheels declare `torch==2.9.1` as a runtime
+dependency. Linux users install `torch==2.9.1+cu128` from the PyTorch CUDA index
+before installing the wheel.
+
+### Download and publish
+
+```bash
+gh run list --workflow=torch-nntile-wheels.yml --branch graph_api --limit 5
+gh run download RUN_ID -D wheelhouse
+```
+
+End-user install instructions:
+[`torch_nntile/README.md`](../../torch_nntile/README.md#prebuilt-wheels-001).
+
+PyPI upload is manual (`twine upload` from downloaded artifacts).
+
 ## Running tests
 
 Requires `BUILD_TESTS=ON` (default) and a finished build. Tests are skipped when
@@ -294,5 +349,6 @@ pytest -vv --cov=wrappers/python/nntile wrappers/python/tests
 ## See also
 
 - [cpp/README.md](../cpp/README.md) — C++ layers under test
+- [torch_nntile.md](../torch_nntile.md) — PyTorch `device="nntile"` bridge
 - [sgoc/README.md](../sgoc/README.md) — SGOC built in Docker sandbox
 - [STYLE_GUIDE.md](../../STYLE_GUIDE.md) — C++ coding style

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -176,8 +176,8 @@ workflow ([`.github/workflows/torch-nntile-wheels.yml`](../../.github/workflows/
 
 | | |
 |-|-|
-| **Trigger** | Push to `graph_api`, or `workflow_dispatch` |
-| **Not triggered by** | Open PRs on feature branches |
+| **Trigger** | `workflow_dispatch` only (manual **Run workflow**) |
+| **Not triggered by** | Push, pull requests, or schedule |
 | **Tooling** | [cibuildwheel](https://cibuildwheel.pypa.io/) 4.1.0 |
 | **Version** | `0.0.1` (`TORCH_NNTILE_WHEEL_VERSION`) |
 
@@ -215,7 +215,7 @@ before installing the wheel.
 ### Download and publish
 
 ```bash
-gh run list --workflow=torch-nntile-wheels.yml --branch graph_api --limit 5
+gh run list --workflow=torch-nntile-wheels.yml --limit 5
 gh run download RUN_ID -D wheelhouse
 ```
 

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -177,9 +177,35 @@ workflow ([`.github/workflows/torch-nntile-wheels.yml`](../../.github/workflows/
 | | |
 |-|-|
 | **Trigger** | `pull_request` closed (merged into `graph_api`), or `workflow_dispatch` |
-| **Skipped when** | PR closed without merge |
+| **Skipped when** | PR closed without merge; open PR pushes |
+| **Job guard** | `merged == true` or `workflow_dispatch` |
 | **Tooling** | [cibuildwheel](https://cibuildwheel.pypa.io/) 4.1.0 |
 | **Version** | `0.0.1` (`TORCH_NNTILE_WHEEL_VERSION`) |
+
+Workflow definition:
+
+```yaml
+on:
+  pull_request:
+    types: [closed]
+    branches: [graph_api]
+  workflow_dispatch:
+
+jobs:
+  build-wheels:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+```
+
+### Triggering
+
+| Goal | Action |
+|------|--------|
+| Build after landing changes | Merge PR into `graph_api` (automatic) |
+| Rebuild without a merge | `gh workflow run torch-nntile-wheels.yml --ref graph_api` |
+| Download artifacts | `gh run download RUN_ID -D wheelhouse` |
+
+The Actions **Run workflow** button requires the workflow file on the repository
+default branch ([`workflow_dispatch` docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)). On merge, checkout uses `pull_request.base.ref` (`graph_api`).
 
 ### Matrix
 
@@ -217,6 +243,7 @@ before installing the wheel.
 ```bash
 gh run list --workflow=torch-nntile-wheels.yml --limit 5
 gh run download RUN_ID -D wheelhouse
+gh workflow run torch-nntile-wheels.yml --ref graph_api   # manual rebuild
 ```
 
 End-user install instructions:

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -176,8 +176,8 @@ workflow ([`.github/workflows/torch-nntile-wheels.yml`](../../.github/workflows/
 
 | | |
 |-|-|
-| **Trigger** | `workflow_dispatch` only (manual **Run workflow**) |
-| **Not triggered by** | Push, pull requests, or schedule |
+| **Trigger** | `pull_request` closed (merged into `graph_api`), or `workflow_dispatch` |
+| **Skipped when** | PR closed without merge |
 | **Tooling** | [cibuildwheel](https://cibuildwheel.pypa.io/) 4.1.0 |
 | **Version** | `0.0.1` (`TORCH_NNTILE_WHEEL_VERSION`) |
 

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -9,8 +9,8 @@ Package README: [`torch_nntile/README.md`](../torch_nntile/README.md).
 ## Prebuilt wheels
 
 CI builds `torch_nntile` 0.0.1 wheels via the **`torch_nntile wheels`** workflow
-(`.github/workflows/torch-nntile-wheels.yml`). It runs **only on manual
-workflow dispatch** — not on push or open PRs.
+(`.github/workflows/torch-nntile-wheels.yml`). It runs when a PR into
+`graph_api` is **merged**, or on manual `workflow_dispatch`.
 
 Each platform is a **separate** artifact (no combined bundle):
 

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -9,8 +9,15 @@ Package README: [`torch_nntile/README.md`](../torch_nntile/README.md).
 ## Prebuilt wheels
 
 CI builds `torch_nntile` 0.0.1 wheels via the **`torch_nntile wheels`** workflow
-(`.github/workflows/torch-nntile-wheels.yml`). It runs when a PR into
-`graph_api` is **merged**, or on manual `workflow_dispatch`.
+(`.github/workflows/torch-nntile-wheels.yml`).
+
+| Trigger | When wheels build |
+|---------|-------------------|
+| **Merge into `graph_api`** | Automatic on `pull_request` closed + merged |
+| **`workflow_dispatch`** | Maintainer runs manually (Actions UI or `gh workflow run`) |
+
+Open PRs do not produce wheels until merged. PRs closed without merging are
+skipped.
 
 Each platform is a **separate** artifact (no combined bundle):
 
@@ -25,6 +32,12 @@ Artifacts, or:
 ```bash
 gh run list --workflow=torch-nntile-wheels.yml --limit 5
 gh run download RUN_ID -D wheelhouse
+```
+
+Manual dispatch (write access required):
+
+```bash
+gh workflow run torch-nntile-wheels.yml --ref graph_api
 ```
 
 Install the matching `torch` first, then the local wheel (see

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -9,8 +9,8 @@ Package README: [`torch_nntile/README.md`](../torch_nntile/README.md).
 ## Prebuilt wheels
 
 CI builds `torch_nntile` 0.0.1 wheels via the **`torch_nntile wheels`** workflow
-(`.github/workflows/torch-nntile-wheels.yml`). It runs on **push to `graph_api`**
-and manual dispatch — not on open PR branches.
+(`.github/workflows/torch-nntile-wheels.yml`). It runs **only on manual
+workflow dispatch** — not on push or open PRs.
 
 Each platform is a **separate** artifact (no combined bundle):
 
@@ -23,7 +23,7 @@ Wheels are **not on PyPI**. Download from Actions → **torch_nntile wheels** �
 Artifacts, or:
 
 ```bash
-gh run list --workflow=torch-nntile-wheels.yml --branch graph_api --limit 5
+gh run list --workflow=torch-nntile-wheels.yml --limit 5
 gh run download RUN_ID -D wheelhouse
 ```
 

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -6,11 +6,38 @@ against `libnntile`, selected ops record into a shared `TensorGraph`, lower to
 
 Package README: [`torch_nntile/README.md`](../torch_nntile/README.md).
 
-## Install
+## Prebuilt wheels
 
-Build NNTile first (see [build/README.md](build/README.md)), then:
+CI builds `torch_nntile` 0.0.1 wheels via the **`torch_nntile wheels`** workflow
+(`.github/workflows/torch-nntile-wheels.yml`). It runs on **push to `graph_api`**
+and manual dispatch — not on open PR branches.
+
+Each platform is a **separate** artifact (no combined bundle):
+
+| Platform | Artifact |
+|----------|----------|
+| Linux CUDA x86_64, Python 3.12 | `torch-nntile-wheel-cp312-manylinux_x86_64` |
+| macOS arm64 CPU, Python 3.12 | `torch-nntile-wheel-cp312-macosx_arm64` |
+
+Wheels are **not on PyPI**. Download from Actions → **torch_nntile wheels** →
+Artifacts, or:
 
 ```bash
+gh run list --workflow=torch-nntile-wheels.yml --branch graph_api --limit 5
+gh run download RUN_ID -D wheelhouse
+```
+
+Install the matching `torch` first, then the local wheel (see
+[`torch_nntile/README.md`](../torch_nntile/README.md#prebuilt-wheels-001) for
+full commands). Maintainer CI notes: [build/README.md](build/README.md#torch_nntile-wheels-ci).
+
+## Install from source
+
+Build NNTile first (see [build/README.md](build/README.md)), then install a
+matching `torch` and the editable extension:
+
+```bash
+pip install 'torch==2.9.1'
 export NNTILE_BUILD_DIR=$PWD/build
 export NNTILE_SOURCE_DIR=$PWD
 export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -13,12 +13,12 @@ Wheels are built in CI, not published to PyPI. Install from a downloaded
 |-|-|
 | **Workflow** (Actions sidebar / run title) | `torch_nntile wheels` |
 | **Workflow file** | `.github/workflows/torch-nntile-wheels.yml` |
-| **Trigger** | Manual **Run workflow** only (`workflow_dispatch`) |
+| **Trigger** | `pull_request` closed (merged into `graph_api`), or manual **Run workflow** |
 | **Python** | 3.12 (`cp312`) |
 
-Open **Actions → torch_nntile wheels → Run workflow**, choose the branch (usually
-`graph_api`), and start the run. The workflow does **not** run automatically on
-push or on PRs.
+Wheels build automatically when a PR into `graph_api` is **merged**, or when a
+maintainer starts the workflow manually (`workflow_dispatch`). Closed PRs that
+were not merged are skipped.
 
 Each matrix job uploads a **separate** artifact — there is no single bundle
 with all platforms:

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -13,12 +13,12 @@ Wheels are built in CI, not published to PyPI. Install from a downloaded
 |-|-|
 | **Workflow** (Actions sidebar / run title) | `torch_nntile wheels` |
 | **Workflow file** | `.github/workflows/torch-nntile-wheels.yml` |
-| **Trigger** | Push to `graph_api`, or manual **Run workflow** |
+| **Trigger** | Manual **Run workflow** only (`workflow_dispatch`) |
 | **Python** | 3.12 (`cp312`) |
 
-The workflow does **not** run on open PR branches. Wheels appear after changes
-land on `graph_api` (merge or direct push), unless someone triggers the workflow
-manually.
+Open **Actions → torch_nntile wheels → Run workflow**, choose the branch (usually
+`graph_api`), and start the run. The workflow does **not** run automatically on
+push or on PRs.
 
 Each matrix job uploads a **separate** artifact — there is no single bundle
 with all platforms:
@@ -34,7 +34,7 @@ with all platforms:
 **Download (`gh` CLI):**
 
 ```bash
-gh run list --workflow=torch-nntile-wheels.yml --branch graph_api --limit 5
+gh run list --workflow=torch-nntile-wheels.yml --limit 5
 gh run download RUN_ID -D wheelhouse
 # → wheelhouse/torch-nntile-wheel-cp312-manylinux_x86_64/*.whl
 # → wheelhouse/torch-nntile-wheel-cp312-macosx_arm64/*.whl

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -2,6 +2,34 @@
 
 PyTorch **PrivateUse1** device registered as `device="nntile"`.
 
+## Prebuilt wheels (0.0.1)
+
+CI builds platform-specific wheels on push to the `graph_api` branch. Download
+artifacts from the GitHub Actions workflow run.
+
+### Linux (CUDA, torch 2.9.1+cu128)
+
+CUDA comes from the PyTorch wheel — install torch first, then `torch_nntile`:
+
+```bash
+pip install torch==2.9.1+cu128 --index-url https://download.pytorch.org/whl/cu128
+pip install torch_nntile==0.0.1
+```
+
+The wheel bundles `libstarpu` and `libnntile`. A compatible NVIDIA driver is
+required at runtime for CUDA StarPU workers (`ncuda > 0`).
+
+### macOS arm64 (CPU-only, torch 2.9.1)
+
+```bash
+pip install torch==2.9.1
+pip install torch_nntile==0.0.1
+```
+
+StarPU runs on CPU workers only (`ncuda=0`). macOS 14.0+ (arm64).
+
+Publishing to PyPI is manual: download CI artifacts and run `twine upload` locally.
+
 ## Phase 1 (stub)
 
 Tensor storage is backed by a host `std::vector<uint8_t>` buffer. Supports
@@ -245,13 +273,12 @@ the MNIST example (or call ``restrict_cuda()``) and shut StarPU down at exit.
 The example calls ``torch_nntile.wait()`` and ``torch_nntile.shutdown_context()``
 in a ``finally`` block; ``init_context()`` also registers an ``atexit`` hook.
 
-## macOS / PyTorch 2.12
+## macOS / PyTorch cpu_fallback ABI
 
-PyTorch 2.12 exports `at::native::cpu_fallback` with four arguments
+PyTorch 2.12+ exports `at::native::cpu_fallback` with four arguments
 (`OperatorHandle`, `Stack*`, `bool error_on_views`, `c10::DispatchKey`).
-Calling it with fewer arguments can leave an unresolved reference to a
-three-argument symbol at load time on macOS. The extension calls the
-four-argument overload explicitly.
+Older releases use a two-argument overload. The extension selects the
+appropriate overload at compile time via `TORCH_VERSION_*`.
 
 After upgrading PyTorch, rebuild:
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -9,7 +9,9 @@ artifacts from the GitHub Actions workflow run.
 
 ### Linux (CUDA, torch 2.9.1+cu128)
 
-CUDA comes from the PyTorch wheel — install torch first, then `torch_nntile`:
+CUDA wheels are built against `torch==2.9.1+cu128`. Install that torch build
+first (the `+cu128` tag is only on the PyTorch CUDA index, not PyPI), then
+`torch_nntile`:
 
 ```bash
 pip install torch==2.9.1+cu128 --index-url https://download.pytorch.org/whl/cu128

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -18,7 +18,24 @@ Wheels are built in CI, not published to PyPI. Install from a downloaded
 
 Wheels build automatically when a PR into `graph_api` is **merged**, or when a
 maintainer starts the workflow manually (`workflow_dispatch`). Closed PRs that
-were not merged are skipped.
+were not merged are skipped. Open PRs do **not** build wheels until merge.
+
+### Triggering a build
+
+**Automatic:** merge a PR into `graph_api`. GitHub fires `pull_request` with
+`types: [closed]`; the job runs only when `pull_request.merged` is true.
+
+**Manual:** from a machine with write access to the repo:
+
+```bash
+gh workflow run torch-nntile-wheels.yml --ref graph_api
+gh run watch
+```
+
+In the GitHub UI, **Run workflow** appears only when the workflow file with
+`workflow_dispatch` exists on the repository **default branch** (see
+[GitHub docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)).
+Use `gh workflow run` if the button is missing.
 
 Each matrix job uploads a **separate** artifact — there is no single bundle
 with all platforms:

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -4,18 +4,51 @@ PyTorch **PrivateUse1** device registered as `device="nntile"`.
 
 ## Prebuilt wheels (0.0.1)
 
-CI builds platform-specific wheels on push to the `graph_api` branch. Download
-artifacts from the GitHub Actions workflow run.
+Wheels are built in CI, not published to PyPI. Install from a downloaded
+`.whl` file after installing the matching `torch` build.
+
+### CI workflow
+
+| | |
+|-|-|
+| **Workflow** (Actions sidebar / run title) | `torch_nntile wheels` |
+| **Workflow file** | `.github/workflows/torch-nntile-wheels.yml` |
+| **Trigger** | Push to `graph_api`, or manual **Run workflow** |
+| **Python** | 3.12 (`cp312`) |
+
+The workflow does **not** run on open PR branches. Wheels appear after changes
+land on `graph_api` (merge or direct push), unless someone triggers the workflow
+manually.
+
+Each matrix job uploads a **separate** artifact — there is no single bundle
+with all platforms:
+
+| Job | Artifact name |
+|-----|---------------|
+| Linux CUDA x86_64 | `torch-nntile-wheel-cp312-manylinux_x86_64` |
+| macOS arm64 CPU | `torch-nntile-wheel-cp312-macosx_arm64` |
+
+**Download (GitHub UI):** Actions → **torch_nntile wheels** → pick a run →
+**Artifacts** at the bottom of the run page.
+
+**Download (`gh` CLI):**
+
+```bash
+gh run list --workflow=torch-nntile-wheels.yml --branch graph_api --limit 5
+gh run download RUN_ID -D wheelhouse
+# → wheelhouse/torch-nntile-wheel-cp312-manylinux_x86_64/*.whl
+# → wheelhouse/torch-nntile-wheel-cp312-macosx_arm64/*.whl
+```
 
 ### Linux (CUDA, torch 2.9.1+cu128)
 
 CUDA wheels are built against `torch==2.9.1+cu128`. Install that torch build
-first (the `+cu128` tag is only on the PyTorch CUDA index, not PyPI), then
-`torch_nntile`:
+first (the `+cu128` tag is only on the PyTorch CUDA index, not PyPI), then the
+wheel:
 
 ```bash
 pip install torch==2.9.1+cu128 --index-url https://download.pytorch.org/whl/cu128
-pip install torch_nntile==0.0.1
+pip install /path/to/torch_nntile-0.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
 ```
 
 The wheel bundles `libstarpu` and `libnntile`. A compatible NVIDIA driver is
@@ -25,12 +58,13 @@ required at runtime for CUDA StarPU workers (`ncuda > 0`).
 
 ```bash
 pip install torch==2.9.1
-pip install torch_nntile==0.0.1
+pip install /path/to/torch_nntile-0.0.1-cp312-cp312-macosx_14_0_arm64.whl
 ```
 
 StarPU runs on CPU workers only (`ncuda=0`). macOS 14.0+ (arm64).
 
 Publishing to PyPI is manual: download CI artifacts and run `twine upload` locally.
+See [docs/build/README.md](../docs/build/README.md) for maintainer CI details.
 
 ## Phase 1 (stub)
 
@@ -207,13 +241,16 @@ Cross-entropy parity (forward, backward, multi-D labels, `ignore_index`):
 pytest -vv torch_nntile/tests/test_cross_entropy_parity.py
 ```
 
-## Install (stub only)
+## Install from source (stub only)
+
+Install `torch==2.9.1` first (same ABI as `install_requires`), then:
 
 ```bash
+pip install 'torch==2.9.1'
 CXX=g++ pip install -e ./torch_nntile --no-build-isolation
 ```
 
-## Install (with libnntile / phase 2)
+## Install from source (with libnntile / phase 2)
 
 Build NNTile first (CPU-only example):
 
@@ -226,9 +263,11 @@ cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_CUDA=OFF \
 cmake --build build -j$(nproc)
 ```
 
-Then install the extension against that build:
+Then install the extension against that build (use the same `torch` version you
+built NNTile against):
 
 ```bash
+pip install 'torch==2.9.1'
 export NNTILE_BUILD_DIR=$PWD/build
 export NNTILE_SOURCE_DIR=$PWD
 export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
@@ -282,9 +321,10 @@ PyTorch 2.12+ exports `at::native::cpu_fallback` with four arguments
 Older releases use a two-argument overload. The extension selects the
 appropriate overload at compile time via `TORCH_VERSION_*`.
 
-After upgrading PyTorch, rebuild:
+After upgrading PyTorch, reinstall the matching torch pin and rebuild:
 
 ```bash
+pip install 'torch==2.9.1'
 CXX=clang++ pip install -e ./torch_nntile --no-build-isolation --force-reinstall
 ```
 

--- a/torch_nntile/csrc/nntile_kernels.cpp
+++ b/torch_nntile/csrc/nntile_kernels.cpp
@@ -16,6 +16,7 @@
 #include <c10/core/DeviceGuard.h>
 #include <c10/core/ScalarType.h>
 #include <torch/library.h>
+#include <torch/version.h>
 
 #include <cstring>
 #include <optional>
@@ -400,11 +401,16 @@ void cpu_fallback(const c10::OperatorHandle &op, torch::jit::Stack *stack)
                    "torch_nntile.init_context)";
         TORCH_CHECK(false, message.str());
     }
+#if (TORCH_VERSION_MAJOR > 2) \
+    || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR >= 12)
     at::native::cpu_fallback(
         op,
         stack,
         /*error_on_views=*/false,
         c10::DispatchKey::CPU);
+#else
+    at::native::cpu_fallback(op, stack);
+#endif
 }
 
 } // namespace torch_nntile

--- a/torch_nntile/pyproject.toml
+++ b/torch_nntile/pyproject.toml
@@ -4,12 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torch_nntile"
-version = "0.7.1"
+version = "0.0.1"
 description = "PyTorch PrivateUse1 device for nntile (TensorGraph ops via libnntile)"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "torch>=2.1",
+    "torch==2.9.1+cu128; platform_system == 'Linux'",
+    "torch==2.9.1; platform_system == 'Darwin'",
 ]
 
 [project.optional-dependencies]
@@ -29,7 +30,7 @@ where = ["."]
 include = ["torch_nntile*"]
 
 [tool.cibuildwheel]
-build = "cp314-*"
+build = "cp312-*"
 skip = "*-musllinux* *-win*"
 build-frontend = "pip; args: --no-build-isolation"
 before-all = "bash {package}/tools/build_wheel_deps.sh \"$NNTILE_SOURCE_DIR\""
@@ -59,24 +60,20 @@ OMP_NUM_THREADS = "1"
 [tool.cibuildwheel.linux]
 archs = ["x86_64"]
 manylinux-x86_64-image = "manylinux_2_28"
-before-build = [
-    "python -m pip install --upgrade pip",
-    "python -m pip install 'setuptools>=61,<82' wheel ninja",
-    "python -m pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torch==2.12.0+cpu'",
-]
-before-test = "python -m pip install --extra-index-url https://download.pytorch.org/whl/cpu 'torch==2.12.0+cpu'"
+before-test = "python -m pip install --index-url https://download.pytorch.org/whl/cu128 'torch==2.9.1+cu128'"
 repair-wheel-command = "bash {package}/tools/repair_wheel_linux.sh {wheel} {dest_dir}"
 
 [tool.cibuildwheel.macos]
 archs = ["arm64"]
-before-build = [
-    "python -m pip install --upgrade pip",
-    "python -m pip install 'setuptools>=61,<82' wheel ninja 'torch==2.12.0'",
-]
-before-test = "python -m pip install 'torch==2.12.0'"
+before-test = "python -m pip install 'torch==2.9.1'"
 repair-wheel-command = "bash {package}/tools/repair_wheel_macos.sh {wheel} {dest_dir} {delocate_archs}"
+
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux_*"
+inherit.environment = "append"
+environment.TORCH_NNTILE_USE_CUDA = "1"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
 inherit.environment = "append"
-environment = { MACOSX_DEPLOYMENT_TARGET = "14.0" }
+environment = { MACOSX_DEPLOYMENT_TARGET = "14.0", TORCH_NNTILE_USE_CUDA = "0" }

--- a/torch_nntile/pyproject.toml
+++ b/torch_nntile/pyproject.toml
@@ -9,8 +9,7 @@ description = "PyTorch PrivateUse1 device for nntile (TensorGraph ops via libnnt
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "torch==2.9.1+cu128; platform_system == 'Linux'",
-    "torch==2.9.1; platform_system == 'Darwin'",
+    "torch==2.9.1",
 ]
 
 [project.optional-dependencies]

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -159,9 +159,15 @@ def _nntile_extension_kwargs() -> dict:
 
 ext_kwargs = _nntile_extension_kwargs()
 
+_wheel_version = os.environ.get("TORCH_NNTILE_WHEEL_VERSION", "0.0.1")
+if sys.platform == "darwin":
+    _torch_requires = "torch==2.9.1"
+else:
+    _torch_requires = "torch==2.9.1+cu128"
+
 setup(
     name="torch_nntile",
-    version="0.7.1",
+    version=_wheel_version,
     packages=find_packages(),
     ext_modules=[
         CppExtension(
@@ -171,5 +177,5 @@ setup(
         )
     ],
     cmdclass={"build_ext": BuildExtension.with_options(no_python_abi_suffix=True)},
-    install_requires=["torch>=2.1"],
+    install_requires=[_torch_requires],
 )

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -160,10 +160,7 @@ def _nntile_extension_kwargs() -> dict:
 ext_kwargs = _nntile_extension_kwargs()
 
 _wheel_version = os.environ.get("TORCH_NNTILE_WHEEL_VERSION", "0.0.1")
-if sys.platform == "darwin":
-    _torch_requires = "torch==2.9.1"
-else:
-    _torch_requires = "torch==2.9.1+cu128"
+_torch_requires = "torch==2.9.1"
 
 setup(
     name="torch_nntile",

--- a/torch_nntile/tools/build_wheel_deps.sh
+++ b/torch_nntile/tools/build_wheel_deps.sh
@@ -11,26 +11,33 @@ if [ ! -f "${repo_root}/CMakeLists.txt" ] || [ ! -d "${repo_root}/nntile" ]; the
     exit 1
 fi
 
-starpu_version="${STARPU_VERSION:-starpu-1.4.8}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 starpu_prefix="${STARPU_PREFIX:-/opt/starpu}"
 build_dir="${NNTILE_BUILD_DIR:-${repo_root}/build/torch_nntile_wheel}"
 jobs="${CMAKE_BUILD_PARALLEL_LEVEL:-2}"
 os_name="$(uname -s)"
+use_cuda="${TORCH_NNTILE_USE_CUDA:-0}"
+starpu_github_repo="${STARPU_GITHUB_REPO:-nntile/starpu}"
+starpu_git_branch="${STARPU_GIT_BRANCH:-master}"
 
 install_linux_packages() {
     if command -v dnf >/dev/null 2>&1; then
         dnf install -y \
             autoconf automake bzip2 cmake curl gcc gcc-c++ git hwloc-devel \
-            libtool make ninja-build openblas-devel pkgconf-pkg-config
+            libtool make ninja-build openblas-devel pkgconf-pkg-config unzip wget
     elif command -v yum >/dev/null 2>&1; then
         yum install -y \
             autoconf automake bzip2 cmake curl gcc gcc-c++ git hwloc-devel \
-            libtool make ninja-build openblas-devel pkgconf-pkg-config
+            libtool make ninja-build openblas-devel pkgconf-pkg-config unzip wget
     elif command -v apt-get >/dev/null 2>&1; then
         apt-get update
         apt-get install -y --no-install-recommends \
             autoconf automake build-essential ca-certificates cmake curl git \
-            libhwloc-dev libopenblas-dev libtool-bin ninja-build pkg-config
+            libhwloc-dev libopenblas-dev libtool-bin ninja-build pkg-config \
+            unzip wget
+        if [ "${use_cuda}" = "1" ]; then
+            apt-get install -y --no-install-recommends libfxt-dev
+        fi
     else
         echo "Unsupported Linux image: no yum or apt-get found" >&2
         exit 1
@@ -42,7 +49,7 @@ install_macos_packages() {
         echo "Homebrew is required for macOS wheel dependency setup" >&2
         exit 1
     fi
-    for package in autoconf automake cmake hwloc libtool ninja pkg-config; do
+    for package in autoconf automake cmake hwloc libtool ninja pkg-config wget; do
         if ! brew list --versions "${package}" >/dev/null 2>&1; then
             brew install "${package}"
         fi
@@ -60,6 +67,13 @@ prepare_prefix() {
     fi
 }
 
+install_torch_cpu() {
+    python -m pip install --upgrade pip
+    python -m pip install "torch==${TORCH_VERSION:-2.9.1}"
+    export TORCH_PREFIX="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+    export CMAKE_PREFIX_PATH="${TORCH_PREFIX}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}"
+}
+
 build_starpu() {
     if PKG_CONFIG_PATH="${starpu_prefix}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}" \
         pkg-config --exists starpu-1.4; then
@@ -67,42 +81,56 @@ build_starpu() {
     fi
 
     prepare_prefix
-    tmp_dir="$(mktemp -d)"
-    trap 'rm -rf "${tmp_dir}"' EXIT
-    archive="${tmp_dir}/starpu.tar.gz"
+    tmp_parent="$(mktemp -d)"
+    trap 'rm -rf "${tmp_parent}"' EXIT
+
+    archive="${tmp_parent}/starpu.zip"
     curl -SL \
-        "https://gitlab.inria.fr/starpu/starpu/-/archive/${starpu_version}/starpu-${starpu_version}.tar.gz" \
+        "https://github.com/${starpu_github_repo}/archive/refs/heads/${starpu_git_branch}.zip" \
         -o "${archive}"
-    tar -xzf "${archive}" -C "${tmp_dir}"
-    starpu_src="$(find "${tmp_dir}" -maxdepth 1 -type d -name 'starpu-*' -print -quit)"
+    unzip -q "${archive}" -d "${tmp_parent}"
+    starpu_src="$(find "${tmp_parent}" -maxdepth 1 -type d -name 'starpu-*' -print -quit)"
     if [ -z "${starpu_src}" ]; then
         echo "StarPU source directory was not found after extraction" >&2
         exit 1
     fi
 
+    configure_args=(
+        --disable-build-doc
+        --disable-build-examples
+        --disable-build-tests
+        --disable-fortran
+        --disable-mpi
+        --disable-opencl
+        --disable-socl
+        --disable-starpufft
+        --disable-starpupy
+        --enable-blas-lib=none
+        --enable-maxbuffers=16
+        --prefix="${starpu_prefix}"
+        --libdir="${starpu_prefix}/lib"
+    )
+
+    if [ "${use_cuda}" = "1" ]; then
+        configure_args+=(
+            --enable-maxcudadev=8
+            --with-fxt
+        )
+    else
+        configure_args+=(
+            --disable-cuda
+            --without-fxt
+        )
+    fi
+
     (
         cd "${starpu_src}"
         ./autogen.sh
-        ./configure \
-            --disable-build-doc \
-            --disable-build-examples \
-            --disable-build-tests \
-            --disable-cuda \
-            --disable-fortran \
-            --disable-mpi \
-            --disable-opencl \
-            --disable-socl \
-            --disable-starpufft \
-            --disable-starpupy \
-            --enable-blas-lib=none \
-            --enable-maxbuffers=16 \
-            --without-fxt \
-            --prefix="${starpu_prefix}" \
-            --libdir="${starpu_prefix}/lib"
+        ./configure "${configure_args[@]}"
         make -j "${jobs}" install
     )
 
-    rm -rf "${tmp_dir}"
+    rm -rf "${tmp_parent}"
     trap - EXIT
 }
 
@@ -115,18 +143,38 @@ build_nntile() {
         -S "${repo_root}"
         -B "${build_dir}"
         -DCMAKE_BUILD_TYPE=Release
-        -DUSE_CUDA=OFF
         -DBUILD_PYTHON_WRAPPERS=OFF
         -DBUILD_TESTS=OFF
         -DBUILD_EXAMPLES=OFF
         -GNinja
     )
+
+    if [ "${use_cuda}" = "1" ]; then
+        cmake_args+=(
+            -DUSE_CUDA=ON
+            -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}"
+        )
+        if [ -n "${CMAKE_CUDA_COMPILER:-}" ]; then
+            cmake_args+=(-DCMAKE_CUDA_COMPILER="${CMAKE_CUDA_COMPILER}")
+        elif [ -n "${CUDA_HOME:-}" ]; then
+            cmake_args+=(-DCMAKE_CUDA_COMPILER="${CUDA_HOME}/bin/nvcc")
+        fi
+        if [ -n "${CMAKE_CUDA_ARCHITECTURES:-}" ]; then
+            cmake_args+=(-DCMAKE_CUDA_ARCHITECTURES="${CMAKE_CUDA_ARCHITECTURES}")
+        fi
+    else
+        cmake_args+=(-DUSE_CUDA=OFF)
+    fi
+
     if [ "${os_name}" = "Darwin" ]; then
         export MACOSX_DEPLOYMENT_TARGET=14.0
         cmake_args+=(
             -DCMAKE_OSX_ARCHITECTURES=arm64
             -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0
         )
+        if [ -n "${TORCH_PREFIX:-}" ]; then
+            cmake_args+=(-DCMAKE_PREFIX_PATH="${TORCH_PREFIX}")
+        fi
     else
         cmake_args+=(
             -DCMAKE_C_COMPILER="${CC:-gcc}"
@@ -139,8 +187,18 @@ build_nntile() {
 }
 
 case "${os_name}" in
-    Linux) install_linux_packages ;;
-    Darwin) install_macos_packages ;;
+    Linux)
+        install_linux_packages
+        if [ "${use_cuda}" = "1" ]; then
+            # shellcheck disable=SC1091
+            source "${script_dir}/setup_torch_cuda_env.sh"
+            export CMAKE_CUDA_COMPILER="${CUDA_HOME}/bin/nvcc"
+        fi
+        ;;
+    Darwin)
+        install_macos_packages
+        install_torch_cpu
+        ;;
     *)
         echo "Unsupported platform for torch_nntile wheel deps: ${os_name}" >&2
         exit 1

--- a/torch_nntile/tools/repair_wheel_linux.sh
+++ b/torch_nntile/tools/repair_wheel_linux.sh
@@ -20,5 +20,9 @@ auditwheel repair \
     --exclude libtorch_cuda.so \
     --exclude libtorch_global_deps.so \
     --exclude libtorch_python.so \
+    --exclude libcuda.so \
+    --exclude libcuda.so.1 \
+    --exclude libnvidia-ml.so \
+    --exclude libnvidia-ml.so.1 \
     -w "${dest_dir}" \
     "${wheel}"

--- a/torch_nntile/tools/setup_torch_cuda_env.sh
+++ b/torch_nntile/tools/setup_torch_cuda_env.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Install torch 2.9.1+cu128 and export CUDA paths for libstarpu/libnntile builds.
+# Source this script; do not execute in a subshell.
+set -euo pipefail
+
+torch_version="${TORCH_VERSION:-2.9.1}"
+torch_cuda_tag="${TORCH_CUDA_TAG:-cu128}"
+torch_cuda_index="${TORCH_CUDA_INDEX:-https://download.pytorch.org/whl/cu128}"
+
+python -m pip install --upgrade pip
+python -m pip install \
+    "torch==${torch_version}+${torch_cuda_tag}" \
+    --index-url "${torch_cuda_index}"
+
+# nvcc is not bundled in the torch wheel.
+python -m pip install nvidia-cuda-nvcc-cu12 nvidia-cudnn-cu12
+
+export TORCH_PREFIX="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+export CUDA_HOME="$(python - <<'PY'
+from pathlib import Path
+import nvidia.cuda_nvcc
+print(Path(nvidia.cuda_nvcc.__file__).resolve().parent)
+PY
+)"
+export PATH="${CUDA_HOME}/bin:${PATH}"
+export CMAKE_PREFIX_PATH="${TORCH_PREFIX}:${CUDA_HOME}"
+export LD_LIBRARY_PATH="$(python -c 'import torch, os; print(os.path.join(os.path.dirname(torch.__file__), "lib"))')${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds CI wheel builds for `torch_nntile` 0.0.1 (CUDA Linux x86_64 + CPU macOS arm64) and supporting packaging/tooling.

## Wheel CI triggers

- **`pull_request` closed** — builds when a PR into `graph_api` is **merged**
- **`workflow_dispatch`** — manual run (`gh workflow run torch-nntile-wheels.yml --ref graph_api`)

## Docs

Wheel CI documented in `torch_nntile/README.md`, `docs/torch_nntile.md`, `docs/build/README.md`, `docs/README.md`, and `AGENTS.md`: triggers, artifacts, install from local `.whl`, `gh` commands, default-branch note for Run workflow UI.

## Changes

- `.github/workflows/torch-nntile-wheels.yml` — cp312 CUDA/macOS matrix, merge + dispatch triggers
- `torch_nntile/tools/` — CUDA env, wheel deps, auditwheel/delocate repair
- `.github/workflows/build-test.yml` — pin `torch==2.9.1` in torch_nntile jobs
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-addbbcc3-6df9-46a5-8171-b0ae9508a1b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-addbbcc3-6df9-46a5-8171-b0ae9508a1b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

