### PR TITLE
Add split/narrow ATen ops for torch_nntile cat/split autograd

### DIFF
--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -107,6 +107,9 @@ run through libnntile `TensorGraph` → `TileGraph` → `Runtime`:
 |------------|-----------|
 | `a + b` | `tensor::add` |
 | `torch.cat` | `tensor::concat` |
+| `torch.cat` backward | `tensor::copy_intersection` (via `aten::narrow`) |
+| `torch.split` / `torch.chunk` | `tensor::copy_intersection` |
+| `torch.split` backward | `tensor::concat` (PyTorch `SplitWithSizesBackward`) |
 | `F.linear` / `nn.Linear` (no bias) | `tensor::gemm` |
 | `F.relu` / `nn.ReLU` | `tensor::relu` |
 | ReLU backward | `tensor::relu_backward` (+ `tensor::clear` on output) |

--- a/torch_nntile/csrc/nntile_executor.cpp
+++ b/torch_nntile/csrc/nntile_executor.cpp
@@ -19,6 +19,7 @@
 #include <nntile/tensor/ops/add_slice.hh>
 #include <nntile/tensor/ops/add_slice_inplace.hh>
 #include <nntile/tensor/ops/concat.hh>
+#include <nntile/tensor/ops/copy_intersection.hh>
 #include <nntile/tensor/ops/multiply.hh>
 #include <nntile/tensor/ops/multiply_inplace.hh>
 #include <nntile/tensor/ops/clear.hh>
@@ -1577,6 +1578,99 @@ void tensor_cat_fp32(
     maybe_execute_after_record();
 }
 
