### PR TITLE
Add F.softmax / nn.Softmax support to torch_nntile

### DIFF
--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -122,6 +122,8 @@ run through libnntile `TensorGraph` → `TileGraph` → `Runtime`:
 | `F.gelu` (`approximate='tanh'`) | `tensor::gelutanh` |
 | GELU in-place (`gelu_`) | `tensor::gelu_inplace` / `tensor::gelutanh_inplace` |
 | GELU backward | `tensor::gelu_backward` or `tensor::gelutanh_backward` |
+| `F.softmax` / `nn.Softmax` | `tensor::maxsumexp` + `tensor::softmax` |
+| Softmax backward | `tensor::sumprod_slice`, `tensor::add_slice`, `tensor::multiply_inplace` |
 | `linear` backward / `mm` | `tensor::gemm` |
 | `F.embedding` / `nn.Embedding` | `tensor::embedding` |
 | Embedding backward | `tensor::embedding_backward` |

--- a/torch_nntile/csrc/nntile_executor.cpp
+++ b/torch_nntile/csrc/nntile_executor.cpp
@@ -624,15 +624,18 @@ namespace
 constexpr int kRedux = 0;
 
 std::vector<nntile::Index> maxsumexp_graph_shape(
-    const std::vector<nntile::Index> &logits_graph)
+    const std::vector<nntile::Index> &input_graph,
+    nntile::Index axis)
 {
-    const nntile::Index class_axis =
-        static_cast<nntile::Index>(logits_graph.size()) - 1;
     std::vector<nntile::Index> maxsumexp_shape;
-    maxsumexp_shape.reserve(logits_graph.size());
-    for (nntile::Index i = 0; i < class_axis; ++i)
+    maxsumexp_shape.reserve(input_graph.size());
+    for (nntile::Index i = 0; i < static_cast<nntile::Index>(input_graph.size());
+         ++i)
     {
-        maxsumexp_shape.push_back(logits_graph[static_cast<std::size_t>(i)]);
+        if (i != axis)
+        {
+            maxsumexp_shape.push_back(input_graph[static_cast<std::size_t>(i)]);
+        }
     }
     maxsumexp_shape.push_back(2);
     return maxsumexp_shape;
@@ -688,9 +691,9 @@ void tensor_cross_entropy_forward_fp32(
         pytorch_shape_to_graph(logits_shape);
     const std::vector<nntile::Index> labels_graph =
         pytorch_shape_to_graph(labels_shape);
-    const std::vector<nntile::Index> maxsumexp_graph =
-        maxsumexp_graph_shape(logits_graph);
     const nntile::Index class_axis = class_graph_axis(logits_shape);
+    const std::vector<nntile::Index> maxsumexp_graph =
+        maxsumexp_graph_shape(logits_graph, class_axis);
     const float scale = cross_entropy_scale(
         labels_data,
         labels_shape,
@@ -755,9 +758,9 @@ void tensor_cross_entropy_backward_fp32(
         pytorch_shape_to_graph(logits_shape);
     const std::vector<nntile::Index> labels_graph =
         pytorch_shape_to_graph(labels_shape);
-    const std::vector<nntile::Index> maxsumexp_graph =
-        maxsumexp_graph_shape(logits_graph);
     const nntile::Index class_axis = class_graph_axis(logits_shape);
+    const std::vector<nntile::Index> maxsumexp_graph =
+        maxsumexp_graph_shape(logits_graph, class_axis);
     const float ce_scale = cross_entropy_scale(
         labels_data,
         labels_shape,
@@ -856,6 +859,51 @@ void tensor_cross_entropy_backward_fp32(
         class_axis);
 
     register_data_node(grad_logits_data, grad_logits_node);
+    maybe_execute_after_record();
+}
+
+void tensor_softmax_fp32(
+    const float *input_data,
+    float *out_data,
+    c10::IntArrayRef pytorch_shape,
+    int64_t dim)
+{
+    const std::vector<nntile::Index> input_graph =
+        pytorch_shape_to_graph(pytorch_shape);
+    const nntile::Index axis = static_cast<nntile::Index>(dim);
+    const std::vector<nntile::Index> maxsumexp_graph =
+        maxsumexp_graph_shape(input_graph, axis);
+
+    auto *src_node = get_or_create_data_node(
+        const_cast<float *>(input_data),
+        input_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *dst_node = get_or_create_data_node(
+        out_data,
+        input_graph,
+        nntile::DataType::FP32,
+        true);
+
+    auto &graph = *src_node->graph();
+    auto *maxsumexp_node =
+        graph.data(maxsumexp_graph, nntile::DataType::FP32)
+            ->set_name("maxsumexp");
+
+    nntile::tensor::clear(maxsumexp_node);
+    nntile::tensor::maxsumexp(
+        src_node,
+        maxsumexp_node,
+        axis,
+        kRedux);
+    nntile::tensor::softmax(
+        maxsumexp_node,
+        src_node,
+        dst_node,
+        static_cast<nntile::Scalar>(1.0),
+        axis);
+
+    register_data_node(out_data, dst_node);
     maybe_execute_after_record();
 }
 
@@ -962,6 +1010,64 @@ void broadcast_slice_to_keepdim(
 }
 
 } // namespace
+
+void tensor_softmax_backward_fp32(
+    const float *grad_output_data,
+    const float *output_data,
+    float *grad_input_data,
+    c10::IntArrayRef pytorch_shape,
+    int64_t dim)
+{
+    const std::vector<nntile::Index> input_graph =
+        pytorch_shape_to_graph(pytorch_shape);
+    const nntile::Index axis = static_cast<nntile::Index>(dim);
+    const std::vector<nntile::Index> reduced_graph =
+        reduced_shape_along_axis(input_graph, axis);
+
+    auto *grad_output_node = get_or_create_data_node(
+        const_cast<float *>(grad_output_data),
+        input_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *output_node = get_or_create_data_node(
+        const_cast<float *>(output_data),
+        input_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *grad_input_node = get_or_create_data_node(
+        grad_input_data,
+        input_graph,
+        nntile::DataType::FP32,
+        true);
+
+    nntile::TensorGraph &graph = *output_node->graph();
+    auto *sumprod_buf = make_graph_tensor(graph, reduced_graph, "sumprod_buf");
+    auto *grad_temp = make_graph_tensor(graph, input_graph, "grad_temp");
+
+    nntile::tensor::sumprod_slice(
+        output_node,
+        grad_output_node,
+        sumprod_buf,
+        axis,
+        kNormRedux,
+        static_cast<nntile::Scalar>(1.0),
+        static_cast<nntile::Scalar>(0.0));
+    nntile::tensor::add_slice(
+        static_cast<nntile::Scalar>(-1.0),
+        sumprod_buf,
+        static_cast<nntile::Scalar>(1.0),
+        grad_output_node,
+        grad_temp,
+        axis);
+    nntile::tensor::multiply_inplace(
+        static_cast<nntile::Scalar>(1.0),
+        output_node,
+        grad_temp);
+    nntile::tensor::copy(grad_temp, grad_input_node);
+
+    register_data_node(grad_input_data, grad_input_node);
+    maybe_execute_after_record();
+}
 
 void tensor_layer_norm_forward_fp32(
     const float *input_data,
@@ -2275,6 +2381,25 @@ void tensor_cross_entropy_backward_fp32(
     bool /*mean_reduction*/)
 {
     require_libnntile("cross_entropy_backward");
+}
+
+void tensor_softmax_fp32(
+    const float * /*input_data*/,
+    float * /*out_data*/,
+    c10::IntArrayRef /*pytorch_shape*/,
+    int64_t /*dim*/)
+{
+    require_libnntile("softmax");
+}
+
+void tensor_softmax_backward_fp32(
+    const float * /*grad_output_data*/,
+    const float * /*output_data*/,
+    float * /*grad_input_data*/,
+    c10::IntArrayRef /*pytorch_shape*/,
+    int64_t /*dim*/)
+{
+    require_libnntile("softmax_backward");
 }
 
 void tensor_sgd_step_fp32(

--- a/torch_nntile/csrc/nntile_executor.h
+++ b/torch_nntile/csrc/nntile_executor.h
@@ -173,6 +173,19 @@ void tensor_cross_entropy_backward_fp32(
     std::int64_t ignore_index,
     bool mean_reduction);
 
+void tensor_softmax_fp32(
+    const float *input_data,
+    float *out_data,
+    c10::IntArrayRef pytorch_shape,
+    int64_t dim);
+
+void tensor_softmax_backward_fp32(
+    const float *grad_output_data,
+    const float *output_data,
+    float *grad_input_data,
+    c10::IntArrayRef pytorch_shape,
+    int64_t dim);
+
 void tensor_sgd_step_fp32(
     int64_t num_iter,
     float momentum,

--- a/torch_nntile/csrc/nntile_softmax.cpp
+++ b/torch_nntile/csrc/nntile_softmax.cpp
@@ -1,0 +1,107 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_softmax.cpp
+ */
+
+#include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
+
+#include <ATen/Functions.h>
+#include <ATen/TensorUtils.h>
+#include <torch/library.h>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+bool is_nntile_device(c10::Device device)
+{
+    return device.type() == c10::DeviceType::PrivateUse1;
+}
+
+void check_softmax_input(
+    const at::Tensor &self,
+    int64_t dim,
+    bool half_to_float,
+    const std::optional<at::Tensor> &out = std::nullopt)
+{
+    TORCH_CHECK(
+        is_nntile_device(self.device()),
+        "nntile softmax: expected nntile");
+    if (out.has_value())
+    {
+        TORCH_CHECK(
+            is_nntile_device(out->device()),
+            "nntile softmax.out: expected nntile output");
+    }
+    TORCH_CHECK(
+        !half_to_float,
+        "nntile softmax does not support half_to_float=True");
+    TORCH_CHECK(
+        self.scalar_type() == at::ScalarType::Float,
+        "nntile softmax supports float32 only");
+    TORCH_CHECK(self.is_contiguous(), "nntile softmax requires contiguous input");
+    TORCH_CHECK(
+        self.dim() > 0,
+        "nntile softmax: cannot compute softmax on empty tensor");
+    at::maybe_wrap_dim(dim, self.dim());
+    if (out.has_value())
+    {
+        TORCH_CHECK(
+            out->sizes() == self.sizes(),
+            "nntile softmax.out: output shape mismatch");
+        TORCH_CHECK(
+            out->is_contiguous(),
+            "nntile softmax.out requires contiguous out");
+    }
+}
+
+void run_softmax(
+    const at::Tensor &self,
+    int64_t dim,
+    at::Tensor &out)
+{
+    const int64_t wrapped_dim = at::maybe_wrap_dim(dim, self.dim());
+    pin_graph_op_inputs({self});
+    pin_graph_op_output(out, true);
+    tensor_softmax_fp32(
+        self.data_ptr<float>(),
+        out.data_ptr<float>(),
+        self.sizes(),
+        wrapped_dim);
+}
+
+} // namespace
+
+at::Tensor softmax(
+    const at::Tensor &self,
+    int64_t dim,
+    bool half_to_float)
+{
+    check_softmax_input(self, dim, half_to_float);
+    at::Tensor out = at::empty_like(self);
+    run_softmax(self, dim, out);
+    return out;
+}
+
+at::Tensor &softmax_out(
+    const at::Tensor &self,
+    int64_t dim,
+    bool half_to_float,
+    at::Tensor &out)
+{
+    check_softmax_input(self, dim, half_to_float, out);
+    run_softmax(self, dim, out);
+    return out;
+}
+
+} // namespace torch_nntile
+
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
+{
+    m.impl("_softmax", TORCH_FN(torch_nntile::softmax));
+    m.impl("_softmax.out", TORCH_FN(torch_nntile::softmax_out));
+}

--- a/torch_nntile/csrc/nntile_softmax_backward.cpp
+++ b/torch_nntile/csrc/nntile_softmax_backward.cpp
@@ -1,0 +1,92 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_softmax_backward.cpp
+ */
+
+#include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
+
+#include <ATen/Functions.h>
+#include <ATen/TensorUtils.h>
+#include <torch/library.h>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+bool is_nntile_device(c10::Device device)
+{
+    return device.type() == c10::DeviceType::PrivateUse1;
+}
+
+void check_softmax_backward(
+    const at::Tensor &grad_output,
+    const at::Tensor &output,
+    int64_t dim,
+    at::ScalarType input_dtype)
+{
+    TORCH_CHECK(
+        is_nntile_device(grad_output.device()) &&
+            is_nntile_device(output.device()),
+        "nntile softmax_backward expects nntile tensors");
+    TORCH_CHECK(
+        input_dtype == at::ScalarType::Float,
+        "nntile softmax_backward supports float32 input only");
+    TORCH_CHECK(
+        grad_output.scalar_type() == at::ScalarType::Float &&
+            output.scalar_type() == at::ScalarType::Float,
+        "nntile softmax_backward supports float32 only");
+    TORCH_CHECK(
+        grad_output.sizes() == output.sizes(),
+        "nntile softmax_backward: shape mismatch");
+    TORCH_CHECK(
+        grad_output.is_contiguous() && output.is_contiguous(),
+        "nntile softmax_backward requires contiguous tensors");
+    TORCH_CHECK(
+        output.dim() > 0,
+        "nntile softmax_backward: cannot compute on empty tensor");
+    at::maybe_wrap_dim(dim, output.dim());
+}
+
+void run_softmax_backward(
+    const at::Tensor &grad_output,
+    const at::Tensor &output,
+    int64_t dim,
+    at::Tensor &grad_input)
+{
+    const int64_t wrapped_dim = at::maybe_wrap_dim(dim, output.dim());
+    pin_graph_op_inputs({output, grad_output});
+    pin_graph_op_output(grad_input, true);
+    tensor_softmax_backward_fp32(
+        grad_output.data_ptr<float>(),
+        output.data_ptr<float>(),
+        grad_input.data_ptr<float>(),
+        output.sizes(),
+        wrapped_dim);
+}
+
+} // namespace
+
+at::Tensor softmax_backward_data(
+    const at::Tensor &grad_output,
+    const at::Tensor &output,
+    int64_t dim,
+    at::ScalarType input_dtype)
+{
+    check_softmax_backward(grad_output, output, dim, input_dtype);
+    at::Tensor grad_input = at::empty_like(output);
+    run_softmax_backward(grad_output, output, dim, grad_input);
+    return grad_input;
+}
+
+} // namespace torch_nntile
+
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
+{
+    m.impl(
+        "_softmax_backward_data",
+        TORCH_FN(torch_nntile::softmax_backward_data));
+}

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -39,6 +39,8 @@ CSRC = [
     "csrc/nntile_silu_backward.cpp",
     "csrc/nntile_gelu.cpp",
     "csrc/nntile_gelu_backward.cpp",
+    "csrc/nntile_softmax.cpp",
+    "csrc/nntile_softmax_backward.cpp",
     "csrc/nntile_mm.cpp",
     "csrc/nntile_bmm.cpp",
     "csrc/nntile_addmm.cpp",

--- a/torch_nntile/tests/test_softmax_parity.py
+++ b/torch_nntile/tests/test_softmax_parity.py
@@ -1,0 +1,93 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_softmax_parity.py
+# Softmax forward/backward parity: CPU PyTorch vs nntile.
+
+import torch
+import pytest
+
+import torch_nntile
+from torch_nntile import _C
+
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _nntile_context_no_fallback():
+    if not _C.has_libnntile():
+        return
+    if torch_nntile.is_cpu_fallback_enabled():
+        pytest.skip(
+            "context has CPU fallback enabled; rebuild with cpu_fallback=False"
+        )
+    yield
+
+
+@pytest.fixture
+def random_input():
+    torch.manual_seed(0)
+    return torch.randn(4, 8)
+
+
+def test_softmax_forward_matches_cpu(random_input):
+    x_cpu = random_input
+    y_cpu = torch.nn.functional.softmax(x_cpu, dim=-1)
+
+    x_nnt = x_cpu.to("nntile")
+    y_nnt = torch.nn.functional.softmax(x_nnt, dim=-1).cpu()
+
+    assert torch.allclose(y_nnt, y_cpu, rtol=1e-4, atol=1e-4)
+
+
+def test_softmax_forward_dim0(random_input):
+    x_cpu = random_input
+    y_cpu = torch.nn.functional.softmax(x_cpu, dim=0)
+
+    x_nnt = x_cpu.to("nntile")
+    y_nnt = torch.nn.functional.softmax(x_nnt, dim=0).cpu()
+
+    assert torch.allclose(y_nnt, y_cpu, rtol=1e-4, atol=1e-4)
+
+
+def test_softmax_backward_matches_cpu(random_input):
+    x_cpu = random_input.clone().requires_grad_(True)
+    y_cpu = torch.nn.functional.softmax(x_cpu, dim=-1)
+    y_cpu.backward(torch.ones_like(y_cpu))
+
+    x_nnt = x_cpu.detach().to("nntile").requires_grad_(True)
+    y_nnt = torch.nn.functional.softmax(x_nnt, dim=-1)
+    y_nnt.backward(torch.ones(y_nnt.shape, device="cpu").to("nntile"))
+
+    assert torch.allclose(x_nnt.grad.cpu(), x_cpu.grad, rtol=1e-4, atol=1e-4)
+
+
+def test_softmax_backward_dim0(random_input):
+    x_cpu = random_input.clone().requires_grad_(True)
+    y_cpu = torch.nn.functional.softmax(x_cpu, dim=0)
+    y_cpu.backward(torch.ones_like(y_cpu))
+
+    x_nnt = x_cpu.detach().to("nntile").requires_grad_(True)
+    y_nnt = torch.nn.functional.softmax(x_nnt, dim=0)
+    y_nnt.backward(torch.ones(y_nnt.shape, device="cpu").to("nntile"))
+
+    assert torch.allclose(x_nnt.grad.cpu(), x_cpu.grad, rtol=1e-4, atol=1e-4)
+
+
+def test_nn_softmax_module(random_input):
+    x_cpu = random_input.clone().requires_grad_(True)
+    module_cpu = torch.nn.Softmax(dim=1)
+    y_cpu = module_cpu(x_cpu)
+    y_cpu.backward(torch.ones_like(y_cpu))
+
+    x_nnt = x_cpu.detach().to("nntile").requires_grad_(True)
+    module_nnt = torch.nn.Softmax(dim=1)
+    y_nnt = module_nnt(x_nnt)
+    y_nnt.backward(torch.ones(y_nnt.shape, device="cpu").to("nntile"))
+
+    assert torch.allclose(y_nnt.cpu(), y_cpu, rtol=1e-4, atol=1e-4)
+    assert torch.allclose(x_nnt.grad.cpu(), x_cpu.grad, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `torch.nn.functional.softmax` and `nn.Softmax` on the `nntile` (PrivateUse1) device by registering PyTorch ATen ops `_softmax`, `_softmax.out`, and `_softmax_backward_data`.

## Changes

- **Forward:** `tensor::maxsumexp` + `tensor::softmax` via new `tensor_softmax_fp32` executor function
- **Backward:** Composed from `tensor::sumprod_slice`, `tensor::add_slice`, and `tensor::multiply_inplace` (same formula as `NNSoftmaxOp` in libnntile)
- **Refactor:** Generalized `maxsumexp_graph_shape` to accept an arbitrary axis (cross-entropy call sites updated)
- **New files:** `nntile_softmax.cpp`, `nntile_softmax_backward.cpp`
- **Tests:** `test_softmax_parity.py` — forward/backward parity for `dim=-1`, `dim=0`, and `nn.Softmax`

## Limitations (v1)

- `float32` contiguous tensors only
- `half_to_float=True` not supported
- `F.log_softmax` not included (follow-up)

## Testing

```bash
pytest -vv torch_nntile/tests/test_softmax_parity.py
```

All 5 parity tests pass on CPU-only build with libnntile.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85be4cf9-3c1e-4817-9564-770f86f2f99e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85be4cf9-3c1e-4817-9564-770f86f2f99e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

