### PR TITLE
Add torch_nntile.nn.SDPA and attention weight layout converters

### DIFF
--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -125,6 +125,8 @@ run through libnntile `TensorGraph` → `TileGraph` → `Runtime`:
 | `linear` backward / `mm` | `tensor::gemm` |
 | `F.embedding` / `nn.Embedding` | `tensor::embedding` |
 | Embedding backward | `tensor::embedding_backward` |
+| `torch_nntile.nn.SDPA` / `sdpa_eager` | `gemm`, `maxsumexp`, `softmax_inplace`, optional `mask_scalar`; backward: `gemm`, `sumprod_slice`, `add_slice_inplace`, `multiply_inplace` |
+| `torch_nntile.nn.weight_layout` | Pure PyTorch permutes for HF ↔ NNTile attention weights (no kernel) |
 | `torch_nntile.training.cross_entropy` | `maxsumexp`, `logsumexp`, `total_sum_accum`, `softmax`, `subtract_indexed_outputs`; backward: chained `scale_slice`, `multiply_slice` |
 | `torch_nntile.training.SGD` | `tensor::sgd_step` (fused SGD with momentum) |
 
@@ -134,6 +136,13 @@ Gradients use **PyTorch autograd** (not `NNGraph` autograd).
 **Embedding v1 limits:** `float32` weights only; `padding_idx` must be `-1`
 (default); `scale_grad_by_freq=False` and `sparse=False` only. Indices may stay
 on CPU while weights are on `device="nntile"`.
+
+**SDPA v1 limits:** `float32` only; `runtime_mode='eager'` only; Q/K/V on
+`device="nntile"` in NNTile layout `[batch..., seq, head_size]` (e.g.
+`(n_heads, batch, seq, head_size)` with `batch_ndim=2`); optional BOOL mask
+`[k_seq, q_seq]` on CPU or nntile; fixed scale `1/sqrt(head_size)`. Use
+`torch_nntile.nn.weight_layout` to convert HF/PyTorch attention weights before
+NNTile-layout projection GEMMs. No dropout, causal flag, GQA, or custom scale.
 
 ### Gradient accumulation
 
@@ -314,6 +323,8 @@ Cross-entropy parity (forward, backward, multi-D labels, `ignore_index`):
 
 ```bash
 pytest -vv torch_nntile/tests/test_cross_entropy_parity.py
+pytest -vv torch_nntile/tests/test_sdpa_parity.py
+pytest -vv torch_nntile/tests/test_attn_weight_layout.py
 ```
 
 ## Install from source (stub only)

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -137,7 +137,7 @@ Gradients use **PyTorch autograd** (not `NNGraph` autograd).
 (default); `scale_grad_by_freq=False` and `sparse=False` only. Indices may stay
 on CPU while weights are on `device="nntile"`.
 
-**SDPA v1 limits:** `float32` only; `runtime_mode='eager'` only; Q/K/V on
+**SDPA v1 limits:** `float32` only; Q/K/V on
 `device="nntile"` in NNTile layout `[batch..., seq, head_size]` (e.g.
 `(n_heads, batch, seq, head_size)` with `batch_ndim=2`); optional BOOL mask
 `[k_seq, q_seq]` on CPU or nntile; fixed scale `1/sqrt(head_size)`. Use

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -140,7 +140,9 @@ on CPU while weights are on `device="nntile"`.
 **SDPA v1 limits:** `float32` only; Q/K/V on
 `device="nntile"` in NNTile layout `[batch..., seq, head_size]` (e.g.
 `(n_heads, batch, seq, head_size)` with `batch_ndim=2`); optional BOOL mask
-`[k_seq, q_seq]` on CPU or nntile; fixed scale `1/sqrt(head_size)`. Use
+`[k_seq, q_seq]` on CPU or nntile; fixed scale `1/sqrt(head_size)`. Works in
+both eager and graph runtime modes (graph defers execution until
+``compile_graph()`` / ``run()`` or ``execute()``). Use
 `torch_nntile.nn.weight_layout` to convert HF/PyTorch attention weights before
 NNTile-layout projection GEMMs. No dropout, causal flag, GQA, or custom scale.
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -140,7 +140,8 @@ on CPU while weights are on `device="nntile"`.
 **SDPA v1 limits:** `float32` only; Q/K/V on
 `device="nntile"` in NNTile layout `[batch..., seq, head_size]` (e.g.
 `(n_heads, batch, seq, head_size)` with `batch_ndim=2`); optional BOOL mask
-`[k_seq, q_seq]` on CPU or nntile; fixed scale `1/sqrt(head_size)`. Works in
+`[q_seq, k_seq]` on CPU or nntile (dim0 = query axis, dim1 = key axis, same as
+GPT-2 `attn_mask` / ``sdpa_causal_mask_bool_fill``); fixed scale `1/sqrt(head_size)`. Works in
 both eager and graph runtime modes (graph defers execution until
 ``compile_graph()`` / ``run()`` or ``execute()``). Use
 `torch_nntile.nn.weight_layout` to convert HF/PyTorch attention weights before

--- a/torch_nntile/csrc/nntile_executor.cpp
+++ b/torch_nntile/csrc/nntile_executor.cpp
@@ -31,6 +31,7 @@
 #include <nntile/tensor/ops/hypot.hh>
 #include <nntile/tensor/ops/hypot_scalar_inverse.hh>
 #include <nntile/tensor/ops/logsumexp.hh>
+#include <nntile/tensor/ops/mask_scalar.hh>
 #include <nntile/tensor/ops/maxsumexp.hh>
 #include <nntile/tensor/ops/gelu.hh>
 #include <nntile/tensor/ops/gelu_backward.hh>
@@ -53,6 +54,7 @@
 #include <nntile/tensor/ops/sgd_step.hh>
 #include <nntile/tensor/ops/scale_slice.hh>
 #include <nntile/tensor/ops/softmax.hh>
+#include <nntile/tensor/ops/softmax_inplace.hh>
 #include <nntile/tensor/ops/subtract_indexed_outputs.hh>
 #include <nntile/tensor/ops/sum_fiber.hh>
 #include <nntile/tensor/ops/sum_slice.hh>
@@ -62,6 +64,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 #include <vector>
 
@@ -2044,6 +2047,329 @@ void tensor_embedding_backward_fp32(
     maybe_execute_after_record();
 }
 