+void tensor_narrow_fp32(
+    const float *input_data,
+    c10::IntArrayRef input_shape,
+    int64_t dim,
+    int64_t start,
+    int64_t length,
+    float *out_data,
+    c10::IntArrayRef out_shape)
+{
+    (void) length;
+    const nntile::Index axis = static_cast<nntile::Index>(dim);
+    const std::vector<nntile::Index> graph_shape =
+        pytorch_shape_to_graph(input_shape);
+
+    auto *input_node = get_or_create_data_node(
+        const_cast<float *>(input_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+
+    const std::vector<nntile::Index> out_graph =
+        pytorch_shape_to_graph(out_shape);
+    auto *out_node = get_or_create_data_node(
+        out_data,
+        out_graph,
+        nntile::DataType::FP32,
+        false);
+
+    nntile::tensor::clear(out_node);
+
+    const nntile::Index ndim = static_cast<nntile::Index>(graph_shape.size());
+    std::vector<nntile::Index> zero(static_cast<size_t>(ndim), 0);
+    std::vector<nntile::Index> dst_off = zero;
+    dst_off[static_cast<size_t>(axis)] = static_cast<nntile::Index>(start);
+
+    nntile::tensor::copy_intersection(
+        input_node,
+        zero,
+        out_node,
+        dst_off);
+    register_data_node(out_data, out_node);
+    maybe_execute_after_record();
+}
+
+void tensor_split_with_sizes_fp32(
+    const float *input_data,
+    c10::IntArrayRef input_shape,
+    int64_t dim,
+    const std::vector<int64_t> &split_sizes,
+    const std::vector<float *> &out_data,
+    const std::vector<c10::IntArrayRef> &out_shapes)
+{
+    const nntile::Index axis = static_cast<nntile::Index>(dim);
+    const std::vector<nntile::Index> graph_shape =
+        pytorch_shape_to_graph(input_shape);
+
+    auto *input_node = get_or_create_data_node(
+        const_cast<float *>(input_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+
+    const nntile::Index ndim = static_cast<nntile::Index>(graph_shape.size());
+    std::vector<nntile::Index> zero(static_cast<size_t>(ndim), 0);
+    nntile::Index accumulate = 0;
+
+    for (std::size_t i = 0; i < split_sizes.size(); ++i)
+    {
+        const std::vector<nntile::Index> out_graph =
+            pytorch_shape_to_graph(out_shapes[i]);
+        auto *out_node = get_or_create_data_node(
+            out_data[i],
+            out_graph,
+            nntile::DataType::FP32,
+            false);
+
+        nntile::tensor::clear(out_node);
+
+        std::vector<nntile::Index> dst_off = zero;
+        dst_off[static_cast<size_t>(axis)] = accumulate;
+
+        nntile::tensor::copy_intersection(
+            input_node,
+            zero,
+            out_node,
+            dst_off);
+        register_data_node(out_data[i], out_node);
+        accumulate += static_cast<nntile::Index>(split_sizes[i]);
+    }
+
+    maybe_execute_after_record();
+}
+
 } // namespace torch_nntile
 
 #else
@@ -1904,6 +1998,29 @@ void tensor_cat_fp32(
     int64_t /*dim*/)
 {
     require_libnntile("cat");
+}
+
+void tensor_narrow_fp32(
+    const float * /*input_data*/,
+    c10::IntArrayRef /*input_shape*/,
+    int64_t /*dim*/,
+    int64_t /*start*/,
+    int64_t /*length*/,
+    float * /*out_data*/,
+    c10::IntArrayRef /*out_shape*/)
+{
+    require_libnntile("narrow");
+}
+
+void tensor_split_with_sizes_fp32(
+    const float * /*input_data*/,
+    c10::IntArrayRef /*input_shape*/,
+    int64_t /*dim*/,
+    const std::vector<int64_t> & /*split_sizes*/,
+    const std::vector<float *> & /*out_data*/,
+    const std::vector<c10::IntArrayRef> & /*out_shapes*/)
+{
+    require_libnntile("split_with_sizes");
 }
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_executor.h
+++ b/torch_nntile/csrc/nntile_executor.h
@@ -239,4 +239,21 @@ void tensor_cat_fp32(
     c10::IntArrayRef out_shape,
     int64_t dim);
 
+void tensor_narrow_fp32(
+    const float *input_data,
+    c10::IntArrayRef input_shape,
+    int64_t dim,
+    int64_t start,
+    int64_t length,
+    float *out_data,
+    c10::IntArrayRef out_shape);
+
+void tensor_split_with_sizes_fp32(
+    const float *input_data,
+    c10::IntArrayRef input_shape,
+    int64_t dim,
+    const std::vector<int64_t> &split_sizes,
+    const std::vector<float *> &out_data,
+    const std::vector<c10::IntArrayRef> &out_shapes);
+
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_narrow.cpp
+++ b/torch_nntile/csrc/nntile_narrow.cpp
@@ -1,0 +1,102 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_narrow.cpp
+ */
+
+#include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
+
+#include <ATen/Functions.h>
+#include <ATen/TensorUtils.h>
+#include <c10/util/irange.h>
+#include <torch/library.h>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+bool is_nntile_device(c10::Device device)
+{
+    return device.type() == c10::DeviceType::PrivateUse1;
+}
+
+void check_narrow_input(const at::Tensor &self)
+{
+    TORCH_CHECK(
+        is_nntile_device(self.device()),
+        "nntile narrow expects tensor on device nntile");
+    TORCH_CHECK(
+        self.scalar_type() == at::ScalarType::Float,
+        "nntile narrow supports float32 only");
+    TORCH_CHECK(
+        self.is_contiguous(),
+        "nntile narrow requires contiguous tensor");
+    TORCH_CHECK(self.dim() > 0, "nntile narrow: cannot narrow a 0-dim tensor");
+}
+
+std::vector<int64_t> make_narrow_output_shape(
+    c10::IntArrayRef input_shape,
+    int64_t dim,
+    int64_t length)
+{
+    std::vector<int64_t> out_shape = input_shape.vec();
+    out_shape[static_cast<std::size_t>(dim)] = length;
+    return out_shape;
+}
+
+void run_narrow(
+    const at::Tensor &self,
+    int64_t dim,
+    int64_t start,
+    int64_t length,
+    at::Tensor &out)
+{
+    pin_graph_op_inputs({self});
+    pin_graph_op_output(out, true);
+    tensor_narrow_fp32(
+        self.data_ptr<float>(),
+        self.sizes(),
+        dim,
+        start,
+        length,
+        out.data_ptr<float>(),
+        out.sizes());
+}
+
+} // namespace
+
+at::Tensor narrow(
+    const at::Tensor &self,
+    int64_t dim,
+    c10::SymInt start,
+    c10::SymInt length)
+{
+    check_narrow_input(self);
+    const int64_t wrapped_dim = at::maybe_wrap_dim(dim, self.dim());
+    const int64_t start_val = start.expect_int();
+    const int64_t length_val = length.expect_int();
+    const int64_t dim_size = self.size(wrapped_dim);
+
+    TORCH_CHECK(
+        start_val >= 0 && start_val <= dim_size,
+        "nntile narrow: start out of range");
+    TORCH_CHECK(
+        length_val >= 0 && start_val + length_val <= dim_size,
+        "nntile narrow: length out of range");
+
+    at::Tensor out = at::empty(
+        make_narrow_output_shape(self.sizes(), wrapped_dim, length_val),
+        self.options().memory_format(at::MemoryFormat::Contiguous));
+    run_narrow(self, wrapped_dim, start_val, length_val, out);
+    return out;
+}
+
+} // namespace torch_nntile
+
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
+{
+    m.impl("narrow", TORCH_FN(torch_nntile::narrow));
+}

--- a/torch_nntile/csrc/nntile_split.cpp
+++ b/torch_nntile/csrc/nntile_split.cpp
@@ -1,0 +1,215 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_split.cpp
+ */
+
+#include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
+
+#include <ATen/Functions.h>
+#include <ATen/TensorUtils.h>
+#include <c10/util/irange.h>
+#include <torch/library.h>
+
+#include <numeric>
+#include <vector>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+bool is_nntile_device(c10::Device device)
+{
+    return device.type() == c10::DeviceType::PrivateUse1;
+}
+
+void check_split_input(const at::Tensor &self)
+{
+    TORCH_CHECK(
+        is_nntile_device(self.device()),
+        "nntile split expects tensor on device nntile");
+    TORCH_CHECK(
+        self.scalar_type() == at::ScalarType::Float,
+        "nntile split supports float32 only");
+    TORCH_CHECK(
+        self.is_contiguous(),
+        "nntile split requires contiguous tensor");
+    TORCH_CHECK(self.dim() > 0, "nntile split: cannot split a 0-dim tensor");
+}
+
+std::vector<int64_t> symint_array_to_int64(c10::SymIntArrayRef sizes)
+{
+    std::vector<int64_t> out;
+    out.reserve(sizes.size());
+    for (const c10::SymInt &size : sizes)
+    {
+        out.push_back(size.expect_int());
+    }
+    return out;
+}
+
+void validate_split_sizes(
+    int64_t dim_size,
+    const std::vector<int64_t> &split_sizes)
+{
+    TORCH_CHECK(!split_sizes.empty(), "nntile split: split_sizes must be non-empty");
+    int64_t total = 0;
+    for (const auto i : c10::irange(split_sizes.size()))
+    {
+        TORCH_CHECK(
+            split_sizes[static_cast<std::size_t>(i)] >= 0,
+            "nntile split: split_sizes must be non-negative");
+        total += split_sizes[static_cast<std::size_t>(i)];
+    }
+    TORCH_CHECK(
+        total == dim_size,
+        "nntile split: split_sizes sum to ",
+        static_cast<long long>(total),
+        " but dim size is ",
+        static_cast<long long>(dim_size));
+}
+
+std::vector<int64_t> compute_equal_split_sizes(
+    int64_t dim_size,
+    int64_t split_size)
+{
+    TORCH_CHECK(split_size > 0, "nntile split: split_size must be positive");
+    std::vector<int64_t> sizes;
+    for (int64_t offset = 0; offset < dim_size; offset += split_size)
+    {
+        sizes.push_back(std::min(split_size, dim_size - offset));
+    }
+    TORCH_CHECK(!sizes.empty(), "nntile split: empty result");
+    return sizes;
+}
+
+std::vector<int64_t> compute_chunk_sizes(int64_t dim_size, int64_t chunks)
+{
+    TORCH_CHECK(chunks > 0, "nntile chunk: chunks must be positive");
+    const int64_t split_size = (dim_size + chunks - 1) / chunks;
+    return compute_equal_split_sizes(dim_size, split_size);
+}
+
+std::vector<at::Tensor> make_split_outputs(
+    const at::Tensor &self,
+    int64_t dim,
+    const std::vector<int64_t> &split_sizes)
+{
+    std::vector<at::Tensor> outputs;
+    outputs.reserve(split_sizes.size());
+    for (const int64_t size : split_sizes)
+    {
+        std::vector<int64_t> out_shape = self.sizes().vec();
+        out_shape[static_cast<std::size_t>(dim)] = size;
+        outputs.push_back(at::empty(
+            out_shape,
+            self.options().memory_format(at::MemoryFormat::Contiguous)));
+    }
+    return outputs;
+}
+
+void run_split_with_sizes(
+    const at::Tensor &self,
+    int64_t dim,
+    const std::vector<int64_t> &split_sizes,
+    std::vector<at::Tensor> &outputs)
+{
+    std::vector<float *> out_data;
+    std::vector<c10::IntArrayRef> out_shapes;
+    out_data.reserve(outputs.size());
+    out_shapes.reserve(outputs.size());
+    for (at::Tensor &out : outputs)
+    {
+        out_data.push_back(out.data_ptr<float>());
+        out_shapes.push_back(out.sizes());
+    }
+
+    pin_graph_op_inputs({self});
+    for (at::Tensor &out : outputs)
+    {
+        pin_graph_op_output(out, true);
+    }
+
+    tensor_split_with_sizes_fp32(
+        self.data_ptr<float>(),
+        self.sizes(),
+        dim,
+        split_sizes,
+        out_data,
+        out_shapes);
+}
+
+std::vector<at::Tensor> split_with_sizes_impl(
+    const at::Tensor &self,
+    const std::vector<int64_t> &split_sizes,
+    int64_t dim)
+{
+    check_split_input(self);
+    const int64_t wrapped_dim = at::maybe_wrap_dim(dim, self.dim());
+    validate_split_sizes(self.size(wrapped_dim), split_sizes);
+
+    std::vector<at::Tensor> outputs =
+        make_split_outputs(self, wrapped_dim, split_sizes);
+    run_split_with_sizes(self, wrapped_dim, split_sizes, outputs);
+    return outputs;
+}
+
+} // namespace
+
+std::vector<at::Tensor> split_with_sizes(
+    const at::Tensor &self,
+    c10::SymIntArrayRef split_sizes,
+    int64_t dim)
+{
+    return split_with_sizes_impl(
+        self,
+        symint_array_to_int64(split_sizes),
+        dim);
+}
+
+std::vector<at::Tensor> split_sizes_array(
+    const at::Tensor &self,
+    at::IntArrayRef split_sizes,
+    int64_t dim)
+{
+    std::vector<int64_t> sizes(split_sizes.begin(), split_sizes.end());
+    return split_with_sizes_impl(self, sizes, dim);
+}
+
+std::vector<at::Tensor> split_tensor(
+    const at::Tensor &self,
+    c10::SymInt split_size,
+    int64_t dim)
+{
+    check_split_input(self);
+    const int64_t wrapped_dim = at::maybe_wrap_dim(dim, self.dim());
+    const std::vector<int64_t> sizes = compute_equal_split_sizes(
+        self.size(wrapped_dim),
+        split_size.expect_int());
+    return split_with_sizes_impl(self, sizes, wrapped_dim);
+}
+
+std::vector<at::Tensor> chunk(
+    const at::Tensor &self,
+    int64_t chunks,
+    int64_t dim)
+{
+    check_split_input(self);
+    const int64_t wrapped_dim = at::maybe_wrap_dim(dim, self.dim());
+    const std::vector<int64_t> sizes =
+        compute_chunk_sizes(self.size(wrapped_dim), chunks);
+    return split_with_sizes_impl(self, sizes, wrapped_dim);
+}
+
+} // namespace torch_nntile
+
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
+{
+    m.impl("split_with_sizes", TORCH_FN(torch_nntile::split_with_sizes));
+    m.impl("split", TORCH_FN(torch_nntile::split_sizes_array));
+    m.impl("split.Tensor", TORCH_FN(torch_nntile::split_tensor));
+    m.impl("chunk", TORCH_FN(torch_nntile::chunk));
+}

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -28,6 +28,8 @@ CSRC = [
     "csrc/nntile_add.cpp",
     "csrc/nntile_mul.cpp",
     "csrc/nntile_cat.cpp",
+    "csrc/nntile_narrow.cpp",
+    "csrc/nntile_split.cpp",
     "csrc/nntile_hypot.cpp",
     "csrc/nntile_linear.cpp",
     "csrc/nntile_relu.cpp",

--- a/torch_nntile/tests/test_split_cat_autograd.py
+++ b/torch_nntile/tests/test_split_cat_autograd.py
@@ -1,0 +1,264 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_split_cat_autograd.py
+# Autograd parity tests for nntile split, narrow, and cat.
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import torch
+import pytest
+
+from torch_nntile import _C
+
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+_PKG_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _grad_with_ones(output: torch.Tensor, inputs: tuple[torch.Tensor, ...]) -> tuple:
+    """Backward via grad_outputs; avoids ``sum`` (not on nntile)."""
+    grad_out = torch.ones_like(output)
+    return torch.autograd.grad(output, inputs, grad_outputs=grad_out)
+
+
+def _run_graph_subprocess(script: str) -> None:
+    env = dict(**__import__("os").environ)
+    repo = Path(__file__).resolve().parents[2]
+    build_lib = repo / "build" / "nntile"
+    starpu_lib = "/opt/starpu/lib"
+    ld = env.get("LD_LIBRARY_PATH", "")
+    for part in (str(build_lib), starpu_lib):
+        if part not in ld.split(":"):
+            ld = f"{part}:{ld}" if ld else part
+    env["LD_LIBRARY_PATH"] = ld
+    env["PYTHONPATH"] = f"{_PKG_ROOT}:{env.get('PYTHONPATH', '')}"
+    proc = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"subprocess failed ({proc.returncode})\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+
+def test_split_with_sizes_forward_2d():
+    x_cpu = torch.randn(2, 7, dtype=torch.float32)
+    expected = torch.split(x_cpu, [3, 4], dim=1)
+
+    parts = torch.split(x_cpu.to("nntile"), [3, 4], dim=1)
+    assert len(parts) == 2
+    for part, ref in zip(parts, expected, strict=True):
+        assert torch.allclose(part.cpu(), ref, rtol=1e-5, atol=1e-5)
+
+
+def test_chunk_forward():
+    x_cpu = torch.randn(2, 7, dtype=torch.float32)
+    expected = torch.chunk(x_cpu, 3, dim=1)
+
+    parts = torch.chunk(x_cpu.to("nntile"), 3, dim=1)
+    assert len(parts) == len(expected)
+    for part, ref in zip(parts, expected, strict=True):
+        assert torch.allclose(part.cpu(), ref, rtol=1e-5, atol=1e-5)
+
+
+def test_split_equal_size_forward():
+    x_cpu = torch.randn(2, 6, dtype=torch.float32)
+    expected = torch.split(x_cpu, 3, dim=1)
+
+    parts = torch.split(x_cpu.to("nntile"), 3, dim=1)
+    for part, ref in zip(parts, expected, strict=True):
+        assert torch.allclose(part.cpu(), ref, rtol=1e-5, atol=1e-5)
+
+
+def test_narrow_forward():
+    x_cpu = torch.randn(2, 7, dtype=torch.float32)
+    expected = x_cpu.narrow(1, 2, 4)
+
+    result = x_cpu.to("nntile").narrow(1, 2, 4)
+    assert torch.allclose(result.cpu(), expected, rtol=1e-5, atol=1e-5)
+
+
+def test_cat_backward_two_tensors():
+    a_cpu = torch.randn(2, 3, dtype=torch.float32, requires_grad=True)
+    b_cpu = torch.randn(2, 4, dtype=torch.float32, requires_grad=True)
+    y_cpu = torch.cat([a_cpu, b_cpu], dim=1)
+    ga_cpu, gb_cpu = _grad_with_ones(y_cpu, (a_cpu, b_cpu))
+
+    a = a_cpu.detach().to("nntile").requires_grad_(True)
+    b = b_cpu.detach().to("nntile").requires_grad_(True)
+    y = torch.cat([a, b], dim=1)
+    ga, gb = _grad_with_ones(y, (a, b))
+
+    assert torch.allclose(ga.cpu(), ga_cpu, rtol=1e-5, atol=1e-5)
+    assert torch.allclose(gb.cpu(), gb_cpu, rtol=1e-5, atol=1e-5)
+
+
+def test_cat_backward_many_tensors():
+    tensors_cpu = [
+        torch.randn(2, 3, dtype=torch.float32, requires_grad=True) for _ in range(4)
+    ]
+    y_cpu = torch.cat(tensors_cpu, dim=1)
+    grads_cpu = _grad_with_ones(y_cpu, tuple(tensors_cpu))
+
+    tensors = [t.detach().to("nntile").requires_grad_(True) for t in tensors_cpu]
+    y = torch.cat(tensors, dim=1)
+    grads = _grad_with_ones(y, tuple(tensors))
+
+    for g, ref in zip(grads, grads_cpu, strict=True):
+        assert torch.allclose(g.cpu(), ref, rtol=1e-5, atol=1e-5)
+
+
+def test_split_backward():
+    x_cpu = torch.randn(2, 7, dtype=torch.float32, requires_grad=True)
+    parts_cpu = torch.split(x_cpu, [3, 4], dim=1)
+    gx_cpu = torch.autograd.grad(
+        parts_cpu,
+        x_cpu,
+        grad_outputs=(
+            torch.ones_like(parts_cpu[0]),
+            torch.ones_like(parts_cpu[1]),
+        ),
+    )[0]
+
+    x = x_cpu.detach().to("nntile").requires_grad_(True)
+    parts = torch.split(x, [3, 4], dim=1)
+    gx = torch.autograd.grad(
+        parts,
+        x,
+        grad_outputs=(
+            torch.ones_like(parts[0]),
+            torch.ones_like(parts[1]),
+        ),
+    )[0]
+
+    assert torch.allclose(gx.cpu(), gx_cpu, rtol=1e-5, atol=1e-5)
+
+
+def test_split_cat_roundtrip_backward():
+    x_cpu = torch.randn(2, 5, dtype=torch.float32, requires_grad=True)
+    y_cpu = torch.cat(torch.split(x_cpu, [2, 3], dim=1), dim=1)
+    gx_cpu = _grad_with_ones(y_cpu, (x_cpu,))[0]
+
+    x = x_cpu.detach().to("nntile").requires_grad_(True)
+    y = torch.cat(torch.split(x, [2, 3], dim=1), dim=1)
+    gx = _grad_with_ones(y, (x,))[0]
+
+    assert torch.allclose(gx.cpu(), gx_cpu, rtol=1e-5, atol=1e-5)
+
+
+def test_chunk_backward():
+    x_cpu = torch.randn(2, 7, dtype=torch.float32, requires_grad=True)
+    parts_cpu = torch.chunk(x_cpu, 3, dim=1)
+    sizes = [part.size(1) for part in parts_cpu]
+    gx_cpu = torch.autograd.grad(
+        parts_cpu,
+        x_cpu,
+        grad_outputs=tuple(torch.ones_like(part) for part in parts_cpu),
+    )[0]
+
+    x = x_cpu.detach().to("nntile").requires_grad_(True)
+    # Chunk backward is not wired on PrivateUse1; split_with_sizes uses the
+    # same concat-in-backward path with identical chunk sizes.
+    parts = torch.split(x, sizes, dim=1)
+    gx = torch.autograd.grad(
+        parts,
+        x,
+        grad_outputs=tuple(torch.ones_like(part) for part in parts),
+    )[0]
+
+    assert torch.allclose(gx.cpu(), gx_cpu, rtol=1e-5, atol=1e-5)
+
+
+def test_split_cat_graph_mode_backward():
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1,
+            ncuda=0,
+            cpu_fallback=False,
+            runtime_mode="graph",
+        )
+        torch_nntile.restrict_cpu()
+
+        x_cpu = torch.randn(2, 5, dtype=torch.float32, requires_grad=True)
+        y_cpu = torch.cat(torch.split(x_cpu, [2, 3], dim=1), dim=1)
+        gx_cpu = torch.autograd.grad(
+            y_cpu,
+            x_cpu,
+            grad_outputs=torch.ones_like(y_cpu),
+        )[0]
+
+        x = x_cpu.detach().to("nntile").requires_grad_(True)
+        parts = torch.split(x, [2, 3], dim=1)
+        y = torch.cat(parts, dim=1)
+        gx = torch.autograd.grad(
+            y,
+            x,
+            grad_outputs=torch.ones_like(y),
+        )[0]
+
+        assert torch_nntile.has_pending_graph()
+        torch_nntile.compile_graph()
+        torch_nntile.run()
+
+        assert torch.allclose(gx.cpu(), gx_cpu, rtol=1e-5, atol=1e-5)
+        """
+    )
+
+
+def test_cat_backward_graph_mode():
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1,
+            ncuda=0,
+            cpu_fallback=False,
+            runtime_mode="graph",
+        )
+        torch_nntile.restrict_cpu()
+
+        a_cpu = torch.randn(2, 3, dtype=torch.float32, requires_grad=True)
+        b_cpu = torch.randn(2, 4, dtype=torch.float32, requires_grad=True)
+        y_cpu = torch.cat([a_cpu, b_cpu], dim=1)
+        ga_cpu, gb_cpu = torch.autograd.grad(
+            y_cpu,
+            (a_cpu, b_cpu),
+            grad_outputs=torch.ones_like(y_cpu),
+        )
+
+        a = a_cpu.detach().to("nntile").requires_grad_(True)
+        b = b_cpu.detach().to("nntile").requires_grad_(True)
+        y = torch.cat([a, b], dim=1)
+        ga, gb = torch.autograd.grad(
+            y,
+            (a, b),
+            grad_outputs=torch.ones_like(y),
+        )
+
+        assert torch_nntile.has_pending_graph()
+        torch_nntile.compile_graph()
+        torch_nntile.run()
+
+        assert torch.allclose(ga.cpu(), ga_cpu, rtol=1e-5, atol=1e-5)
+        assert torch.allclose(gb.cpu(), gb_cpu, rtol=1e-5, atol=1e-5)
+        """
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables full PyTorch autograd for `torch.cat` and `torch.split` on `device="nntile"` by registering `aten::narrow` and split/chunk forward kernels that record `tensor::copy_intersection` ops into the TensorGraph.

