### PR TITLE
Document PyTorch grad accumulation and add parity tests

### DIFF
--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -126,6 +126,36 @@ run through libnntile `TensorGraph` → `TileGraph` → `Runtime`:
 PyTorch C-order shapes are converted to TensorGraph storage layout internally.
 Gradients use **PyTorch autograd** (not `NNGraph` autograd).
 
+### Gradient accumulation
+
+`torch_nntile` does **not** implement NNGraph-style `get_or_create_grad` /
+`add_inplace` fan-in. PyTorch's autograd engine owns all gradient accumulation:
+
+| Mechanism | When | torch_nntile op |
+|-----------|------|-----------------|
+| `AccumulateGrad` | Leaf `.grad` (params, inputs with `requires_grad=True`) | `add_.Tensor` (in-place `+=` on subsequent grads) or buffer steal on first grad |
+| `InputBuffer` | Fan-in on intermediate tensors (diamond graphs) | `add_.Tensor` or `add.Tensor` |
+| Optimizer / SGD | `param.add_(grad, alpha=-lr)`, `velocity.add_(grad)` | `add_.Tensor` |
+
+Backward ATen ops (`linear_backward`, `silu_backward`, …) always **overwrite**
+fresh grad buffers (`beta=0`). Accumulation is delegated to PyTorch; do not fold
+`beta=1` into backward kernels unless profiling proves a fusion win.
+
+**Grad buffer stealing:** backward return tensors must not be pinned for graph
+recording (`pin_graph_op_output(..., false)`), so PyTorch can move the first
+grad into `param.grad` without an extra copy.
+
+**Training microbatches:** use the standard PyTorch pattern — scale loss, call
+`loss.backward()` multiple times, then `optimizer.step()`. No special
+`torch_nntile` API. Prefer `optimizer.zero_grad(set_to_none=True)` so the
+first backward can steal into `.grad`; `grad.zero_()` is supported via
+`zero_` / `fill_(0)` when `set_to_none=False`.
+
+PyTorch does not fuse accumulation across the backward graph without
+`torch.compile`; each `+=` dispatches to `add_` as a separate kernel.
+
+Tests: `pytest -vv torch_nntile/tests/test_grad_accumulation.py`
+
 ### CPU fallback control
 
 ```python

--- a/torch_nntile/csrc/nntile_kernels.cpp
+++ b/torch_nntile/csrc/nntile_kernels.cpp
@@ -156,6 +156,11 @@ at::Tensor &fill_scalar(at::Tensor &self, const at::Scalar &value)
     return self;
 }
 
+at::Tensor &zero_tensor(at::Tensor &self)
+{
+    return fill_scalar(self, 0);
+}
+
 at::Tensor empty_memory_format(
     at::IntArrayRef size,
     std::optional<at::ScalarType> dtype_opt,
@@ -423,6 +428,7 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
     m.impl("_copy_from_and_resize", TORCH_FN(torch_nntile::copy_from_and_resize));
     m.impl("_local_scalar_dense", TORCH_FN(torch_nntile::local_scalar_dense));
     m.impl("fill_.Scalar", TORCH_FN(torch_nntile::fill_scalar));
+    m.impl("zero_", TORCH_FN(torch_nntile::zero_tensor));
     m.impl("set_.source_Tensor", TORCH_FN(torch_nntile::set_source_tensor));
     m.impl("set_.source_Storage", TORCH_FN(torch_nntile::set_source_storage));
     m.impl(

--- a/torch_nntile/tests/test_grad_accumulation.py
+++ b/torch_nntile/tests/test_grad_accumulation.py
@@ -27,7 +27,6 @@ def _nntile_context_no_fallback():
         pytest.skip(
             "context has CPU fallback enabled; rebuild with cpu_fallback=False"
         )
-    torch_nntile.init_context(ncpu=1, ncuda=0, cpu_fallback=False)
     yield
 
 
@@ -60,9 +59,10 @@ def test_microbatch_grad_accumulation_matches_cpu():
     w_cpu = torch.randn(4, 3, requires_grad=True)
 
     y1_cpu = torch.nn.functional.relu(torch.nn.functional.linear(x1_cpu, w_cpu, None))
-    (y1_cpu.sum() / 2).backward()
     y2_cpu = torch.nn.functional.relu(torch.nn.functional.linear(x2_cpu, w_cpu, None))
-    (y2_cpu.sum() / 2).backward()
+    grad_scale = 0.5
+    y1_cpu.backward(torch.full_like(y1_cpu, grad_scale))
+    y2_cpu.backward(torch.full_like(y2_cpu, grad_scale))
 
     w_ref = w_cpu.grad.clone()
 
@@ -73,11 +73,11 @@ def test_microbatch_grad_accumulation_matches_cpu():
     y1_nnt = torch.nn.functional.relu(
         torch.nn.functional.linear(x1_nnt, w_nnt, None)
     )
-    (y1_nnt.sum() / 2).backward()
     y2_nnt = torch.nn.functional.relu(
         torch.nn.functional.linear(x2_nnt, w_nnt, None)
     )
-    (y2_nnt.sum() / 2).backward()
+    y1_nnt.backward(torch.full(y1_nnt.shape, grad_scale, device="cpu").to("nntile"))
+    y2_nnt.backward(torch.full(y2_nnt.shape, grad_scale, device="cpu").to("nntile"))
 
     assert torch.allclose(w_nnt.grad.cpu(), w_ref, rtol=1e-4, atol=1e-4)
 

--- a/torch_nntile/tests/test_grad_accumulation.py
+++ b/torch_nntile/tests/test_grad_accumulation.py
@@ -1,0 +1,94 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_grad_accumulation.py
+# Gradient accumulation parity: diamond fan-in, microbatch backward, grad.zero_.
+
+from __future__ import annotations
+
+import torch
+import pytest
+
+import torch_nntile
+from torch_nntile import _C
+
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _nntile_context_no_fallback():
+    if not _C.has_libnntile():
+        return
+    if torch_nntile.is_cpu_fallback_enabled():
+        pytest.skip(
+            "context has CPU fallback enabled; rebuild with cpu_fallback=False"
+        )
+    torch_nntile.init_context(ncpu=1, ncuda=0, cpu_fallback=False)
+    yield
+
+
+def test_diamond_shared_weight_grad_matches_cpu():
+    """Weight used in two branches: w.grad must accumulate both paths."""
+    torch.manual_seed(0)
+    x_cpu = torch.randn(2, 3)
+    w_cpu = torch.randn(4, 3, requires_grad=True)
+
+    h1_cpu = torch.nn.functional.linear(x_cpu, w_cpu, None)
+    h2_cpu = torch.nn.functional.linear(x_cpu, w_cpu, None)
+    y_cpu = h1_cpu + h2_cpu
+    y_cpu.backward(torch.ones_like(y_cpu))
+
+    x_nnt = x_cpu.to("nntile")
+    w_nnt = w_cpu.detach().to("nntile").requires_grad_(True)
+    h1_nnt = torch.nn.functional.linear(x_nnt, w_nnt, None)
+    h2_nnt = torch.nn.functional.linear(x_nnt, w_nnt, None)
+    y_nnt = h1_nnt + h2_nnt
+    y_nnt.backward(torch.ones(y_nnt.shape, device="cpu").to("nntile"))
+
+    assert torch.allclose(w_nnt.grad.cpu(), w_cpu.grad, rtol=1e-4, atol=1e-4)
+
+
+def test_microbatch_grad_accumulation_matches_cpu():
+    """Two backward() calls without clearing .grad exercises add_ on params."""
+    torch.manual_seed(1)
+    x1_cpu = torch.randn(2, 3)
+    x2_cpu = torch.randn(2, 3)
+    w_cpu = torch.randn(4, 3, requires_grad=True)
+
+    y1_cpu = torch.nn.functional.relu(torch.nn.functional.linear(x1_cpu, w_cpu, None))
+    (y1_cpu.sum() / 2).backward()
+    y2_cpu = torch.nn.functional.relu(torch.nn.functional.linear(x2_cpu, w_cpu, None))
+    (y2_cpu.sum() / 2).backward()
+
+    w_ref = w_cpu.grad.clone()
+
+    x1_nnt = x1_cpu.to("nntile")
+    x2_nnt = x2_cpu.to("nntile")
+    w_nnt = w_cpu.detach().to("nntile").requires_grad_(True)
+
+    y1_nnt = torch.nn.functional.relu(
+        torch.nn.functional.linear(x1_nnt, w_nnt, None)
+    )
+    (y1_nnt.sum() / 2).backward()
+    y2_nnt = torch.nn.functional.relu(
+        torch.nn.functional.linear(x2_nnt, w_nnt, None)
+    )
+    (y2_nnt.sum() / 2).backward()
+
+    assert torch.allclose(w_nnt.grad.cpu(), w_ref, rtol=1e-4, atol=1e-4)
+
+
+def test_grad_zero_matches_cpu():
+    """optimizer.zero_grad(set_to_none=False) path uses grad.zero_() -> fill_(0)."""
+    grad_cpu = torch.tensor([[1.0, -2.0], [3.0, 4.0]])
+    grad_nnt = grad_cpu.clone().to("nntile")
+
+    grad_cpu.zero_()
+    grad_nnt.zero_()
+
+    assert torch.allclose(grad_nnt.cpu(), grad_cpu)
+    assert torch.all(grad_nnt.cpu() == 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the investigation plan for PyTorch gradient accumulation in `torch_nntile`:

- Documents that PyTorch autograd owns grad accumulation (`AccumulateGrad`, `InputBuffer`); `add`/`add_` are the integration points — no NNGraph `get_or_create_grad` layer needed.
- Registers `zero_` on `PrivateUse1` (delegates to `fill_(0)`) so `optimizer.zero_grad(set_to_none=False)` works without CPU fallback.
- Adds parity tests for diamond fan-in, microbatch accumulation (two `backward()` calls), and `grad.zero_()`.

## Changes

- [`torch_nntile/README.md`](torch_nntile/README.md): new "Gradient accumulation" section with mechanism table and training guidance.
- [`torch_nntile/csrc/nntile_kernels.cpp`](torch_nntile/csrc/nntile_kernels.cpp): register `zero_` ATen op.
- [`torch_nntile/tests/test_grad_accumulation.py`](torch_nntile/tests/test_grad_accumulation.py): three CPU vs nntile parity tests.

## Testing

```bash
export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
export STARPU_SILENT=1 STARPU_FXT_TRACE=0 STARPU_WORKERS_NOBIND=1
pytest -vv torch_nntile/tests/test_grad_accumulation.py
```

All 3 tests pass locally with libnntile built (`cpu_fallback=False`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a6aa646-cfa6-47d6-8abf-f9af770830a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a6aa646-cfa6-47d6-8abf-f9af770830a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

