### PR TITLE
Hook F.cross_entropy for nntile tensors

### DIFF
--- a/torch_nntile/torch_nntile/__init__.py
+++ b/torch_nntile/torch_nntile/__init__.py
@@ -17,6 +17,7 @@ from ._cuda_deps import ensure_linux_cuda_deps
 ensure_linux_cuda_deps()
 
 from . import _C  # noqa: E402, F401 — loads kernels and allocator
+from . import loss as _loss  # noqa: E402, F401
 from . import normalization as _normalization  # noqa: E402, F401
 
 _registered = False

--- a/torch_nntile/torch_nntile/loss.py
+++ b/torch_nntile/torch_nntile/loss.py
@@ -10,8 +10,19 @@ from __future__ import annotations
 
 import torch
 import torch.nn.functional as F
+from torch.nn.modules.loss import _Reduction
 
 _ORIGINAL_CROSS_ENTROPY = F.cross_entropy
+
+
+def _resolve_reduction(
+    reduction: str,
+    size_average: bool | None,
+    reduce: bool | None,
+) -> str:
+    if size_average is not None or reduce is not None:
+        return _Reduction.legacy_get_string(size_average, reduce)
+    return reduction
 
 
 def cross_entropy(
@@ -40,6 +51,7 @@ def cross_entropy(
         raise ValueError("nntile cross_entropy does not support weight")
     if label_smoothing != 0.0:
         raise ValueError("nntile cross_entropy does not support label_smoothing")
+    reduction = _resolve_reduction(reduction, size_average, reduce)
     if reduction not in ("mean", "sum"):
         raise ValueError("nntile cross_entropy supports reduction 'mean' or 'sum'")
     from torch_nntile.training import cross_entropy as _nntile_cross_entropy

--- a/torch_nntile/torch_nntile/loss.py
+++ b/torch_nntile/torch_nntile/loss.py
@@ -1,0 +1,62 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/torch_nntile/loss.py
+# Cross-entropy loss support for device="nntile".
+
+"""Loss helpers for the nntile device."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+_ORIGINAL_CROSS_ENTROPY = F.cross_entropy
+
+
+def cross_entropy(
+    input: torch.Tensor,
+    target: torch.Tensor,
+    weight: torch.Tensor | None = None,
+    size_average: bool | None = None,
+    ignore_index: int = -100,
+    reduce: bool | None = None,
+    reduction: str = "mean",
+    label_smoothing: float = 0.0,
+) -> torch.Tensor:
+    """Cross-entropy on ``device='nntile'`` via libnntile tensor ops."""
+    if input.device.type != "nntile":
+        return _ORIGINAL_CROSS_ENTROPY(
+            input,
+            target,
+            weight=weight,
+            size_average=size_average,
+            ignore_index=ignore_index,
+            reduce=reduce,
+            reduction=reduction,
+            label_smoothing=label_smoothing,
+        )
+    if weight is not None:
+        raise ValueError("nntile cross_entropy does not support weight")
+    if label_smoothing != 0.0:
+        raise ValueError("nntile cross_entropy does not support label_smoothing")
+    if reduction not in ("mean", "sum"):
+        raise ValueError("nntile cross_entropy supports reduction 'mean' or 'sum'")
+    from torch_nntile.training import cross_entropy as _nntile_cross_entropy
+
+    return _nntile_cross_entropy(
+        input,
+        target,
+        reduction=reduction,
+        ignore_index=ignore_index,
+    )
+
+
+def patch_cross_entropy() -> None:
+    """Route ``torch.nn.functional.cross_entropy`` to the nntile implementation."""
+    F.cross_entropy = cross_entropy  # type: ignore[assignment]
+
+
+patch_cross_entropy()
+
+__all__ = ["cross_entropy", "patch_cross_entropy"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Routes `torch.nn.functional.cross_entropy` to the existing nntile cross-entropy implementation when logits are on `device="nntile"`, mirroring the `F.rms_norm` hook in `normalization.py`.

## Changes

- Add [`torch_nntile/torch_nntile/loss.py`](torch_nntile/torch_nntile/loss.py) with `cross_entropy()` wrapper and `patch_cross_entropy()`
- Import `loss` from [`torch_nntile/__init__.py`](torch_nntile/torch_nntile/__init__.py) so the patch applies on `import torch_nntile`
- Resolve deprecated `size_average` / `reduce` via `_Reduction.legacy_get_string` on the nntile path before validation (Bugbot fix)

## Behavior

- **CPU/CUDA tensors:** unchanged — delegates to the original `F.cross_entropy`
- **Nntile tensors:** delegates to existing `training.cross_entropy` / `_NntileCrossEntropy` / C++ path
- **Legacy args:** `size_average` / `reduce` are resolved the same way as native `F.cross_entropy` before nntile validation
- **Unsupported on nntile:** `weight`, `label_smoothing`, `reduction='none'` raise `ValueError` (same limits as before)

## Usage

```python
import torch
import torch.nn.functional as F
import torch_nntile

logits = model(x)  # device="nntile"
loss = F.cross_entropy(logits, targets, reduction="mean", ignore_index=-100)
```

## Out of scope

No C++, executor, test, example, or `train_full_batch_step` changes. `training.cross_entropy` remains available as the internal implementation.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30e8b512-5be2-4112-8c4f-4b2020b9cc56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30e8b512-5be2-4112-8c4f-4b2020b9cc56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

