### PR TITLE
Implement ATen mul, mul_, and add_ for nntile device

### DIFF
--- a/torch_nntile/csrc/nntile_add.cpp
+++ b/torch_nntile/csrc/nntile_add.cpp
@@ -102,10 +102,30 @@ at::Tensor &add_out(
     return out;
 }
 
+at::Tensor &add_inplace_tensor(
+    at::Tensor &self,
+    const at::Tensor &other,
+    const at::Scalar &alpha)
+{
+    check_add_inputs(self, other);
+    const float other_scale = alpha.to<float>();
+    const float self_scale = 1.0f;
+    pin_graph_op_inputs({self, other});
+    pin_graph_op_output(self, true);
+    tensor_add_inplace_fp32(
+        other_scale,
+        other.data_ptr<float>(),
+        self_scale,
+        self.data_ptr<float>(),
+        self.sizes());
+    return self;
+}
+
 } // namespace torch_nntile
 
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
 {
     m.impl("add.Tensor", TORCH_FN(torch_nntile::add_tensor));
     m.impl("add.out", TORCH_FN(torch_nntile::add_out));
+    m.impl("add_.Tensor", TORCH_FN(torch_nntile::add_inplace_tensor));
 }

--- a/torch_nntile/csrc/nntile_executor.cpp
+++ b/torch_nntile/csrc/nntile_executor.cpp
@@ -14,6 +14,9 @@
 
 #include <nntile/base_types.hh>
 #include <nntile/tensor/ops/add.hh>
+#include <nntile/tensor/ops/add_inplace.hh>
+#include <nntile/tensor/ops/multiply.hh>
+#include <nntile/tensor/ops/multiply_inplace.hh>
 #include <nntile/tensor/ops/clear.hh>
 #include <nntile/tensor/ops/gemm.hh>
 #include <nntile/tensor/ops/logsumexp.hh>
@@ -77,6 +80,91 @@ void tensor_add_fp32(
         static_cast<nntile::Scalar>(beta),
         y_node)->set_name("z");
     register_data_node(out_data, z_node);