- **Cat backward**: PyTorch `CatBackward` slices `grad_out` via `narrow` → materialized `copy_intersection` extraction
- **Split backward**: PyTorch `SplitWithSizesBackward` concatenates grad parts via existing `torch.cat` forward path
- **Constraints**: fp32, contiguous tensors on nntile (same as existing `torch.cat`)

## Changes

- `tensor_narrow_fp32` / `tensor_split_with_sizes_fp32` in `nntile_executor.cpp` (clear output + `copy_intersection` with correct `dst_offset`)
- New `nntile_narrow.cpp` and `nntile_split.cpp` ATen registrations
- Autograd parity tests (`test_split_cat_autograd.py`) including graph mode with `cpu_fallback=False`
- README Phase 2 op table updated

## Testing

```bash
export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
export STARPU_SILENT=1 STARPU_FXT_TRACE=0 STARPU_WORKERS_NOBIND=1
pytest -vv torch_nntile/tests/test_split_cat_autograd.py torch_nntile/tests/test_cat_parity.py
```

All 20 tests pass locally (11 new + 9 existing cat parity).

## Notes

- `torch.chunk` forward is supported; chunk backward on PrivateUse1 is not wired by PyTorch (`SplitBackward` derivative missing). Equivalent backward works via `torch.split` with chunk-computed sizes.
- `torch.tensor_split` is out of scope (uses `SliceBackward`, not concat).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-155e1f20-d933-4c76-bbe6-367afbbf526d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-155e1f20-d933-4c76-bbe6-367afbbf526d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

