### PR TITLE
Add embedding support to torch_nntile

### DIFF
--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -123,11 +123,17 @@ run through libnntile `TensorGraph` → `TileGraph` → `Runtime`:
 | GELU in-place (`gelu_`) | `tensor::gelu_inplace` / `tensor::gelutanh_inplace` |
 | GELU backward | `tensor::gelu_backward` or `tensor::gelutanh_backward` |
 | `linear` backward / `mm` | `tensor::gemm` |
+| `F.embedding` / `nn.Embedding` | `tensor::embedding` |
+| Embedding backward | `tensor::embedding_backward` |
 | `torch_nntile.training.cross_entropy` | `maxsumexp`, `logsumexp`, `total_sum_accum`, `softmax`, `subtract_indexed_outputs`; backward: chained `scale_slice`, `multiply_slice` |
 | `torch_nntile.training.SGD` | `tensor::sgd_step` (fused SGD with momentum) |
 
 PyTorch C-order shapes are converted to TensorGraph storage layout internally.
 Gradients use **PyTorch autograd** (not `NNGraph` autograd).
+
+**Embedding v1 limits:** `float32` weights only; `padding_idx` must be `-1`
+(default); `scale_grad_by_freq=False` and `sparse=False` only. Indices may stay
+on CPU while weights are on `device="nntile"`.
 
 ### CPU fallback control
 