+    maybe_execute_after_record();
+}
+
+void tensor_add_inplace_fp32(
+    float alpha,
+    const float *other_data,
+    float beta,
+    float *self_data,
+    c10::IntArrayRef pytorch_shape)
+{
+    const std::vector<nntile::Index> graph_shape =
+        pytorch_shape_to_graph(pytorch_shape);
+
+    auto *other_node = get_or_create_data_node(
+        const_cast<float *>(other_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+    auto *self_node = get_or_create_data_node(
+        self_data,
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+
+    nntile::tensor::add_inplace(
+        static_cast<nntile::Scalar>(alpha),
+        other_node,
+        static_cast<nntile::Scalar>(beta),
+        self_node);
+    register_data_node(self_data, self_node);
+    maybe_execute_after_record();
+}
+
+void tensor_mul_fp32(
+    const float *self_data,
+    const float *other_data,
+    float *out_data,
+    c10::IntArrayRef pytorch_shape)
+{
+    const std::vector<nntile::Index> graph_shape =
+        pytorch_shape_to_graph(pytorch_shape);
+
+    auto *self_node = get_or_create_data_node(
+        const_cast<float *>(self_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+    auto *other_node = get_or_create_data_node(
+        const_cast<float *>(other_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+
+    auto *out_node = nntile::tensor::multiply(
+        self_node,
+        other_node,
+        static_cast<nntile::Scalar>(1.0))->set_name("z");
+    register_data_node(out_data, out_node);
+    maybe_execute_after_record();
+}
+
+void tensor_mul_inplace_fp32(
+    const float *other_data,
+    float *self_data,
+    c10::IntArrayRef pytorch_shape)
+{
+    const std::vector<nntile::Index> graph_shape =
+        pytorch_shape_to_graph(pytorch_shape);
+
+    auto *other_node = get_or_create_data_node(
+        const_cast<float *>(other_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+    auto *self_node = get_or_create_data_node(
+        self_data,
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+
+    nntile::tensor::multiply_inplace(
+        static_cast<nntile::Scalar>(1.0),
+        other_node,
+        self_node);
+    register_data_node(self_data, self_node);
     maybe_execute_after_record();
 }
 
@@ -593,6 +681,33 @@ void tensor_add_fp32(
     c10::IntArrayRef /*pytorch_shape*/)
 {
     require_libnntile("add");
+}
+
+void tensor_add_inplace_fp32(
+    float /*alpha*/,
+    const float * /*other_data*/,
+    float /*beta*/,
+    float * /*self_data*/,
+    c10::IntArrayRef /*pytorch_shape*/)
+{
+    require_libnntile("add_");
+}
+
+void tensor_mul_fp32(
+    const float * /*self_data*/,
+    const float * /*other_data*/,
+    float * /*out_data*/,
+    c10::IntArrayRef /*pytorch_shape*/)
+{
+    require_libnntile("mul");
+}
+
+void tensor_mul_inplace_fp32(
+    const float * /*other_data*/,
+    float * /*self_data*/,
+    c10::IntArrayRef /*pytorch_shape*/)
+{
+    require_libnntile("mul_");
 }
 
 void tensor_linear_fp32(

--- a/torch_nntile/csrc/nntile_executor.h
+++ b/torch_nntile/csrc/nntile_executor.h
@@ -19,6 +19,24 @@ void tensor_add_fp32(
     float *out_data,
     c10::IntArrayRef pytorch_shape);
 
+void tensor_add_inplace_fp32(
+    float alpha,
+    const float *other_data,
+    float beta,
+    float *self_data,
+    c10::IntArrayRef pytorch_shape);
+
+void tensor_mul_fp32(
+    const float *self_data,
+    const float *other_data,
+    float *out_data,
+    c10::IntArrayRef pytorch_shape);
+
+void tensor_mul_inplace_fp32(
+    const float *other_data,
+    float *self_data,
+    c10::IntArrayRef pytorch_shape);
+
 void tensor_linear_fp32(
     const float *input_data,
     c10::IntArrayRef input_shape,

--- a/torch_nntile/csrc/nntile_mul.cpp
+++ b/torch_nntile/csrc/nntile_mul.cpp
@@ -1,0 +1,119 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_mul.cpp
+ */
+
+#include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
+
+#include <ATen/Functions.h>
+#include <ATen/TensorUtils.h>
+#include <torch/library.h>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+bool is_nntile_device(c10::Device device)
+{
+    return device.type() == c10::DeviceType::PrivateUse1;
+}
+
+void check_mul_inputs(
+    const at::Tensor &self,
+    const at::Tensor &other,
+    const std::optional<at::Tensor> &out = std::nullopt)
+{
+    TORCH_CHECK(
+        is_nntile_device(self.device()) &&
+            is_nntile_device(other.device()),
+        "nntile mul expects both operands on device nntile");
+    if (out.has_value())
+    {
+        TORCH_CHECK(
+            is_nntile_device(out->device()),
+            "nntile mul.out expects output on device nntile");
+    }
+    TORCH_CHECK(self.sizes() == other.sizes(), "nntile mul: shape mismatch");
+    TORCH_CHECK(
+        self.scalar_type() == other.scalar_type(),
+        "nntile mul: dtype mismatch");
+    TORCH_CHECK(
+        self.scalar_type() == at::ScalarType::Float,
+        "nntile mul supports float32 only in phase 2");
+    TORCH_CHECK(
+        self.is_contiguous() && other.is_contiguous(),
+        "nntile mul requires contiguous tensors");
+    if (out.has_value())
+    {
+        TORCH_CHECK(
+            out->sizes() == self.sizes(),
+            "nntile mul.out: output shape mismatch");
+        TORCH_CHECK(
+            out->is_contiguous(),
+            "nntile mul.out requires contiguous output");
+    }
+}
+
+void run_mul_kernel(
+    const at::Tensor &self,
+    const at::Tensor &other,
+    at::Tensor &out)
+{
+    pin_graph_op_inputs({self, other});
+    pin_graph_op_output(out, true);
+    tensor_mul_fp32(
+        self.data_ptr<float>(),
+        other.data_ptr<float>(),
+        out.data_ptr<float>(),
+        self.sizes());
+}
+
+void run_mul_inplace_kernel(at::Tensor &self, const at::Tensor &other)
+{
+    pin_graph_op_inputs({self, other});
+    pin_graph_op_output(self, true);
+    tensor_mul_inplace_fp32(
+        other.data_ptr<float>(),
+        self.data_ptr<float>(),
+        self.sizes());
+}
+
+} // namespace
+
+at::Tensor mul_tensor(const at::Tensor &self, const at::Tensor &other)
+{
+    check_mul_inputs(self, other);
+    at::Tensor out = at::empty_like(self);
+    run_mul_kernel(self, other, out);
+    return out;
+}
+
+at::Tensor &mul_out(
+    const at::Tensor &self,
+    const at::Tensor &other,
+    at::Tensor &out)
+{
+    check_mul_inputs(self, other, out);
+    run_mul_kernel(self, other, out);
+    return out;
+}
+
+at::Tensor &mul_inplace_tensor(at::Tensor &self, const at::Tensor &other)
+{
+    check_mul_inputs(self, other);
+    run_mul_inplace_kernel(self, other);
+    return self;
+}
+
+} // namespace torch_nntile
+
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
+{
+    m.impl("mul.Tensor", TORCH_FN(torch_nntile::mul_tensor));
+    m.impl("mul.out", TORCH_FN(torch_nntile::mul_out));
+    m.impl("mul_.Tensor", TORCH_FN(torch_nntile::mul_inplace_tensor));
+}

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -26,6 +26,7 @@ CSRC = [
     "csrc/nntile_graph_recorder.cpp",
     "csrc/nntile_executor.cpp",
     "csrc/nntile_add.cpp",
+    "csrc/nntile_mul.cpp",
     "csrc/nntile_linear.cpp",
     "csrc/nntile_relu.cpp",
     "csrc/nntile_threshold_backward.cpp",

--- a/torch_nntile/tests/test_add_inplace_parity.py
+++ b/torch_nntile/tests/test_add_inplace_parity.py
@@ -1,0 +1,54 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_add_inplace_parity.py
+# Parity tests for nntile add_ via TensorGraph (libnntile).
+
+import torch
+import pytest
+
+import torch_nntile
+from torch_nntile import _C
+
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+
+def test_add_inplace_matches_cpu():
+    a_cpu = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    b_cpu = torch.tensor([[0.5, -1.0], [2.0, 0.25]])
+
+    a = a_cpu.clone().to("nntile")
+    b = b_cpu.to("nntile")
+    expected = a_cpu + b_cpu
+
+    a.add_(b)
+    assert torch.allclose(a.cpu(), expected)
+
+
+def test_add_inplace_with_alpha_matches_cpu():
+    a_cpu = torch.tensor([1.0, -2.0, 3.5])
+    b_cpu = torch.tensor([0.25, 4.0, -1.5])
+
+    a = a_cpu.clone().to("nntile")
+    b = b_cpu.to("nntile")
+    expected = torch.add(a_cpu, b_cpu, alpha=2.0)
+
+    a.add_(b, alpha=2.0)
+    assert torch.allclose(a.cpu(), expected)
+
+
+def test_add_inplace_2d_shape_parity():
+    shape = (4, 6)
+    a_cpu = torch.randn(shape, dtype=torch.float32)
+    b_cpu = torch.randn(shape, dtype=torch.float32)
+
+    a_nntile = a_cpu.clone().to("nntile")
+    b_nntile = b_cpu.to("nntile")
+    a_nntile.add_(b_nntile)
+
+    a_cpu.add_(b_cpu)
+    assert torch.allclose(a_nntile.cpu(), a_cpu, rtol=1e-5, atol=1e-5)

--- a/torch_nntile/tests/test_mul_parity.py
+++ b/torch_nntile/tests/test_mul_parity.py
@@ -1,0 +1,52 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_mul_parity.py
+# Parity tests for nntile mul via TensorGraph (libnntile).
+
+import torch
+import pytest
+
+import torch_nntile
+from torch_nntile import _C
+
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+
+def test_mul_matches_cpu():
+    a_cpu = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    b_cpu = torch.tensor([[0.5, -1.0], [2.0, 0.25]])
+
+    a = a_cpu.to("nntile")
+    b = b_cpu.to("nntile")
+    z = a * b
+
+    assert z.device.type == "nntile"
+    assert torch.allclose(z.cpu(), a_cpu * b_cpu)
+
+
+def test_mul_inplace_matches_cpu():
+    a_cpu = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    b_cpu = torch.tensor([[0.5, -1.0], [2.0, 0.25]])
+
+    a = a_cpu.clone().to("nntile")
+    b = b_cpu.to("nntile")
+    expected = a_cpu * b_cpu
+
+    a.mul_(b)
+    assert torch.allclose(a.cpu(), expected)
+
+
+def test_mul_2d_shape_parity():
+    shape = (4, 6)
+    a_cpu = torch.randn(shape, dtype=torch.float32)
+    b_cpu = torch.randn(shape, dtype=torch.float32)
+
+    z_nntile = (a_cpu.to("nntile") * b_cpu.to("nntile")).cpu()
+    z_cpu = a_cpu * b_cpu
+
+    assert torch.allclose(z_nntile, z_cpu, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PyTorch ATen in-place operations use a trailing underscore in their schema names (e.g. `add_.Tensor`, `mul_.Tensor`, `fill_.Scalar`, `resize_`). This PR registers the missing elementwise ops on the `nntile` (`PrivateUse1`) backend:

- **Out-of-place multiply:** `mul.Tensor`, `mul.out` → TensorGraph `multiply`
- **In-place multiply:** `mul_.Tensor` → TensorGraph `multiply_inplace`
- **In-place add:** `add_.Tensor` → TensorGraph `add_inplace`

## Changes

- Add `tensor_mul_fp32`, `tensor_mul_inplace_fp32`, and `tensor_add_inplace_fp32` in `nntile_executor`
- New `nntile_mul.cpp` with ATen registrations
- Extend `nntile_add.cpp` with `add_.Tensor`
- Parity tests for `a * b`, `a.mul_(b)`, and `a.add_(b)` against CPU reference

## Testing

```bash
export LD_LIBRARY_PATH=/opt/starpu/lib:/workspace/build/nntile
export STARPU_SILENT=1 STARPU_FXT_TRACE=0 STARPU_WORKERS_NOBIND=1
cd torch_nntile
pytest -vv tests/test_mul_parity.py tests/test_add_inplace_parity.py tests/test_add_parity.py
```

All 9 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3162884-256d-40b8-94f5-73a691e4c9ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3162884-256d-40b8-94f5-73a691e4c9ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