+namespace
+{
+
+constexpr float kSdpaMaskVal =
+    -std::numeric_limits<float>::infinity();
+constexpr int kSdpaRedux = 0;
+
+nntile::TensorGraph::TensorNode *make_sdpa_temp_tensor(
+    nntile::TensorGraph &graph,
+    const std::vector<nntile::Index> &shape,
+    const char *name)
+{
+    auto *node = graph.data(shape, nntile::DataType::FP32)->set_name(name);
+    track_graph_node(node);
+    return node;
+}
+
+nntile::TensorGraph::TensorNode *compute_sdpa_attn(
+    nntile::TensorGraph::TensorNode *q_node,
+    nntile::TensorGraph::TensorNode *k_node,
+    nntile::TensorGraph::TensorNode *mask_node,
+    nntile::Index batch_ndim,
+    float scale)
+{
+    const auto &q_shape = q_node->shape();
+    const auto &k_shape = k_node->shape();
+    const nntile::Index q_ndim = static_cast<nntile::Index>(q_shape.size());
+    const nntile::Index q_seq = q_shape[static_cast<std::size_t>(q_ndim - 2)];
+    const nntile::Index k_seq = k_shape[static_cast<std::size_t>(q_ndim - 2)];
+
+    std::vector<nntile::Index> batch_shape(
+        q_shape.begin(),
+        q_shape.begin() + static_cast<ptrdiff_t>(batch_ndim));
+
+    std::vector<nntile::Index> attn_shape = batch_shape;
+    attn_shape.push_back(q_seq);
+    attn_shape.push_back(k_seq);
+
+    nntile::TensorGraph &graph = *q_node->graph();
+    auto *attn_node = make_sdpa_temp_tensor(graph, attn_shape, "sdpa_attn");
+    nntile::tensor::gemm(
+        q_node,
+        k_node,
+        attn_node,
+        static_cast<nntile::Scalar>(scale),
+        static_cast<nntile::Scalar>(0.0),
+        false,
+        true,
+        static_cast<nntile::Index>(1),
+        batch_ndim);
+
+    if (mask_node != nullptr)
+    {
+        nntile::tensor::mask_scalar(
+            mask_node,
+            static_cast<nntile::Scalar>(kSdpaMaskVal),
+            attn_node,
+            batch_ndim);
+    }
+
+    std::vector<nntile::Index> maxsumexp_shape = batch_shape;
+    maxsumexp_shape.push_back(q_seq);
+    maxsumexp_shape.push_back(static_cast<nntile::Index>(2));
+    auto *maxsumexp_node =
+        make_sdpa_temp_tensor(graph, maxsumexp_shape, "sdpa_maxsumexp");
+    nntile::tensor::clear(maxsumexp_node);
+
+    const nntile::Index attn_axis = q_ndim - 1;
+    nntile::tensor::maxsumexp(
+        attn_node,
+        maxsumexp_node,
+        attn_axis,
+        kSdpaRedux);
+    nntile::tensor::softmax_inplace(
+        maxsumexp_node,
+        attn_node,
+        static_cast<nntile::Scalar>(1.0),
+        attn_axis);
+
+    return attn_node;
+}
+
+} // namespace
+
+void tensor_sdpa_forward_fp32(
+    const float *q_data,
+    c10::IntArrayRef q_shape,
+    const float *k_data,
+    c10::IntArrayRef k_shape,
+    const float *v_data,
+    c10::IntArrayRef v_shape,
+    const std::uint8_t *mask_data,
+    c10::IntArrayRef mask_shape,
+    float *out_data,
+    int64_t batch_ndim)
+{
+    const std::vector<nntile::Index> q_graph = pytorch_shape_to_graph(q_shape);
+    const std::vector<nntile::Index> k_graph = pytorch_shape_to_graph(k_shape);
+    const std::vector<nntile::Index> v_graph = pytorch_shape_to_graph(v_shape);
+    const nntile::Index batch_ndim_graph =
+        static_cast<nntile::Index>(batch_ndim);
+    const nntile::Index q_ndim = static_cast<nntile::Index>(q_graph.size());
+    const nntile::Index head_size = q_graph[static_cast<std::size_t>(q_ndim - 1)];
+    const float scale =
+        1.0f / std::sqrt(static_cast<float>(static_cast<std::int64_t>(head_size)));
+
+    auto *q_node = get_or_create_data_node(
+        const_cast<float *>(q_data),
+        q_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *k_node = get_or_create_data_node(
+        const_cast<float *>(k_data),
+        k_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *v_node = get_or_create_data_node(
+        const_cast<float *>(v_data),
+        v_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *out_node = get_or_create_data_node(
+        out_data,
+        q_graph,
+        nntile::DataType::FP32,
+        false);
+
+    nntile::TensorGraph::TensorNode *mask_node = nullptr;
+    if (mask_data != nullptr)
+    {
+        const std::vector<nntile::Index> mask_graph =
+            pytorch_shape_to_graph(mask_shape);
+        mask_node = get_or_create_data_node(
+            const_cast<std::uint8_t *>(mask_data),
+            mask_graph,
+            nntile::DataType::BOOL,
+            true);
+    }
+
+    auto *attn_node = compute_sdpa_attn(
+        q_node,
+        k_node,
+        mask_node,
+        batch_ndim_graph,
+        scale);
+    nntile::tensor::gemm(
+        attn_node,
+        v_node,
+        out_node,
+        static_cast<nntile::Scalar>(1.0),
+        static_cast<nntile::Scalar>(0.0),
+        false,
+        false,
+        static_cast<nntile::Index>(1),
+        batch_ndim_graph);
+    register_data_node(out_data, out_node);
+    maybe_execute_after_record();
+}
+
+void tensor_sdpa_backward_fp32(
+    const float *q_data,
+    c10::IntArrayRef q_shape,
+    const float *k_data,
+    c10::IntArrayRef k_shape,
+    const float *v_data,
+    c10::IntArrayRef v_shape,
+    const std::uint8_t *mask_data,
+    c10::IntArrayRef mask_shape,
+    const float *grad_out_data,
+    float *grad_q_data,
+    float *grad_k_data,
+    float *grad_v_data,
+    int64_t batch_ndim)
+{
+    const std::vector<nntile::Index> q_graph = pytorch_shape_to_graph(q_shape);
+    const std::vector<nntile::Index> k_graph = pytorch_shape_to_graph(k_shape);
+    const std::vector<nntile::Index> v_graph = pytorch_shape_to_graph(v_shape);
+    const nntile::Index batch_ndim_graph =
+        static_cast<nntile::Index>(batch_ndim);
+    const nntile::Index q_ndim = static_cast<nntile::Index>(q_graph.size());
+    const nntile::Index head_size = q_graph[static_cast<std::size_t>(q_ndim - 1)];
+    const nntile::Index q_seq = q_graph[static_cast<std::size_t>(q_ndim - 2)];
+    const float scale =
+        1.0f / std::sqrt(static_cast<float>(static_cast<std::int64_t>(head_size)));
+
+    auto *q_node = get_or_create_data_node(
+        const_cast<float *>(q_data),
+        q_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *k_node = get_or_create_data_node(
+        const_cast<float *>(k_data),
+        k_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *v_node = get_or_create_data_node(
+        const_cast<float *>(v_data),
+        v_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *grad_out_node = get_or_create_data_node(
+        const_cast<float *>(grad_out_data),
+        q_graph,
+        nntile::DataType::FP32,
+        true);
+
+    nntile::TensorGraph::TensorNode *mask_node = nullptr;
+    if (mask_data != nullptr)
+    {
+        const std::vector<nntile::Index> mask_graph =
+            pytorch_shape_to_graph(mask_shape);
+        mask_node = get_or_create_data_node(
+            const_cast<std::uint8_t *>(mask_data),
+            mask_graph,
+            nntile::DataType::BOOL,
+            true);
+    }
+
+    nntile::TensorGraph &graph = *q_node->graph();
+    auto *attn_node = compute_sdpa_attn(
+        q_node,
+        k_node,
+        mask_node,
+        batch_ndim_graph,
+        scale);
+
+    std::vector<nntile::Index> batch_shape(
+        q_graph.begin(),
+        q_graph.begin() + static_cast<ptrdiff_t>(batch_ndim_graph));
+    std::vector<nntile::Index> attn_shape = batch_shape;
+    attn_shape.push_back(q_seq);
+    attn_shape.push_back(k_graph[static_cast<std::size_t>(q_ndim - 2)]);
+    std::vector<nntile::Index> sumprod_shape = batch_shape;
+    sumprod_shape.push_back(q_seq);
+
+    auto *grad_temp = make_sdpa_temp_tensor(graph, attn_shape, "sdpa_grad_temp");
+    auto *sumprod_buf = make_sdpa_temp_tensor(graph, sumprod_shape, "sdpa_sumprod");
+
+    auto *grad_v_node = get_or_create_data_node(
+        grad_v_data,
+        v_graph,
+        nntile::DataType::FP32,
+        false);
+    nntile::tensor::gemm(
+        attn_node,
+        grad_out_node,
+        grad_v_node,
+        static_cast<nntile::Scalar>(1.0),
+        static_cast<nntile::Scalar>(0.0),
+        true,
+        false,
+        static_cast<nntile::Index>(1),
+        batch_ndim_graph);
+
+    nntile::tensor::gemm(
+        grad_out_node,
+        v_node,
+        grad_temp,
+        static_cast<nntile::Scalar>(1.0),
+        static_cast<nntile::Scalar>(0.0),
+        false,
+        true,
+        static_cast<nntile::Index>(1),
+        batch_ndim_graph);
+
+    const nntile::Index attn_axis = q_ndim - 1;
+    nntile::tensor::sumprod_slice(
+        attn_node,
+        grad_temp,
+        sumprod_buf,
+        attn_axis,
+        kSdpaRedux,
+        static_cast<nntile::Scalar>(1.0),
+        static_cast<nntile::Scalar>(0.0));
+    nntile::tensor::add_slice_inplace(
+        static_cast<nntile::Scalar>(-1.0),
+        sumprod_buf,
+        static_cast<nntile::Scalar>(1.0),
+        grad_temp,
+        attn_axis);
+    nntile::tensor::multiply_inplace(
+        static_cast<nntile::Scalar>(1.0),
+        attn_node,
+        grad_temp);
+
+    auto *grad_q_node = get_or_create_data_node(
+        grad_q_data,
+        q_graph,
+        nntile::DataType::FP32,
+        false);
+    nntile::tensor::gemm(
+        grad_temp,
+        k_node,
+        grad_q_node,
+        static_cast<nntile::Scalar>(scale),
+        static_cast<nntile::Scalar>(0.0),
+        false,
+        false,
+        static_cast<nntile::Index>(1),
+        batch_ndim_graph);
+
+    auto *grad_k_node = get_or_create_data_node(
+        grad_k_data,
+        k_graph,
+        nntile::DataType::FP32,
+        false);
+    nntile::tensor::gemm(
+        grad_temp,
+        q_node,
+        grad_k_node,
+        static_cast<nntile::Scalar>(scale),
+        static_cast<nntile::Scalar>(0.0),
+        true,
+        false,
+        static_cast<nntile::Index>(1),
+        batch_ndim_graph);
+
+    register_data_node(grad_v_data, grad_v_node);
+    register_data_node(grad_q_data, grad_q_node);
+    register_data_node(grad_k_data, grad_k_node);
+    maybe_execute_after_record();
+}
+
 } // namespace torch_nntile
 
 #else
@@ -2483,6 +2809,39 @@ void tensor_embedding_backward_fp32(
     int /*redux*/)
 {
     require_libnntile("embedding_backward");
+}
+
+void tensor_sdpa_forward_fp32(
+    const float * /*q_data*/,
+    c10::IntArrayRef /*q_shape*/,
+    const float * /*k_data*/,
+    c10::IntArrayRef /*k_shape*/,
+    const float * /*v_data*/,
+    c10::IntArrayRef /*v_shape*/,
+    const std::uint8_t * /*mask_data*/,
+    c10::IntArrayRef /*mask_shape*/,
+    float * /*out_data*/,
+    int64_t /*batch_ndim*/)
+{
+    require_libnntile("sdpa_forward");
+}
+
+void tensor_sdpa_backward_fp32(
+    const float * /*q_data*/,
+    c10::IntArrayRef /*q_shape*/,
+    const float * /*k_data*/,
+    c10::IntArrayRef /*k_shape*/,
+    const float * /*v_data*/,
+    c10::IntArrayRef /*v_shape*/,
+    const std::uint8_t * /*mask_data*/,
+    c10::IntArrayRef /*mask_shape*/,
+    const float * /*grad_out_data*/,
+    float * /*grad_q_data*/,
+    float * /*grad_k_data*/,
+    float * /*grad_v_data*/,
+    int64_t /*batch_ndim*/)
+{
+    require_libnntile("sdpa_backward");
 }
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_executor.h
+++ b/torch_nntile/csrc/nntile_executor.h
@@ -333,4 +333,31 @@ void tensor_embedding_backward_fp32(
     nntile::Index axis,
     int redux);
 
+void tensor_sdpa_forward_fp32(
+    const float *q_data,
+    c10::IntArrayRef q_shape,
+    const float *k_data,
+    c10::IntArrayRef k_shape,
+    const float *v_data,
+    c10::IntArrayRef v_shape,
+    const std::uint8_t *mask_data,
+    c10::IntArrayRef mask_shape,
+    float *out_data,
+    int64_t batch_ndim);
+
+void tensor_sdpa_backward_fp32(
+    const float *q_data,
+    c10::IntArrayRef q_shape,
+    const float *k_data,
+    c10::IntArrayRef k_shape,
+    const float *v_data,
+    c10::IntArrayRef v_shape,
+    const std::uint8_t *mask_data,
+    c10::IntArrayRef mask_shape,
+    const float *grad_out_data,
+    float *grad_q_data,
+    float *grad_k_data,
+    float *grad_v_data,
+    int64_t batch_ndim);
+
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -294,6 +294,12 @@ void bind_storage_to_runtime(
             static_cast<const std::int64_t *>(data_ptr),
             count);
         break;
+    case nntile::DataType::BOOL:
+        runtime.bind_data(
+            target,
+            reinterpret_cast<const bool *>(data_ptr),
+            count);
+        break;
     default:
         throw std::runtime_error(
             "torch_nntile graph recorder: unsupported bind dtype");

--- a/torch_nntile/csrc/nntile_module.cpp
+++ b/torch_nntile/csrc/nntile_module.cpp
@@ -21,6 +21,7 @@
 #include "nntile_context.h"
 #include "nntile_cross_entropy.h"
 #include "nntile_rms_norm.h"
+#include "nntile_sdpa.h"
 #include "nntile_norm.h"
 #include "nntile_graph_recorder.h"
 #include "nntile_sgd_step.h"
@@ -362,6 +363,25 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         py::arg("rstd"),
         py::arg("weight") = py::none(),
         py::arg("output_mask"));
+    m.def(
+        "sdpa_forward",
+        &torch_nntile::sdpa_forward,
+        "NNTile SDPA eager forward (NNTile tensor layout)",
+        py::arg("q"),
+        py::arg("k"),
+        py::arg("v"),
+        py::arg("mask") = py::none(),
+        py::arg("batch_ndim") = 2);
+    m.def(
+        "sdpa_backward",
+        &torch_nntile::sdpa_backward,
+        "NNTile SDPA eager backward",
+        py::arg("q"),
+        py::arg("k"),
+        py::arg("v"),
+        py::arg("grad_out"),
+        py::arg("mask") = py::none(),
+        py::arg("batch_ndim") = 2);
     m.def(
         "norm_forward",
         [](const at::Tensor &input,

--- a/torch_nntile/csrc/nntile_sdpa.cpp
+++ b/torch_nntile/csrc/nntile_sdpa.cpp
@@ -6,7 +6,6 @@
 
 #include "nntile_sdpa.h"
 
-#include "nntile_context.h"
 #include "nntile_executor.h"
 #include "nntile_graph_recorder_impl.h"
 
@@ -24,13 +23,6 @@ namespace
 bool is_nntile_device(c10::Device device)
 {
     return device.type() == c10::DeviceType::PrivateUse1;
-}
-
-void check_sdpa_runtime_mode()
-{
-    TORCH_CHECK(
-        get_runtime_mode() == RuntimeMode::Eager,
-        "nntile sdpa: only supported in runtime_mode='eager'");
 }
 
 void check_sdpa_tensor(
@@ -98,7 +90,6 @@ at::Tensor sdpa_forward(
     const std::optional<at::Tensor> &mask,
     int64_t batch_ndim)
 {
-    check_sdpa_runtime_mode();
     check_sdpa_qkv(q, k, v, batch_ndim);
     if (mask.has_value())
     {
@@ -157,7 +148,6 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> sdpa_backward(
     const std::optional<at::Tensor> &mask,
     int64_t batch_ndim)
 {
-    check_sdpa_runtime_mode();
     check_sdpa_qkv(q, k, v, batch_ndim);
     check_sdpa_tensor(grad_out, "grad_out");
     if (mask.has_value())

--- a/torch_nntile/csrc/nntile_sdpa.cpp
+++ b/torch_nntile/csrc/nntile_sdpa.cpp
@@ -1,0 +1,220 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_sdpa.cpp
+ */
+
+#include "nntile_sdpa.h"
+
+#include "nntile_context.h"
+#include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
+
+#include <ATen/Functions.h>
+#include <ATen/TensorUtils.h>
+
+#include <cmath>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+bool is_nntile_device(c10::Device device)
+{
+    return device.type() == c10::DeviceType::PrivateUse1;
+}
+
+void check_sdpa_runtime_mode()
+{
+    TORCH_CHECK(
+        get_runtime_mode() == RuntimeMode::Eager,
+        "nntile sdpa: only supported in runtime_mode='eager'");
+}
+
+void check_sdpa_tensor(
+    const at::Tensor &tensor,
+    const char *name)
+{
+    TORCH_CHECK(
+        is_nntile_device(tensor.device()),
+        "nntile sdpa: expected nntile ",
+        name);
+    TORCH_CHECK(
+        tensor.scalar_type() == at::ScalarType::Float,
+        "nntile sdpa supports float32 only");
+    TORCH_CHECK(tensor.is_contiguous(), "nntile sdpa requires contiguous");
+    TORCH_CHECK(tensor.dim() >= 3, "nntile sdpa: tensor rank must be >= 3");
+}
+
+void check_sdpa_qkv(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &v,
+    int64_t batch_ndim)
+{
+    check_sdpa_tensor(q, "q");
+    check_sdpa_tensor(k, "k");
+    check_sdpa_tensor(v, "v");
+    TORCH_CHECK(
+        q.sizes() == k.sizes() && q.sizes() == v.sizes(),
+        "nntile sdpa: Q, K, V must have the same shape");
+    TORCH_CHECK(
+        batch_ndim >= 1 && batch_ndim <= q.dim() - 2,
+        "nntile sdpa: invalid batch_ndim");
+}
+
+void check_sdpa_mask(
+    const at::Tensor &mask,
+    const at::Tensor &q)
+{
+    TORCH_CHECK(
+        mask.scalar_type() == at::ScalarType::Bool ||
+            mask.scalar_type() == at::ScalarType::Byte,
+        "nntile sdpa: mask must be bool or uint8");
+    TORCH_CHECK(
+        mask.is_contiguous(),
+        "nntile sdpa: mask must be contiguous");
+    TORCH_CHECK(
+        mask.is_cpu() || is_nntile_device(mask.device()),
+        "nntile sdpa: mask must be on CPU or nntile");
+    const int64_t q_ndim = q.dim();
+    const int64_t q_seq = q.size(q_ndim - 2);
+    const int64_t k_seq = q.size(q_ndim - 2);
+    TORCH_CHECK(
+        mask.dim() == 2 &&
+            mask.size(0) == k_seq &&
+            mask.size(1) == q_seq,
+        "nntile sdpa: mask shape must be [k_seq, q_seq]");
+}
+
+} // namespace
+
+at::Tensor sdpa_forward(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const std::optional<at::Tensor> &mask,
+    int64_t batch_ndim)
+{
+    check_sdpa_runtime_mode();
+    check_sdpa_qkv(q, k, v, batch_ndim);
+    if (mask.has_value())
+    {
+        TORCH_CHECK(
+            mask->scalar_type() == at::ScalarType::Bool ||
+                mask->scalar_type() == at::ScalarType::Byte,
+            "nntile sdpa: mask must be bool or uint8");
+        check_sdpa_mask(*mask, q);
+    }
+
+    at::Tensor out = at::empty_like(q);
+    at::Tensor mask_u8;
+    std::vector<at::Tensor> inputs = {q, k, v};
+    if (mask.has_value())
+    {
+        if (mask->scalar_type() == at::ScalarType::Bool)
+        {
+            mask_u8 = mask->to(at::kByte);
+        }
+        else
+        {
+            mask_u8 = *mask;
+        }
+        inputs.push_back(mask_u8);
+    }
+    pin_graph_op_inputs(inputs);
+    pin_graph_op_output(out, true);
+
+    const std::uint8_t *mask_data = nullptr;
+    c10::IntArrayRef mask_shape;
+    if (mask.has_value())
+    {
+        mask_data = mask_u8.data_ptr<std::uint8_t>();
+        mask_shape = mask_u8.sizes();
+    }
+
+    tensor_sdpa_forward_fp32(
+        q.data_ptr<float>(),
+        q.sizes(),
+        k.data_ptr<float>(),
+        k.sizes(),
+        v.data_ptr<float>(),
+        v.sizes(),
+        mask_data,
+        mask_shape,
+        out.data_ptr<float>(),
+        batch_ndim);
+    return out;
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> sdpa_backward(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &grad_out,
+    const std::optional<at::Tensor> &mask,
+    int64_t batch_ndim)
+{
+    check_sdpa_runtime_mode();
+    check_sdpa_qkv(q, k, v, batch_ndim);
+    check_sdpa_tensor(grad_out, "grad_out");
+    if (mask.has_value())
+    {
+        TORCH_CHECK(
+            mask->scalar_type() == at::ScalarType::Bool ||
+                mask->scalar_type() == at::ScalarType::Byte,
+            "nntile sdpa: mask must be bool or uint8");
+        check_sdpa_mask(*mask, q);
+    }
+
+    at::Tensor grad_q = at::empty_like(q);
+    at::Tensor grad_k = at::empty_like(k);
+    at::Tensor grad_v = at::empty_like(v);
+
+    at::Tensor mask_u8;
+    std::vector<at::Tensor> inputs = {q, k, v, grad_out};
+    if (mask.has_value())
+    {
+        if (mask->scalar_type() == at::ScalarType::Bool)
+        {
+            mask_u8 = mask->to(at::kByte);
+        }
+        else
+        {
+            mask_u8 = *mask;
+        }
+        inputs.push_back(mask_u8);
+    }
+    pin_graph_op_inputs(inputs);
+    pin_graph_op_output(grad_q, false);
+    pin_graph_op_output(grad_k, false);
+    pin_graph_op_output(grad_v, false);
+
+    const std::uint8_t *mask_data = nullptr;
+    c10::IntArrayRef mask_shape;
+    if (mask.has_value())
+    {
+        mask_data = mask_u8.data_ptr<std::uint8_t>();
+        mask_shape = mask_u8.sizes();
+    }
+
+    tensor_sdpa_backward_fp32(
+        q.data_ptr<float>(),
+        q.sizes(),
+        k.data_ptr<float>(),
+        k.sizes(),
+        v.data_ptr<float>(),
+        v.sizes(),
+        mask_data,
+        mask_shape,
+        grad_out.data_ptr<float>(),
+        grad_q.data_ptr<float>(),
+        grad_k.data_ptr<float>(),
+        grad_v.data_ptr<float>(),
+        batch_ndim);
+    return {grad_q, grad_k, grad_v};
+}
+
+} // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_sdpa.cpp
+++ b/torch_nntile/csrc/nntile_sdpa.cpp
@@ -59,7 +59,8 @@ void check_sdpa_qkv(
 
 void check_sdpa_mask(
     const at::Tensor &mask,
-    const at::Tensor &q)
+    const at::Tensor &q,
+    const at::Tensor &k)
 {
     TORCH_CHECK(
         mask.scalar_type() == at::ScalarType::Bool ||
@@ -72,13 +73,14 @@ void check_sdpa_mask(
         mask.is_cpu() || is_nntile_device(mask.device()),
         "nntile sdpa: mask must be on CPU or nntile");
     const int64_t q_ndim = q.dim();
+    const int64_t k_ndim = k.dim();
     const int64_t q_seq = q.size(q_ndim - 2);
-    const int64_t k_seq = q.size(q_ndim - 2);
+    const int64_t k_seq = k.size(k_ndim - 2);
     TORCH_CHECK(
         mask.dim() == 2 &&
-            mask.size(0) == k_seq &&
-            mask.size(1) == q_seq,
-        "nntile sdpa: mask shape must be [k_seq, q_seq]");
+            mask.size(0) == q_seq &&
+            mask.size(1) == k_seq,
+        "nntile sdpa: mask shape must be [q_seq, k_seq]");
 }
 
 } // namespace
@@ -97,7 +99,7 @@ at::Tensor sdpa_forward(
             mask->scalar_type() == at::ScalarType::Bool ||
                 mask->scalar_type() == at::ScalarType::Byte,
             "nntile sdpa: mask must be bool or uint8");
-        check_sdpa_mask(*mask, q);
+        check_sdpa_mask(*mask, q, k);
     }
 
     at::Tensor out = at::empty_like(q);
@@ -150,13 +152,16 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> sdpa_backward(
 {
     check_sdpa_qkv(q, k, v, batch_ndim);
     check_sdpa_tensor(grad_out, "grad_out");
+    TORCH_CHECK(
+        grad_out.sizes() == q.sizes(),
+        "nntile sdpa_backward: grad_out shape must match Q");
     if (mask.has_value())
     {
         TORCH_CHECK(
             mask->scalar_type() == at::ScalarType::Bool ||
                 mask->scalar_type() == at::ScalarType::Byte,
             "nntile sdpa: mask must be bool or uint8");
-        check_sdpa_mask(*mask, q);
+        check_sdpa_mask(*mask, q, k);
     }
 
     at::Tensor grad_q = at::empty_like(q);

--- a/torch_nntile/csrc/nntile_sdpa.h
+++ b/torch_nntile/csrc/nntile_sdpa.h
@@ -1,0 +1,32 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_sdpa.h
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+
+#include <cstdint>
+#include <tuple>
+
+namespace torch_nntile
+{
+
+at::Tensor sdpa_forward(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const std::optional<at::Tensor> &mask,
+    int64_t batch_ndim);
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> sdpa_backward(
+    const at::Tensor &q,
+    const at::Tensor &k,
+    const at::Tensor &v,
+    const at::Tensor &grad_out,
+    const std::optional<at::Tensor> &mask,
+    int64_t batch_ndim);
+
+} // namespace torch_nntile

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -52,6 +52,7 @@ CSRC = [
     "csrc/nntile_broadcast.cpp",
     "csrc/nntile_repeat.cpp",
     "csrc/nntile_embedding.cpp",
+    "csrc/nntile_sdpa.cpp",
 ]
 
 

--- a/torch_nntile/tests/test_attn_weight_layout.py
+++ b/torch_nntile/tests/test_attn_weight_layout.py
@@ -1,0 +1,73 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_attn_weight_layout.py
+# Attention weight layout conversion tests.
+
+from __future__ import annotations
+
+import torch
+
+from torch_nntile.nn.weight_layout import (
+    convert_attn_weights,
+    nntile_to_torch_o_weight,
+    nntile_to_torch_qkv_weight,
+    torch_to_nntile_o_weight,
+    torch_to_nntile_qkv_weight,
+)
+
+
+def test_qkv_weight_round_trip():
+    hidden, n_heads, head_size = 32, 4, 8
+    w = torch.randn(hidden, n_heads, head_size)
+    w_nt = torch_to_nntile_qkv_weight(w)
+    assert w_nt.shape == (hidden, head_size, n_heads)
+    w_rt = nntile_to_torch_qkv_weight(w_nt)
+    assert torch.equal(w, w_rt)
+
+
+def test_o_weight_round_trip():
+    n_heads, head_size, hidden = 4, 8, 32
+    w = torch.randn(n_heads, head_size, hidden)
+    w_nt = torch_to_nntile_o_weight(w)
+    assert w_nt.shape == (head_size, n_heads, hidden)
+    w_rt = nntile_to_torch_o_weight(w_nt)
+    assert torch.equal(w, w_rt)
+
+
+def test_convert_attn_weights_torch_to_nntile():
+    weights = {
+        "attn.q_weight": torch.randn(32, 4, 8),
+        "attn.k_weight": torch.randn(32, 4, 8),
+        "attn.v_weight": torch.randn(32, 4, 8),
+        "attn.o_weight": torch.randn(4, 8, 32),
+        "attn.q_bias": torch.randn(4, 8),
+    }
+    out = convert_attn_weights(weights, "torch_to_nntile")
+    assert out["attn.q_weight"].shape == (32, 8, 4)
+    assert out["attn.o_weight"].shape == (8, 4, 32)
+    assert torch.equal(out["attn.q_bias"], weights["attn.q_bias"])
+
+
+def test_convert_attn_weights_matches_generate_test_data_layout():
+    """Match ``generate_test_data._gpt2_attn_weights`` axis swaps."""
+    hidden, n_heads, head_size = 64, 4, 16
+    # HF-style stacked c_attn slice as (hidden, n_heads, head_size)
+    hf_q = torch.randn(hidden, n_heads, head_size)
+    nnt_q = hf_q.transpose(1, 2).contiguous()
+    assert torch.equal(torch_to_nntile_qkv_weight(hf_q), nnt_q)
+
+    hf_o = torch.randn(n_heads, head_size, hidden)
+    nnt_o = hf_o.transpose(0, 1).contiguous()
+    assert torch.equal(torch_to_nntile_o_weight(hf_o), nnt_o)
+
+    round_trip = convert_attn_weights(
+        {
+            "attn.q_weight": hf_q,
+            "attn.o_weight": hf_o,
+        },
+        "torch_to_nntile",
+    )
+    back = convert_attn_weights(round_trip, "nntile_to_torch")
+    assert torch.equal(back["attn.q_weight"], hf_q)
+    assert torch.equal(back["attn.o_weight"], hf_o)

--- a/torch_nntile/tests/test_sdpa_parity.py
+++ b/torch_nntile/tests/test_sdpa_parity.py
@@ -121,9 +121,9 @@ def test_sdpa_forward_with_mask_matches_reference():
     k_cpu = torch.randn(*shape)
     v_cpu = torch.randn(*shape)
     mask = torch.zeros(seq, seq, dtype=torch.bool)
-    for key in range(seq):
-        for query in range(seq):
-            mask[key, query] = key <= query
+    for query in range(seq):
+        for key in range(seq):
+            mask[query, key] = key <= query
 
     ref = _reference_sdpa_eager(q_cpu, k_cpu, v_cpu, mask)
     out = sdpa_eager(
@@ -134,6 +134,61 @@ def test_sdpa_forward_with_mask_matches_reference():
         batch_ndim=2,
     )
     assert torch.allclose(out.cpu(), ref, rtol=1e-4, atol=1e-4)
+
+
+def test_sdpa_mask_axis_order_matches_causal_layout():
+    """Mask dim0=query, dim1=key (libnntile sdpa_causal_mask_bool_fill layout)."""
+    shape = (1, 1, 5, 8)
+    seq = shape[2]
+    torch.manual_seed(7)
+    q_cpu = torch.randn(*shape)
+    k_cpu = torch.randn(*shape)
+    v_cpu = torch.randn(*shape)
+    mask = torch.zeros(seq, seq, dtype=torch.bool)
+    for query in range(seq):
+        for key in range(seq):
+            mask[query, key] = key <= query
+
+    ref = _reference_sdpa_eager(q_cpu, k_cpu, v_cpu, mask)
+    out = sdpa_eager(
+        q_cpu.to("nntile"),
+        k_cpu.to("nntile"),
+        v_cpu.to("nntile"),
+        mask,
+        batch_ndim=2,
+    )
+    assert torch.allclose(out.cpu(), ref, rtol=1e-4, atol=1e-4)
+
+    # Asymmetric pattern: only (query=2, key=3) allowed. Transposed mask must differ.
+    mask_sparse = torch.zeros(seq, seq, dtype=torch.bool)
+    mask_sparse[2, 3] = True
+    out_sparse = sdpa_eager(
+        q_cpu.to("nntile"),
+        k_cpu.to("nntile"),
+        v_cpu.to("nntile"),
+        mask_sparse,
+        batch_ndim=2,
+    )
+    out_transposed_mask = sdpa_eager(
+        q_cpu.to("nntile"),
+        k_cpu.to("nntile"),
+        v_cpu.to("nntile"),
+        mask_sparse.t().contiguous(),
+        batch_ndim=2,
+    )
+    assert not torch.allclose(
+        out_sparse.cpu(), out_transposed_mask.cpu(), rtol=1e-4, atol=1e-4
+    )
+
+
+def test_sdpa_backward_rejects_mismatched_grad_out():
+    shape = (2, 1, 4, 8)
+    q = torch.randn(*shape).to("nntile")
+    k = torch.randn(*shape).to("nntile")
+    v = torch.randn(*shape).to("nntile")
+    bad_grad = torch.randn(2, 1, 3, 8).to("nntile")
+    with pytest.raises(RuntimeError, match="grad_out shape must match"):
+        _C.sdpa_backward(q, k, v, bad_grad, None, 2)
 
 
 def test_sdpa_module_forward():

--- a/torch_nntile/tests/test_sdpa_parity.py
+++ b/torch_nntile/tests/test_sdpa_parity.py
@@ -153,31 +153,75 @@ def test_sdpa_rejects_cpu_tensors():
         sdpa_eager(q, k, v)
 
 
-def test_sdpa_rejects_graph_mode():
+def test_sdpa_graph_mode_deferred_until_execute():
     import subprocess
     import sys
+    import textwrap
     from pathlib import Path
 
     root = Path(__file__).resolve().parents[1]
-    script = f"""
-import sys
-sys.path.insert(0, {str(root)!r})
-import torch
-import torch_nntile
-from torch_nntile.nn import sdpa_eager
+    repo = Path(__file__).resolve().parents[2]
+    env = dict(**__import__("os").environ)
+    build_lib = repo / "build" / "nntile"
+    starpu_lib = "/opt/starpu/lib"
+    ld = env.get("LD_LIBRARY_PATH", "")
+    for part in (str(build_lib), starpu_lib):
+        if part not in ld.split(":"):
+            ld = f"{part}:{ld}" if ld else part
+    env["LD_LIBRARY_PATH"] = ld
+    env["PYTHONPATH"] = f"{root}:{env.get('PYTHONPATH', '')}"
 
-torch_nntile.init_context(
-    ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
-)
-torch_nntile.restrict_cpu()
-q = torch.randn(2, 1, 4, 8).to("nntile")
-k = torch.randn(2, 1, 4, 8).to("nntile")
-v = torch.randn(2, 1, 4, 8).to("nntile")
-try:
-    sdpa_eager(q, k, v)
-except RuntimeError as exc:
-    assert "runtime_mode='eager'" in str(exc)
-else:
-    raise AssertionError("expected RuntimeError")
-"""
-    subprocess.check_call([sys.executable, "-c", script])
+    script = textwrap.dedent(
+        """
+        import torch
+        import torch_nntile
+        from torch_nntile.nn import sdpa_eager
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+
+        shape = (2, 1, 4, 8)
+        q_cpu = torch.randn(*shape, requires_grad=True)
+        k_cpu = torch.randn(*shape, requires_grad=True)
+        v_cpu = torch.randn(*shape, requires_grad=True)
+        ref = torch.einsum(
+            "...ce,...ed->...cd",
+            torch.softmax(
+                torch.einsum("...ed,...cd->...ce", k_cpu, q_cpu)
+                * (shape[-1] ** -0.5),
+                dim=-1,
+            ),
+            v_cpu,
+        )
+        grad_out = torch.randn_like(ref)
+        ref.backward(grad_out)
+
+        q = q_cpu.detach().to("nntile").requires_grad_(True)
+        k = k_cpu.detach().to("nntile").requires_grad_(True)
+        v = v_cpu.detach().to("nntile").requires_grad_(True)
+        out = sdpa_eager(q, k, v, batch_ndim=2)
+        assert torch_nntile.has_pending_graph()
+        out.backward(grad_out.to("nntile"))
+        assert torch_nntile.has_pending_graph()
+        torch_nntile.execute()
+        assert not torch_nntile.has_pending_graph()
+        assert torch.allclose(out.detach().cpu(), ref, rtol=1e-4, atol=1e-4)
+        assert torch.allclose(q.grad.cpu(), q_cpu.grad, rtol=1e-4, atol=1e-4)
+        assert torch.allclose(k.grad.cpu(), k_cpu.grad, rtol=1e-4, atol=1e-4)
+        assert torch.allclose(v.grad.cpu(), v_cpu.grad, rtol=1e-4, atol=1e-4)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"subprocess failed ({proc.returncode})\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )

--- a/torch_nntile/tests/test_sdpa_parity.py
+++ b/torch_nntile/tests/test_sdpa_parity.py
@@ -1,0 +1,183 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_sdpa_parity.py
+# SDPA eager parity vs NNTile-layout reference implementation.
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+import torch_nntile
+from torch_nntile import _C
+from torch_nntile.nn import SDPA, sdpa_eager
+
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _nntile_context_no_fallback():
+    if not _C.has_libnntile():
+        return
+    if torch_nntile.is_cpu_fallback_enabled():
+        pytest.skip(
+            "context has CPU fallback enabled; rebuild with cpu_fallback=False"
+        )
+    if not torch_nntile.is_context_initialized():
+        torch_nntile.init_context(
+            ncpu=1,
+            ncuda=0,
+            verbose=0,
+            cpu_fallback=False,
+            runtime_mode="eager",
+        )
+    torch_nntile.restrict_cpu()
+    yield
+
+
+def _reference_sdpa_eager(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    mask: torch.Tensor | None,
+) -> torch.Tensor:
+    head_size = q.shape[-1]
+    scale = 1.0 / math.sqrt(float(head_size))
+    scores = torch.einsum("...ed,...cd->...ce", k, q) * scale
+    if mask is not None:
+        mask_expanded = mask.to(dtype=torch.bool, device=scores.device)
+        while mask_expanded.dim() < scores.dim():
+            mask_expanded = mask_expanded.unsqueeze(0)
+        expand_shape = list(scores.shape[:-2]) + [
+            mask_expanded.size(-2),
+            mask_expanded.size(-1),
+        ]
+        mask_expanded = mask_expanded.expand(expand_shape)
+        scores = torch.where(
+            mask_expanded,
+            scores,
+            torch.full_like(scores, -math.inf),
+        )
+    attn = torch.softmax(scores, dim=-1)
+    return torch.einsum("...ce,...ed->...cd", attn, v)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (4, 2, 8, 16),
+        (2, 3, 6, 8),
+        (1, 1, 4, 8),
+    ],
+)
+def test_sdpa_forward_matches_reference(shape):
+    torch.manual_seed(0)
+    q_cpu = torch.randn(*shape)
+    k_cpu = torch.randn(*shape)
+    v_cpu = torch.randn(*shape)
+    ref = _reference_sdpa_eager(q_cpu, k_cpu, v_cpu, None)
+
+    q = q_cpu.to("nntile")
+    k = k_cpu.to("nntile")
+    v = v_cpu.to("nntile")
+    out = sdpa_eager(q, k, v, batch_ndim=2)
+    assert torch.allclose(out.cpu(), ref, rtol=1e-4, atol=1e-4)
+    assert not torch_nntile.has_pending_graph()
+
+
+@pytest.mark.parametrize("shape", [(4, 2, 8, 16), (2, 3, 6, 8)])
+def test_sdpa_backward_matches_reference(shape):
+    torch.manual_seed(1)
+    q_cpu = torch.randn(*shape, requires_grad=True)
+    k_cpu = torch.randn(*shape, requires_grad=True)
+    v_cpu = torch.randn(*shape, requires_grad=True)
+    ref = _reference_sdpa_eager(q_cpu, k_cpu, v_cpu, None)
+    grad_out = torch.randn_like(ref)
+    ref.backward(grad_out)
+
+    q = q_cpu.detach().to("nntile").requires_grad_(True)
+    k = k_cpu.detach().to("nntile").requires_grad_(True)
+    v = v_cpu.detach().to("nntile").requires_grad_(True)
+    out = sdpa_eager(q, k, v, batch_ndim=2)
+    out.backward(grad_out.to("nntile"))
+
+    assert torch.allclose(q.grad.cpu(), q_cpu.grad, rtol=1e-4, atol=1e-4)
+    assert torch.allclose(k.grad.cpu(), k_cpu.grad, rtol=1e-4, atol=1e-4)
+    assert torch.allclose(v.grad.cpu(), v_cpu.grad, rtol=1e-4, atol=1e-4)
+
+
+def test_sdpa_forward_with_mask_matches_reference():
+    shape = (2, 2, 6, 8)
+    seq = shape[2]
+    torch.manual_seed(2)
+    q_cpu = torch.randn(*shape)
+    k_cpu = torch.randn(*shape)
+    v_cpu = torch.randn(*shape)
+    mask = torch.zeros(seq, seq, dtype=torch.bool)
+    for key in range(seq):
+        for query in range(seq):
+            mask[key, query] = key <= query
+
+    ref = _reference_sdpa_eager(q_cpu, k_cpu, v_cpu, mask)
+    out = sdpa_eager(
+        q_cpu.to("nntile"),
+        k_cpu.to("nntile"),
+        v_cpu.to("nntile"),
+        mask,
+        batch_ndim=2,
+    )
+    assert torch.allclose(out.cpu(), ref, rtol=1e-4, atol=1e-4)
+
+
+def test_sdpa_module_forward():
+    mod = SDPA(batch_ndim=2)
+    q = torch.randn(2, 1, 4, 8).to("nntile")
+    k = torch.randn(2, 1, 4, 8).to("nntile")
+    v = torch.randn(2, 1, 4, 8).to("nntile")
+    out = mod(q, k, v)
+    assert out.shape == q.shape
+
+
+def test_sdpa_rejects_cpu_tensors():
+    q = torch.randn(2, 1, 4, 8)
+    k = torch.randn(2, 1, 4, 8)
+    v = torch.randn(2, 1, 4, 8)
+    with pytest.raises(ValueError, match="nntile"):
+        sdpa_eager(q, k, v)
+
+
+def test_sdpa_rejects_graph_mode():
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    script = f"""
+import sys
+sys.path.insert(0, {str(root)!r})
+import torch
+import torch_nntile
+from torch_nntile.nn import sdpa_eager
+
+torch_nntile.init_context(
+    ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+)
+torch_nntile.restrict_cpu()
+q = torch.randn(2, 1, 4, 8).to("nntile")
+k = torch.randn(2, 1, 4, 8).to("nntile")
+v = torch.randn(2, 1, 4, 8).to("nntile")
+try:
+    sdpa_eager(q, k, v)
+except RuntimeError as exc:
+    assert "runtime_mode='eager'" in str(exc)
+else:
+    raise AssertionError("expected RuntimeError")
+"""
+    subprocess.check_call([sys.executable, "-c", script])

--- a/torch_nntile/torch_nntile/__init__.py
+++ b/torch_nntile/torch_nntile/__init__.py
@@ -18,6 +18,7 @@ ensure_linux_cuda_deps()
 
 from . import _C  # noqa: E402, F401 — loads kernels and allocator
 from . import loss as _loss  # noqa: E402, F401
+from . import nn as nn  # noqa: E402, F401
 from . import normalization as _normalization  # noqa: E402, F401
 from . import norm as _norm  # noqa: E402, F401
 
@@ -250,4 +251,5 @@ __all__ = [
     "set_axis_group_tiling",
     "format_axis_groups",
     "print_axis_groups",
+    "nn",
 ]

--- a/torch_nntile/torch_nntile/nn/__init__.py
+++ b/torch_nntile/torch_nntile/nn/__init__.py
@@ -1,0 +1,28 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/torch_nntile/nn/__init__.py
+# Neural network modules for device="nntile".
+
+"""``torch_nntile.nn`` layers and layout helpers."""
+
+from __future__ import annotations
+
+from torch_nntile.nn.sdpa import SDPA, sdpa_eager
+from torch_nntile.nn.weight_layout import (
+    convert_attn_weights,
+    nntile_to_torch_o_weight,
+    nntile_to_torch_qkv_weight,
+    torch_to_nntile_o_weight,
+    torch_to_nntile_qkv_weight,
+)
+
+__all__ = [
+    "SDPA",
+    "convert_attn_weights",
+    "nntile_to_torch_o_weight",
+    "nntile_to_torch_qkv_weight",
+    "sdpa_eager",
+    "torch_to_nntile_o_weight",
+    "torch_to_nntile_qkv_weight",
+]

--- a/torch_nntile/torch_nntile/nn/sdpa.py
+++ b/torch_nntile/torch_nntile/nn/sdpa.py
@@ -56,7 +56,8 @@ def sdpa_eager(
     """NNTile-layout SDPA eager on ``device='nntile'``.
 
     Q/K/V shape ``[batch..., seq, head_size]`` (C-order). Optional BOOL mask
-    ``[k_seq, q_seq]`` on CPU or nntile. Scale is ``1/sqrt(head_size)``.
+    ``[q_seq, k_seq]`` on CPU or nntile (dim0 = query, dim1 = key, matching
+    ``tensor::mask_scalar`` / GPT-2 ``attn_mask``). Scale is ``1/sqrt(head_size)``.
   """
     if q.device.type != "nntile":
         raise ValueError("sdpa_eager expects nntile Q/K/V tensors")

--- a/torch_nntile/torch_nntile/nn/sdpa.py
+++ b/torch_nntile/torch_nntile/nn/sdpa.py
@@ -1,0 +1,89 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/torch_nntile/nn/sdpa.py
+# SDPA eager layer for device="nntile".
+
+"""Scaled dot-product attention matching ``nntile::sdpa_eager``."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from torch_nntile import _C
+
+
+class _NntileSdpaEager(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q: Tensor,
+        k: Tensor,
+        v: Tensor,
+        mask: Tensor | None,
+        batch_ndim: int,
+    ) -> Tensor:
+        out = _C.sdpa_forward(q, k, v, mask, int(batch_ndim))
+        ctx.save_for_backward(q, k, v)
+        ctx.mask = mask
+        ctx.batch_ndim = int(batch_ndim)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor):
+        q, k, v = ctx.saved_tensors
+        grad_q, grad_k, grad_v = _C.sdpa_backward(
+            q,
+            k,
+            v,
+            grad_out,
+            ctx.mask,
+            ctx.batch_ndim,
+        )
+        return grad_q, grad_k, grad_v, None, None
+
+
+def sdpa_eager(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    mask: Tensor | None = None,
+    *,
+    batch_ndim: int = 2,
+) -> Tensor:
+    """NNTile-layout SDPA eager on ``device='nntile'``.
+
+    Q/K/V shape ``[batch..., seq, head_size]`` (C-order). Optional BOOL mask
+    ``[k_seq, q_seq]`` on CPU or nntile. Scale is ``1/sqrt(head_size)``.
+  """
+    if q.device.type != "nntile":
+        raise ValueError("sdpa_eager expects nntile Q/K/V tensors")
+    if k.device.type != "nntile" or v.device.type != "nntile":
+        raise ValueError("sdpa_eager expects nntile Q/K/V tensors")
+    if q.dtype != torch.float32 or k.dtype != torch.float32 or v.dtype != torch.float32:
+        raise ValueError("nntile sdpa supports float32 only")
+    if mask is not None and mask.dtype != torch.bool:
+        raise ValueError("nntile sdpa: mask must be bool")
+    return _NntileSdpaEager.apply(q, k, v, mask, batch_ndim)
+
+
+class SDPA(nn.Module):
+    """Scaled dot-product attention via libnntile ``sdpa_eager``."""
+
+    def __init__(self, batch_ndim: int = 2) -> None:
+        super().__init__()
+        self.batch_ndim = int(batch_ndim)
+
+    def forward(
+        self,
+        q: Tensor,
+        k: Tensor,
+        v: Tensor,
+        mask: Tensor | None = None,
+    ) -> Tensor:
+        return sdpa_eager(q, k, v, mask, batch_ndim=self.batch_ndim)
+
+
+__all__ = ["SDPA", "sdpa_eager"]

--- a/torch_nntile/torch_nntile/nn/weight_layout.py
+++ b/torch_nntile/torch_nntile/nn/weight_layout.py
@@ -1,0 +1,104 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/torch_nntile/nn/weight_layout.py
+# Attention weight layout conversion between PyTorch/HF and NNTile.
+
+"""Convert attention projection weights for NNTile GEMM layouts."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+from torch import Tensor
+
+_QKV_KEYS = ("q_weight", "k_weight", "v_weight")
+_O_KEY = "o_weight"
+_BIAS_KEYS = ("q_bias", "k_bias", "v_bias", "o_bias")
+
+
+def torch_to_nntile_qkv_weight(w: Tensor) -> Tensor:
+    """``(hidden, n_heads, head_size)`` -> ``(hidden, head_size, n_heads)``."""
+    if w.dim() != 3:
+        raise ValueError("qkv weight must be 3D (hidden, n_heads, head_size)")
+    return w.transpose(1, 2).contiguous()
+
+
+def nntile_to_torch_qkv_weight(w: Tensor) -> Tensor:
+    """``(hidden, head_size, n_heads)`` -> ``(hidden, n_heads, head_size)``."""
+    if w.dim() != 3:
+        raise ValueError("qkv weight must be 3D (hidden, head_size, n_heads)")
+    return w.transpose(1, 2).contiguous()
+
+
+def torch_to_nntile_o_weight(w: Tensor) -> Tensor:
+    """``(n_heads, head_size, hidden)`` -> ``(head_size, n_heads, hidden)``."""
+    if w.dim() != 3:
+        raise ValueError("o weight must be 3D (n_heads, head_size, hidden)")
+    return w.transpose(0, 1).contiguous()
+
+
+def nntile_to_torch_o_weight(w: Tensor) -> Tensor:
+    """``(head_size, n_heads, hidden)`` -> ``(n_heads, head_size, hidden)``."""
+    if w.dim() != 3:
+        raise ValueError("o weight must be 3D (head_size, n_heads, hidden)")
+    return w.transpose(0, 1).contiguous()
+
+
+def _with_prefix(prefix: str, key: str) -> str:
+    if not prefix:
+        return key
+    if prefix.endswith("."):
+        return f"{prefix}{key}"
+    return f"{prefix}.{key}"
+
+
+def _matches_suffix(full_key: str, suffix: str) -> bool:
+    return full_key == suffix or full_key.endswith(f".{suffix}")
+
+
+def convert_attn_weights(
+    weights: dict[str, Tensor],
+    direction: Literal["torch_to_nntile", "nntile_to_torch"],
+    *,
+    prefix: str = "",
+) -> dict[str, Tensor]:
+    """Convert q/k/v/o weights in a state-dict slice; biases are unchanged."""
+    if direction == "torch_to_nntile":
+        qkv_fn = torch_to_nntile_qkv_weight
+        o_fn = torch_to_nntile_o_weight
+    elif direction == "nntile_to_torch":
+        qkv_fn = nntile_to_torch_qkv_weight
+        o_fn = nntile_to_torch_o_weight
+    else:
+        raise ValueError(
+            "direction must be 'torch_to_nntile' or 'nntile_to_torch'"
+        )
+
+    prefix_with_dot = _with_prefix(prefix, "") if prefix else ""
+
+    out: dict[str, Tensor] = dict(weights)
+    for full_key, tensor in weights.items():
+        if prefix_with_dot and not full_key.startswith(prefix_with_dot):
+            continue
+        for suffix in _QKV_KEYS:
+            if _matches_suffix(full_key, suffix):
+                out[full_key] = qkv_fn(tensor)
+                break
+        else:
+            if _matches_suffix(full_key, _O_KEY):
+                out[full_key] = o_fn(tensor)
+            elif any(_matches_suffix(full_key, key) for key in _BIAS_KEYS):
+                out[full_key] = tensor.contiguous()
+
+    return out
+
+
+__all__ = [
+    "convert_attn_weights",
+    "nntile_to_torch_o_weight",
+    "nntile_to_torch_qkv_weight",
+    "torch_to_nntile_o_weight",
+    "torch_to_nntile_qkv_weight",
+]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `torch_nntile.nn.SDPA` / `sdpa_eager` for FP32 scaled dot-product attention on `device="nntile"`, matching the NNTile `sdpa_eager` decomposition. Also adds `torch_nntile.nn.weight_layout` helpers for HF ↔ NNTile attention weight conversion (for future GPT-2 integration).

**Runtime modes:** SDPA works in both **eager** and **graph** modes.

## Bugbot fixes

1. **Mask axis order:** Mask shape is now `[q_seq, k_seq]` (dim0 = query, dim1 = key), matching `tensor::mask_scalar` and GPT-2 `attn_mask` / `sdpa_causal_mask_bool_fill`.
2. **`grad_out` validation:** `sdpa_backward` rejects `grad_out` tensors whose shape does not match `Q`.

## API

- `torch_nntile.nn.SDPA(batch_ndim=2)` — `nn.Module` wrapper
- `torch_nntile.nn.sdpa_eager(q, k, v, mask=None, batch_ndim=2)` — functional
- `torch_nntile.nn.weight_layout` — weight converters

## v1 limits

- FP32 only; Q/K/V on `device="nntile"` in layout `[batch..., seq, head_size]`
- Optional BOOL mask `[q_seq, k_seq]` on CPU or nntile
- Fixed scale `1/sqrt(head_size)`
- No dropout, causal flag, GQA, or custom scale

## Tests

- `torch_nntile/tests/test_sdpa_parity.py` — parity, graph mode, mask axis order, `grad_out` shape check
- `torch_nntile/tests/test_attn_weight_layout.py` — weight round-trips
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0131342-cfb1-4577-8fd3-0b0dcbb45d74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0131342-cfb1-4577-8fd3-0b0dcbb45d74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