--- a/torch_nntile/csrc/nntile_embedding.cpp
+++ b/torch_nntile/csrc/nntile_embedding.cpp
@@ -1,0 +1,195 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_embedding.cpp
+ */
+
+#include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
+
+#include <ATen/Functions.h>
+#include <ATen/TensorUtils.h>
+#include <torch/library.h>
+
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
+#include <nntile/base_types.hh>
+#endif
+
+#include <cstdint>
+#include <vector>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+bool is_nntile_device(c10::Device device)
+{
+    return device.type() == c10::DeviceType::PrivateUse1;
+}
+
+void check_embedding_optional_args(
+    int64_t padding_idx,
+    bool scale_grad_by_freq,
+    bool sparse)
+{
+    TORCH_CHECK(!sparse, "nntile embedding: sparse=True is not supported");
+    TORCH_CHECK(
+        !scale_grad_by_freq,
+        "nntile embedding: scale_grad_by_freq=True is not supported");
+    TORCH_CHECK(
+        padding_idx < 0,
+        "nntile embedding: padding_idx >= 0 is not supported");
+}
+
+void check_embedding_forward_inputs(
+    const at::Tensor &weight,
+    const at::Tensor &indices)
+{
+    TORCH_CHECK(
+        is_nntile_device(weight.device()),
+        "nntile embedding: weight must be on device nntile");
+    TORCH_CHECK(
+        indices.scalar_type() == at::ScalarType::Long,
+        "nntile embedding: indices must be int64");
+    TORCH_CHECK(
+        indices.is_cpu() || is_nntile_device(indices.device()),
+        "nntile embedding: indices must be CPU or nntile");
+    TORCH_CHECK(weight.dim() == 2, "nntile embedding: weight must be 2D");
+    TORCH_CHECK(
+        weight.scalar_type() == at::ScalarType::Float,
+        "nntile embedding supports float32 weight only");
+    TORCH_CHECK(
+        weight.is_contiguous() && indices.is_contiguous(),
+        "nntile embedding requires contiguous tensors");
+}
+
+void check_embedding_backward_inputs(
+    const at::Tensor &grad_output,
+    const at::Tensor &indices,
+    int64_t num_weights)
+{
+    TORCH_CHECK(
+        is_nntile_device(grad_output.device()),
+        "nntile embedding_dense_backward: grad_output must be on device nntile");
+    TORCH_CHECK(
+        indices.scalar_type() == at::ScalarType::Long,
+        "nntile embedding_dense_backward: indices must be int64");
+    TORCH_CHECK(
+        indices.is_cpu() || is_nntile_device(indices.device()),
+        "nntile embedding_dense_backward: indices must be CPU or nntile");
+    TORCH_CHECK(
+        grad_output.scalar_type() == at::ScalarType::Float,
+        "nntile embedding_dense_backward supports float32 only");
+    TORCH_CHECK(
+        grad_output.is_contiguous() && indices.is_contiguous(),
+        "nntile embedding_dense_backward requires contiguous tensors");
+    TORCH_CHECK(num_weights > 0, "nntile embedding_dense_backward: invalid num_weights");
+    TORCH_CHECK(
+        grad_output.dim() == indices.dim() + 1,
+        "nntile embedding_dense_backward: grad_output rank mismatch");
+    TORCH_CHECK(
+        grad_output.size(-1) > 0,
+        "nntile embedding_dense_backward: invalid embedding dimension");
+    for (int64_t i = 0; i < indices.dim(); ++i)
+    {
+        TORCH_CHECK(
+            grad_output.size(i) == indices.size(i),
+            "nntile embedding_dense_backward: shape mismatch");
+    }
+}
+
+at::Tensor prepare_indices(const at::Tensor &indices)
+{
+    return indices.is_contiguous() ? indices : indices.contiguous();
+}
+
+std::vector<int64_t> embedding_output_shape(
+    c10::IntArrayRef index_shape,
+    int64_t embed_dim)
+{
+    std::vector<int64_t> out_shape(index_shape.begin(), index_shape.end());
+    out_shape.push_back(embed_dim);
+    return out_shape;
+}
+
+} // namespace
+
+at::Tensor embedding(
+    const at::Tensor &weight,
+    const at::Tensor &indices,
+    int64_t padding_idx,
+    bool scale_grad_by_freq,
+    bool sparse)
+{
+    check_embedding_forward_inputs(weight, indices);
+    check_embedding_optional_args(padding_idx, scale_grad_by_freq, sparse);
+
+    const at::Tensor indices_contig = prepare_indices(indices);
+    const std::vector<int64_t> out_shape =
+        embedding_output_shape(indices_contig.sizes(), weight.size(1));
+    at::Tensor output = at::empty(
+        out_shape,
+        weight.options().memory_format(at::MemoryFormat::Contiguous));
+
+    const nntile::Index axis =
+        static_cast<nntile::Index>(indices_contig.dim());
+    pin_graph_op_inputs({weight, indices_contig});
+    pin_graph_op_output(output, true);
+    tensor_embedding_forward_fp32(
+        indices_contig.data_ptr<std::int64_t>(),
+        indices_contig.sizes(),
+        weight.data_ptr<float>(),
+        weight.sizes(),
+        output.data_ptr<float>(),
+        output.sizes(),
+        axis);
+    return output;
+}
+
+at::Tensor embedding_dense_backward(
+    const at::Tensor &grad_output,
+    const at::Tensor &indices,
+    int64_t num_weights,
+    int64_t padding_idx,
+    bool scale_grad_by_freq)
+{
+    check_embedding_backward_inputs(grad_output, indices, num_weights);
+    check_embedding_optional_args(padding_idx, scale_grad_by_freq, false);
+
+    const at::Tensor indices_contig = prepare_indices(indices);
+    const int64_t embed_dim = grad_output.size(-1);
+    TORCH_CHECK(
+        num_weights > 0 && embed_dim > 0,
+        "nntile embedding_dense_backward: invalid weight shape");
+
+    at::Tensor grad_weight = at::zeros(
+        {num_weights, embed_dim},
+        grad_output.options().memory_format(at::MemoryFormat::Contiguous));
+
+    const nntile::Index axis =
+        static_cast<nntile::Index>(indices_contig.dim());
+    pin_graph_op_inputs({grad_output, indices_contig});
+    pin_graph_op_output(grad_weight, false);
+    tensor_embedding_backward_fp32(
+        indices_contig.data_ptr<std::int64_t>(),
+        indices_contig.sizes(),
+        grad_output.data_ptr<float>(),
+        grad_output.sizes(),
+        grad_weight.data_ptr<float>(),
+        grad_weight.sizes(),
+        axis,
+        0);
+    return grad_weight;
+}
+
+} // namespace torch_nntile
+
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
+{
+    m.impl("embedding", TORCH_FN(torch_nntile::embedding));
+    m.impl(
+        "embedding_dense_backward",
+        TORCH_FN(torch_nntile::embedding_dense_backward));
+}

--- a/torch_nntile/csrc/nntile_executor.cpp
+++ b/torch_nntile/csrc/nntile_executor.cpp
@@ -21,6 +21,8 @@
 #include <nntile/tensor/ops/add_slice_inplace.hh>
 #include <nntile/tensor/ops/concat.hh>
 #include <nntile/tensor/ops/copy_intersection.hh>
+#include <nntile/tensor/ops/embedding.hh>
+#include <nntile/tensor/ops/embedding_backward.hh>
 #include <nntile/tensor/ops/multiply.hh>
 #include <nntile/tensor/ops/multiply_inplace.hh>
 #include <nntile/tensor/ops/clear.hh>
@@ -1706,6 +1708,87 @@ void tensor_split_with_sizes_fp32(
     maybe_execute_after_record();
 }
 
+void tensor_embedding_forward_fp32(
+    const std::int64_t *index_data,
+    c10::IntArrayRef index_shape,
+    const float *weight_data,
+    c10::IntArrayRef weight_shape,
+    float *out_data,
+    c10::IntArrayRef out_shape,
+    nntile::Index axis)
+{
+    const std::vector<nntile::Index> index_graph =
+        pytorch_shape_to_graph(index_shape);
+    const std::vector<nntile::Index> weight_graph =
+        pytorch_shape_to_graph(weight_shape);
+    const std::vector<nntile::Index> out_graph =
+        pytorch_shape_to_graph(out_shape);
+
+    auto *index_node = get_or_create_data_node(
+        const_cast<std::int64_t *>(index_data),
+        index_graph,
+        nntile::DataType::INT64,
+        true);
+    auto *weight_node = get_or_create_data_node(
+        const_cast<float *>(weight_data),
+        weight_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *out_node = get_or_create_data_node(
+        out_data,
+        out_graph,
+        nntile::DataType::FP32,
+        false);
+
+    nntile::tensor::embedding(index_node, weight_node, out_node, axis);
+    register_data_node(out_data, out_node);
+    maybe_execute_after_record();
+}
+
+void tensor_embedding_backward_fp32(
+    const std::int64_t *index_data,
+    c10::IntArrayRef index_shape,
+    const float *grad_out_data,
+    c10::IntArrayRef grad_out_shape,
+    float *grad_weight_data,
+    c10::IntArrayRef weight_shape,
+    nntile::Index axis,
+    int redux)
+{
+    const std::vector<nntile::Index> index_graph =
+        pytorch_shape_to_graph(index_shape);
+    const std::vector<nntile::Index> grad_out_graph =
+        pytorch_shape_to_graph(grad_out_shape);
+    const std::vector<nntile::Index> weight_graph =
+        pytorch_shape_to_graph(weight_shape);
+
+    auto *index_node = get_or_create_data_node(
+        const_cast<std::int64_t *>(index_data),
+        index_graph,
+        nntile::DataType::INT64,
+        true);
+    auto *grad_out_node = get_or_create_data_node(
+        const_cast<float *>(grad_out_data),
+        grad_out_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *grad_weight_node = get_or_create_data_node(
+        grad_weight_data,
+        weight_graph,
+        nntile::DataType::FP32,
+        false);
+
+    nntile::tensor::clear(grad_weight_node);
+    nntile::tensor::embedding_backward(
+        index_node,
+        grad_out_node,
+        grad_weight_node,
+        axis,
+        redux);
+    register_data_node(grad_weight_data, grad_weight_node);
+    maybe_execute_after_record();
+}
+
 } // namespace torch_nntile
 
 #else
@@ -2082,6 +2165,31 @@ void tensor_split_with_sizes_fp32(
     const std::vector<c10::IntArrayRef> & /*out_shapes*/)
 {
     require_libnntile("split_with_sizes");
+}
+
+void tensor_embedding_forward_fp32(
+    const std::int64_t * /*index_data*/,
+    c10::IntArrayRef /*index_shape*/,
+    const float * /*weight_data*/,
+    c10::IntArrayRef /*weight_shape*/,
+    float * /*out_data*/,
+    c10::IntArrayRef /*out_shape*/,
+    nntile::Index /*axis*/)
+{
+    require_libnntile("embedding");
+}
+
+void tensor_embedding_backward_fp32(
+    const std::int64_t * /*index_data*/,
+    c10::IntArrayRef /*index_shape*/,
+    const float * /*grad_out_data*/,
+    c10::IntArrayRef /*grad_out_shape*/,
+    float * /*grad_weight_data*/,
+    c10::IntArrayRef /*weight_shape*/,
+    nntile::Index /*axis*/,
+    int /*redux*/)
+{
+    require_libnntile("embedding_backward");
 }
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_executor.h
+++ b/torch_nntile/csrc/nntile_executor.h
@@ -10,7 +10,17 @@
 
 #include <c10/util/ArrayRef.h>
 
+#include <cstdint>
 #include <vector>
+
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
+#include <nntile/base_types.hh>
+#else
+namespace nntile
+{
+using Index = std::int64_t;
+} // namespace nntile
+#endif
 
 namespace torch_nntile
 {
@@ -277,5 +287,24 @@ void tensor_split_with_sizes_fp32(
     const std::vector<int64_t> &split_sizes,
     const std::vector<float *> &out_data,
     const std::vector<c10::IntArrayRef> &out_shapes);
+
+void tensor_embedding_forward_fp32(
+    const std::int64_t *index_data,
+    c10::IntArrayRef index_shape,
+    const float *weight_data,
+    c10::IntArrayRef weight_shape,
+    float *out_data,
+    c10::IntArrayRef out_shape,
+    nntile::Index axis);
+
+void tensor_embedding_backward_fp32(
+    const std::int64_t *index_data,
+    c10::IntArrayRef index_shape,
+    const float *grad_out_data,
+    c10::IntArrayRef grad_out_shape,
+    float *grad_weight_data,
+    c10::IntArrayRef weight_shape,
+    nntile::Index axis,
+    int redux);
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_kernels.cpp
+++ b/torch_nntile/csrc/nntile_kernels.cpp
@@ -203,6 +203,11 @@ at::Tensor &fill_scalar(at::Tensor &self, const at::Scalar &value)
     return self;
 }
 
+at::Tensor &zero_(at::Tensor &self)
+{
+    return fill_scalar(self, 0);
+}
+
 at::Tensor empty_memory_format(
     at::IntArrayRef size,
     std::optional<at::ScalarType> dtype_opt,
@@ -583,6 +588,7 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
     m.impl("_copy_from_and_resize", TORCH_FN(torch_nntile::copy_from_and_resize));
     m.impl("_local_scalar_dense", TORCH_FN(torch_nntile::local_scalar_dense));
     m.impl("fill_.Scalar", TORCH_FN(torch_nntile::fill_scalar));
+    m.impl("zero_", TORCH_FN(torch_nntile::zero_));
     m.impl("set_.source_Tensor", TORCH_FN(torch_nntile::set_source_tensor));
     m.impl("set_.source_Storage", TORCH_FN(torch_nntile::set_source_storage));
     m.impl(

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -50,6 +50,7 @@ CSRC = [
     "csrc/nntile_rms_norm.cpp",
     "csrc/nntile_broadcast.cpp",
     "csrc/nntile_repeat.cpp",
+    "csrc/nntile_embedding.cpp",
 ]
 
 

--- a/torch_nntile/tests/test_embedding_parity.py
+++ b/torch_nntile/tests/test_embedding_parity.py
@@ -1,0 +1,161 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_embedding_parity.py
+# Embedding parity: CPU PyTorch vs nntile tensor ops.
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import torch
+import pytest
+import torch.nn as nn
+import torch.nn.functional as F
+
+import torch_nntile
+from torch_nntile import _C
+
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+_PKG_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run_graph_subprocess(script: str) -> None:
+    env = dict(**__import__("os").environ)
+    repo = Path(__file__).resolve().parents[2]
+    build_lib = repo / "build" / "nntile"
+    starpu_lib = "/opt/starpu/lib"
+    ld = env.get("LD_LIBRARY_PATH", "")
+    for part in (str(build_lib), starpu_lib):
+        if part not in ld.split(":"):
+            ld = f"{part}:{ld}" if ld else part
+    env["LD_LIBRARY_PATH"] = ld
+    env["PYTHONPATH"] = f"{_PKG_ROOT}:{env.get('PYTHONPATH', '')}"
+    proc = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"subprocess failed ({proc.returncode})\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+
+@pytest.mark.parametrize("index_shape", [(8,), (4, 5), (2, 3, 4)])
+def test_embedding_forward_matches_cpu(index_shape):
+    torch.manual_seed(0)
+    num_embeddings, embed_dim = 16, 7
+    weight_cpu = torch.randn(num_embeddings, embed_dim, dtype=torch.float32)
+    indices = torch.randint(0, num_embeddings, index_shape)
+
+    out_cpu = F.embedding(indices, weight_cpu)
+    weight_nnt = weight_cpu.detach().to("nntile")
+    out_nnt = F.embedding(indices, weight_nnt)
+
+    assert torch.allclose(out_nnt.detach().cpu(), out_cpu, rtol=1e-5, atol=1e-5)
+
+
+def test_embedding_backward_matches_cpu():
+    torch.manual_seed(1)
+    num_embeddings, embed_dim = 12, 6
+    indices = torch.randint(0, num_embeddings, (5, 4))
+
+    weight_cpu = nn.Embedding(num_embeddings, embed_dim)
+    torch.nn.init.normal_(weight_cpu.weight, mean=0.0, std=0.1)
+    weight_cpu.weight.requires_grad_(True)
+
+    out_cpu = weight_cpu(indices)
+    out_cpu.sum().backward()
+    grad_cpu = weight_cpu.weight.grad.detach().clone()
+
+    weight_nnt = nn.Embedding(num_embeddings, embed_dim).to("nntile")
+    with torch.no_grad():
+        weight_nnt.weight.copy_(weight_cpu.weight.detach())
+    weight_nnt.weight.requires_grad_(True)
+
+    out_nnt = weight_nnt(indices)
+    grad_out = torch.ones_like(out_cpu).to("nntile")
+    torch.autograd.backward([out_nnt], [grad_out])
+    grad_nnt = weight_nnt.weight.grad.cpu()
+
+    assert torch.allclose(grad_nnt, grad_cpu, rtol=1e-5, atol=1e-5)
+
+
+def test_embedding_duplicate_indices():
+    torch.manual_seed(2)
+    num_embeddings, embed_dim = 6, 4
+    indices = torch.tensor([0, 1, 0, 2, 1, 0])
+
+    weight_cpu = nn.Embedding(num_embeddings, embed_dim)
+    torch.nn.init.normal_(weight_cpu.weight, mean=0.0, std=0.2)
+    weight_cpu.weight.requires_grad_(True)
+
+    out_cpu = weight_cpu(indices)
+    out_cpu.sum().backward()
+    grad_cpu = weight_cpu.weight.grad.detach().clone()
+
+    weight_nnt = nn.Embedding(num_embeddings, embed_dim).to("nntile")
+    with torch.no_grad():
+        weight_nnt.weight.copy_(weight_cpu.weight.detach())
+    weight_nnt.weight.requires_grad_(True)
+
+    out_nnt = weight_nnt(indices)
+    grad_out = torch.ones_like(out_cpu).to("nntile")
+    torch.autograd.backward([out_nnt], [grad_out])
+    grad_nnt = weight_nnt.weight.grad.cpu()
+
+    assert torch.allclose(grad_nnt, grad_cpu, rtol=1e-5, atol=1e-5)
+
+
+def test_embedding_indices_on_cpu():
+    torch.manual_seed(3)
+    num_embeddings, embed_dim = 10, 5
+    indices = torch.randint(0, num_embeddings, (3, 3))
+    weight_cpu = torch.randn(num_embeddings, embed_dim, dtype=torch.float32)
+
+    out_cpu = F.embedding(indices, weight_cpu)
+    weight_nnt = weight_cpu.detach().to("nntile")
+    out_nnt = F.embedding(indices, weight_nnt)
+
+    assert indices.device.type == "cpu"
+    assert torch.allclose(out_nnt.detach().cpu(), out_cpu, rtol=1e-5, atol=1e-5)
+
+
+def test_embedding_graph_mode():
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch.nn.functional as F
+        import torch_nntile
+
+        torch.manual_seed(4)
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+
+        num_embeddings, embed_dim = 8, 4
+        indices = torch.randint(0, num_embeddings, (2, 3))
+        weight_cpu = torch.randn(num_embeddings, embed_dim, dtype=torch.float32)
+        out_cpu = F.embedding(indices, weight_cpu)
+
+        weight_nnt = weight_cpu.detach().to("nntile")
+        out_nnt = F.embedding(indices, weight_nnt)
+        assert torch_nntile.has_pending_graph()
+        torch_nntile.compile_graph()
+        torch_nntile.run()
+        assert torch.allclose(
+            out_nnt.detach().cpu(), out_cpu, rtol=1e-5, atol=1e-5
+        )
+        """
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `F.embedding` / `nn.Embedding` support on `device="nntile"` by wiring libnntile `tensor::embedding` and `tensor::embedding_backward` through the existing ATen dispatch + executor bridge pattern.

## Changes

- **`nntile_embedding.cpp`**: PrivateUse1 kernels for `aten::embedding` and `aten::embedding_dense_backward`
- **`nntile_executor.{h,cpp}`**: `tensor_embedding_forward_fp32` / `tensor_embedding_backward_fp32` bridge functions
- **`nntile_kernels.cpp`**: `aten::zero_` registration (needed for embedding autograd grad buffer init)
- **`test_embedding_parity.py`**: Forward/backward parity, duplicate indices, CPU indices, graph mode
- **`README.md`**: Phase 2 op table + v1 limitations

## v1 limitations

- `float32` weights only
- `padding_idx` must be `-1` (default)
- `scale_grad_by_freq=False` and `sparse=False` only
- Indices may remain on CPU while weights are on nntile

## Testing

```bash
export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
cd torch_nntile && pytest -vv tests/test_embedding_parity.py
pytest -vv tests/test_graph_execution.py
```

All 7 embedding parity tests and 11 graph execution regression tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-634646f7-f043-414b-9c03-fd9728ef9dff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-634646f7-f043-414b-9c03-fd9728ef9dff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

