### PR TITLE
Add minimal GPT-2 LM stack for torch_nntile

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -294,7 +294,8 @@ jobs:
           export LD_LIBRARY_PATH="${PWD}/build/nntile:/opt/starpu/lib:${LD_LIBRARY_PATH:-}"
           export STARPU_SILENT=1 STARPU_FXT_TRACE=0 STARPU_WORKERS_NOBIND=1
           export OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 GOTO_NUM_THREADS=1
-          pip install --break-system-packages 'torch==2.9.1' pytest
+          pip install --break-system-packages \
+            'torch==2.9.1' pytest 'numpy>=1.21' 'transformers<4.53'
           CXX=g++ pip install --break-system-packages \
             -e ./torch_nntile --no-build-isolation --force-reinstall
           pytest -vv --rootdir=. -m 'not slow' torch_nntile/tests/

--- a/nntile/include/nntile/tensor/ops/contiguous_view.hh
+++ b/nntile/include/nntile/tensor/ops/contiguous_view.hh
@@ -1,0 +1,55 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file include/nntile/tensor/ops/contiguous_view.hh
+ * TensorGraph contiguous_view: dst is a storage alias of src.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include <string>
+
+#include <nntile/tensor/graph.hh>
+
+namespace nntile
+{
+struct LoweringContext;
+}
+
+namespace nntile::tensor
+{
+
+struct TensorContiguousViewOp : TensorGraph::OpNode
+{
+    TensorGraph::TensorNode *src = nullptr;
+    TensorGraph::TensorNode *dst = nullptr;
+
+    TensorContiguousViewOp() = default;
+    TensorContiguousViewOp(
+        TensorGraph::TensorNode *src_,
+        TensorGraph::TensorNode *dst_) :
+        src(src_), dst(dst_)
+    {
+        inputs_ = {src};
+        outputs_ = {dst};
+    }
+
+    std::string op_name() const override { return "CONTIGUOUS_VIEW"; }
+
+    std::shared_ptr<TensorGraph::OpNode> clone() const override
+    {
+        return std::make_shared<TensorContiguousViewOp>(*this);
+    }
+
+    void lower_to_tile(const LoweringContext &ctx) const override;
+};
+
+void contiguous_view(
+    TensorGraph::TensorNode *src,
+    TensorGraph::TensorNode *dst);
+
+} // namespace nntile::tensor

--- a/nntile/include/nntile/tile/ops/copy.hh
+++ b/nntile/include/nntile/tile/ops/copy.hh
@@ -39,6 +39,28 @@ struct TileCopyOp : TileGraph::OpNode
     }
 };
 
+struct TileCopySameNumelOp : TileGraph::OpNode
+{
+    TileGraph::TileNode* src = nullptr;
+    TileGraph::TileNode* dst = nullptr;
+    TileCopySameNumelOp() = default;
+    TileCopySameNumelOp(TileGraph::TileNode* s, TileGraph::TileNode* d) :
+        src(s), dst(d)
+    {
+        inputs_ = {src};
+        outputs_ = {dst};
+    }
+    std::string op_name() const override { return "TILE_COPY_SAME_NUMEL"; }
+    void execute(Runtime& runtime) const override;
+    std::shared_ptr<TileGraph::OpNode> clone() const override
+    {
+        return std::make_shared<TileCopySameNumelOp>(*this);
+    }
+};
+
 //! Copy: dst = src (uses existing output)
 void copy(TileGraph::TileNode* src, TileGraph::TileNode* dst);
+
+//! Copy contiguous buffers when shapes may differ but numel matches
+void copy_same_numel(TileGraph::TileNode* src, TileGraph::TileNode* dst);
 } // namespace nntile::tile

--- a/nntile/src/CMakeLists.txt
+++ b/nntile/src/CMakeLists.txt
@@ -354,6 +354,7 @@ set(GRAPH_TENSOR_LAYER_SRC
     "tensor/ops/adamw_step.cc"
     "tensor/ops/clear.cc"
     "tensor/ops/concat.cc"
+    "tensor/ops/contiguous_view.cc"
     "tensor/ops/conv2d_bwd_input_inplace.cc"
     "tensor/ops/conv2d_bwd_weight_inplace.cc"
     "tensor/ops/conv2d_inplace.cc"

--- a/nntile/src/tensor/ops/contiguous_view.cc
+++ b/nntile/src/tensor/ops/contiguous_view.cc
@@ -1,0 +1,89 @@
+#include <nntile/common.hh>
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file nntile/src/tensor/ops/contiguous_view.cc
+ * TensorGraph contiguous_view operation implementation.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/tensor/ops/contiguous_view.hh"
+
+#include "nntile/tensor.hh"
+#include "nntile/tensor/tile_lowering_helpers.hh"
+#include "nntile/tile/ops/copy.hh"
+#include "nntile/tensor/ops/contiguous_view.hh"
+
+#include <stdexcept>
+
+namespace nntile::tensor
+{
+
+namespace
+{
+
+void validate_contiguous_view(
+    TensorGraph::TensorNode *src,
+    TensorGraph::TensorNode *dst,
+    const std::string &op_name)
+{
+    if (src->nelems() != dst->nelems())
+    {
+        throw std::invalid_argument(
+            op_name + ": src and dst must have the same numel (" +
+            std::to_string(src->nelems()) + " vs " +
+            std::to_string(dst->nelems()) + ")");
+    }
+}
+
+} // namespace
+
+void contiguous_view(
+    TensorGraph::TensorNode *src,
+    TensorGraph::TensorNode *dst)
+{
+    if (src == nullptr || dst == nullptr)
+    {
+        throw std::invalid_argument(
+            "contiguous_view: tensors must be non-null");
+    }
+    if (src->graph() != dst->graph())
+    {
+        throw std::invalid_argument(
+            "contiguous_view: tensors must belong to same graph");
+    }
+    if (src->dtype() != dst->dtype())
+    {
+        throw std::invalid_argument(
+            "contiguous_view: tensors must have the same dtype");
+    }
+    if (src == dst)
+    {
+        throw std::invalid_argument(
+            "contiguous_view: src and dst must be distinct tensors");
+    }
+    validate_contiguous_view(src, dst, "contiguous_view");
+
+    auto op = std::make_shared<TensorContiguousViewOp>(src, dst);
+    src->graph()->add_op(op);
+}
+
+void TensorContiguousViewOp::lower_to_tile(const LoweringContext &ctx) const
+{
+    const auto &src_tiles = tile_lower::tiles_of(ctx.tile_map, src);
+    const auto &dst_tiles = tile_lower::tiles_of(ctx.tile_map, dst);
+    if (src_tiles.size() != dst_tiles.size())
+    {
+        throw std::runtime_error(
+            "lower_to_tile CONTIGUOUS_VIEW: tile count mismatch");
+    }
+    for (size_t i = 0; i < src_tiles.size(); ++i)
+    {
+        tile::copy_same_numel(src_tiles[i], dst_tiles[i]);
+    }
+}
+
+} // namespace nntile::tensor

--- a/nntile/src/tile/ops/copy.cc
+++ b/nntile/src/tile/ops/copy.cc
@@ -18,6 +18,7 @@
 #include <nntile/dtype.hh>
 #include <nntile/core.hh>
 #include <nntile/core/copy.hh>
+#include <nntile/starpu/copy.hh>
 
 #include <nntile/runtime.hh>
 namespace nntile::tile
@@ -28,6 +29,28 @@ template<typename T>
 void run_cp(Runtime& runtime, TileGraph::TileNode* s, TileGraph::TileNode* d)
 {
     nntile::core::copy<T>(runtime.starpu_worker_hint(), runtime.get_tile<T>(s), runtime.get_tile<T>(d));
+}
+
+template<typename T>
+void run_cp_same_numel(
+    Runtime& runtime,
+    TileGraph::TileNode* s,
+    TileGraph::TileNode* d)
+{
+    if (s->nelems() != d->nelems())
+    {
+        throw std::runtime_error("tile copy_same_numel: numel mismatch");
+    }
+    auto& src_tile = runtime.get_tile<T>(s);
+    auto& dst_tile = runtime.get_tile<T>(d);
+    if (src_tile.nelems != dst_tile.nelems)
+    {
+        throw std::runtime_error("tile copy_same_numel: buffer numel mismatch");
+    }
+    starpu::copy.submit(
+        runtime.starpu_worker_hint(),
+        src_tile,
+        dst_tile);
 }
 } // namespace
 void copy(TileGraph::TileNode* src, TileGraph::TileNode* dst)
@@ -76,6 +99,69 @@ void TileCopyOp::execute(Runtime& runtime) const
             break;
         default:
             throw std::runtime_error("Unsupported data type for tile copy");
+    }
+}
+
+void copy_same_numel(TileGraph::TileNode* src, TileGraph::TileNode* dst)
+{
+    if (!src || !dst)
+    {
+        throw std::invalid_argument("tile copy_same_numel: null");
+    }
+    if (src->graph() != dst->graph())
+    {
+        throw std::invalid_argument("tile copy_same_numel: same graph");
+    }
+    if (src->dtype() != dst->dtype())
+    {
+        throw std::invalid_argument("tile copy_same_numel: dtype");
+    }
+    if (src == dst)
+    {
+        throw std::invalid_argument("tile copy_same_numel: distinct");
+    }
+    if (src->nelems() != dst->nelems())
+    {
+        throw std::invalid_argument("tile copy_same_numel: numel mismatch");
+    }
+    src->graph()->add_op(std::make_shared<TileCopySameNumelOp>(src, dst));
+}
+
+void TileCopySameNumelOp::execute(Runtime& runtime) const
+{
+    DataType dtype = runtime.get_dtype(src);
+    switch (dtype)
+    {
+        case DataType::FP32:
+            run_cp_same_numel<nntile::fp32_t>(runtime, src, dst);
+            break;
+        case DataType::FP32_FAST_TF32:
+            run_cp_same_numel<nntile::fp32_fast_tf32_t>(runtime, src, dst);
+            break;
+        case DataType::FP32_FAST_FP16:
+            run_cp_same_numel<nntile::fp32_fast_fp16_t>(runtime, src, dst);
+            break;
+        case DataType::FP32_FAST_BF16:
+            run_cp_same_numel<nntile::fp32_fast_bf16_t>(runtime, src, dst);
+            break;
+        case DataType::FP64:
+            run_cp_same_numel<nntile::fp64_t>(runtime, src, dst);
+            break;
+        case DataType::FP16:
+            run_cp_same_numel<nntile::fp16_t>(runtime, src, dst);
+            break;
+        case DataType::BF16:
+            run_cp_same_numel<nntile::bf16_t>(runtime, src, dst);
+            break;
+        case DataType::INT64:
+            run_cp_same_numel<nntile::int64_t>(runtime, src, dst);
+            break;
+        case DataType::BOOL:
+            run_cp_same_numel<nntile::bool_t>(runtime, src, dst);
+            break;
+        default:
+            throw std::runtime_error(
+                "Unsupported data type for tile copy_same_numel");
     }
 }
 } // namespace nntile::tile

--- a/torch_nntile/csrc/nntile_executor.cpp
+++ b/torch_nntile/csrc/nntile_executor.cpp
@@ -61,6 +61,7 @@
 #include <nntile/tensor/ops/sumprod_fiber.hh>
 #include <nntile/tensor/ops/sumprod_slice.hh>
 #include <nntile/tensor/ops/total_sum_accum.hh>
+#include <nntile/tensor/ops/transpose.hh>
 
 #include <cmath>
 #include <cstring>
@@ -201,6 +202,114 @@ void tensor_add_fp32(
         static_cast<nntile::Scalar>(beta),
         y_node)->set_name("z");
     register_data_node(out_data, z_node);
+    maybe_execute_after_record();
+}
+
+void tensor_contiguous_fp32(
+    const float *src_data,
+    float *dst_data,
+    c10::IntArrayRef pytorch_shape)
+{
+    const std::vector<nntile::Index> graph_shape =
+        pytorch_shape_to_graph(pytorch_shape);
+
+    auto *src_node = get_or_create_data_node(
+        const_cast<float *>(src_data),
+        graph_shape,
+        nntile::DataType::FP32,
+        true);
+    auto *dst_node = get_or_create_data_node(
+        dst_data,
+        graph_shape,
+        nntile::DataType::FP32,
+        false);
+
+    nntile::tensor::copy(src_node, dst_node);
+    register_data_node(dst_data, dst_node);
+    maybe_execute_after_record();
+}
+
+void tensor_model_transpose_forward_fp32(
+    const float *src_data,
+    c10::IntArrayRef src_shape,
+    float *dst_data,
+    int64_t model_ndim)
+{
+    const std::vector<nntile::Index> src_graph =
+        pytorch_shape_to_graph(src_shape);
+    const nntile::Index n = static_cast<nntile::Index>(src_graph.size());
+    TORCH_CHECK(
+        model_ndim > 0 && model_ndim < static_cast<int64_t>(n),
+        "nntile model_transpose: invalid model_ndim");
+    const nntile::Index tensor_ndim =
+        n - static_cast<nntile::Index>(model_ndim);
+
+    std::vector<nntile::Index> dst_graph(static_cast<std::size_t>(n));
+    for (nntile::Index i = 0; i < n; ++i)
+    {
+        dst_graph[static_cast<std::size_t>(i)] =
+            src_graph[static_cast<std::size_t>((i + tensor_ndim) % n)];
+    }
+
+    auto *src_node = get_or_create_data_node(
+        const_cast<float *>(src_data),
+        src_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *dst_node = get_or_create_data_node(
+        dst_data,
+        dst_graph,
+        nntile::DataType::FP32,
+        false);
+
+    nntile::tensor::transpose(
+        static_cast<nntile::Scalar>(1.0),
+        src_node,
+        dst_node,
+        tensor_ndim);
+    register_data_node(dst_data, dst_node);
+    maybe_execute_after_record();
+}
+
+void tensor_model_transpose_backward_fp32(
+    const float *grad_out_data,
+    c10::IntArrayRef grad_out_shape,
+    float *grad_src_data,
+    int64_t model_ndim)
+{
+    const std::vector<nntile::Index> grad_out_graph =
+        pytorch_shape_to_graph(grad_out_shape);
+    const nntile::Index n =
+        static_cast<nntile::Index>(grad_out_graph.size());
+    TORCH_CHECK(
+        model_ndim > 0 && model_ndim < static_cast<int64_t>(n),
+        "nntile model_transpose backward: invalid model_ndim");
+
+    std::vector<nntile::Index> grad_src_graph(static_cast<std::size_t>(n));
+    for (nntile::Index i = 0; i < n; ++i)
+    {
+        grad_src_graph[static_cast<std::size_t>(i)] =
+            grad_out_graph[static_cast<std::size_t>(
+                (i + static_cast<nntile::Index>(model_ndim)) % n)];
+    }
+
+    auto *grad_out_node = get_or_create_data_node(
+        const_cast<float *>(grad_out_data),
+        grad_out_graph,
+        nntile::DataType::FP32,
+        true);
+    auto *grad_src_node = get_or_create_data_node(
+        grad_src_data,
+        grad_src_graph,
+        nntile::DataType::FP32,
+        false);
+
+    nntile::tensor::transpose(
+        static_cast<nntile::Scalar>(1.0),
+        grad_out_node,
+        grad_src_node,
+        static_cast<nntile::Index>(model_ndim));
+    register_data_node(grad_src_data, grad_src_node);
     maybe_execute_after_record();
 }
 
@@ -2507,6 +2616,32 @@ void tensor_add_fp32(
     c10::IntArrayRef /*pytorch_shape*/)
 {
     require_libnntile("add");
+}
+
+void tensor_contiguous_fp32(
+    const float * /*src_data*/,
+    float * /*dst_data*/,
+    c10::IntArrayRef /*pytorch_shape*/)
+{
+    require_libnntile("contiguous");
+}
+
+void tensor_model_transpose_forward_fp32(
+    const float * /*src_data*/,
+    c10::IntArrayRef /*src_shape*/,
+    float * /*dst_data*/,
+    int64_t /*model_ndim*/)
+{
+    require_libnntile("model_transpose_forward");
+}
+
+void tensor_model_transpose_backward_fp32(
+    const float * /*grad_out_data*/,
+    c10::IntArrayRef /*grad_out_shape*/,
+    float * /*grad_src_data*/,
+    int64_t /*model_ndim*/)
+{
+    require_libnntile("model_transpose_backward");
 }
 
 void tensor_add_inplace_fp32(

--- a/torch_nntile/csrc/nntile_executor.h
+++ b/torch_nntile/csrc/nntile_executor.h
@@ -33,6 +33,23 @@ void tensor_add_fp32(
     float *out_data,
     c10::IntArrayRef pytorch_shape);
 
+void tensor_contiguous_fp32(
+    const float *src_data,
+    float *dst_data,
+    c10::IntArrayRef pytorch_shape);
+
+void tensor_model_transpose_forward_fp32(
+    const float *src_data,
+    c10::IntArrayRef src_shape,
+    float *dst_data,
+    int64_t model_ndim);
+
+void tensor_model_transpose_backward_fp32(
+    const float *grad_out_data,
+    c10::IntArrayRef grad_out_shape,
+    float *grad_src_data,
+    int64_t model_ndim);
+
 void tensor_add_inplace_fp32(
     float alpha,
     const float *other_data,

--- a/torch_nntile/csrc/nntile_gemm.cpp
+++ b/torch_nntile/csrc/nntile_gemm.cpp
@@ -144,7 +144,19 @@ std::tuple<at::Tensor, at::Tensor> gemm_backward(
 at::Tensor matmul_nd(const at::Tensor &a, const at::Tensor &b)
 {
     check_gemm_tensors(a, b);
-    const PreparedGemmOperands prepared = prepare_gemm_operands_inferred(a, b);
+    PreparedGemmOperands prepared;
+    if (a.dim() == 2 && b.dim() == 2)
+    {
+        prepared = prepare_mm_operands(a, b);
+    }
+    else if (a.dim() == 3 && b.dim() == 3 && a.size(0) == b.size(0))
+    {
+        prepared = prepare_bmm_operands(a, b);
+    }
+    else
+    {
+        prepared = prepare_gemm_operands_inferred(a, b);
+    }
     at::Tensor out = make_gemm_output(prepared.out_shape, a);
     run_gemm(prepared, out);
     return out;

--- a/torch_nntile/csrc/nntile_gemm.cpp
+++ b/torch_nntile/csrc/nntile_gemm.cpp
@@ -1,0 +1,158 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_gemm.cpp
+ */
+
+#include "nntile_gemm.h"
+
+#include "nntile_executor.h"
+#include "nntile_gemm_layout.h"
+#include "nntile_graph_recorder_impl.h"
+
+#include <ATen/Functions.h>
+#include <ATen/TensorUtils.h>
+#include <torch/library.h>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+bool is_nntile_device(c10::Device device)
+{
+    return device.type() == c10::DeviceType::PrivateUse1;
+}
+
+void check_gemm_tensors(
+    const at::Tensor &a,
+    const at::Tensor &b)
+{
+    TORCH_CHECK(
+        is_nntile_device(a.device()) && is_nntile_device(b.device()),
+        "nntile gemm expects nntile tensors");
+    TORCH_CHECK(a.dim() >= 1 && b.dim() >= 1, "nntile gemm: operands must be >= 1D");
+    TORCH_CHECK(
+        a.scalar_type() == at::ScalarType::Float &&
+            b.scalar_type() == at::ScalarType::Float,
+        "nntile gemm supports float32 only");
+}
+
+at::Tensor make_gemm_output(
+    const std::vector<int64_t> &out_shape,
+    const at::Tensor &ref)
+{
+    std::vector<int64_t> sizes(out_shape.begin(), out_shape.end());
+    return at::empty(
+        sizes,
+        ref.options().memory_format(at::MemoryFormat::Contiguous));
+}
+
+void run_gemm(const PreparedGemmOperands &prepared, at::Tensor &out)
+{
+    pin_graph_op_inputs({prepared.a, prepared.b});
+    pin_graph_op_output(out, true);
+    tensor_gemm_fp32(
+        prepared.params,
+        prepared.a.data_ptr<float>(),
+        prepared.a_gemm_shape,
+        prepared.b.data_ptr<float>(),
+        prepared.b_gemm_shape,
+        out.data_ptr<float>(),
+        prepared.out_shape);
+}
+
+} // namespace
+
+at::Tensor gemm_forward(
+    const at::Tensor &a,
+    const at::Tensor &b,
+    int64_t ndim,
+    int64_t batch_ndim)
+{
+    check_gemm_tensors(a, b);
+    const PreparedGemmOperands prepared =
+        prepare_gemm_operands(a, b, ndim, batch_ndim);
+    at::Tensor out = make_gemm_output(prepared.out_shape, a);
+    run_gemm(prepared, out);
+    return out;
+}
+
+std::tuple<at::Tensor, at::Tensor> gemm_backward(
+    const at::Tensor &a,
+    const at::Tensor &b,
+    const at::Tensor &grad_out,
+    int64_t ndim,
+    int64_t batch_ndim,
+    std::array<bool, 2> output_mask)
+{
+    check_gemm_tensors(a, b);
+    TORCH_CHECK(
+        is_nntile_device(grad_out.device()),
+        "nntile gemm_backward expects nntile grad_out");
+    TORCH_CHECK(
+        grad_out.scalar_type() == at::ScalarType::Float,
+        "nntile gemm_backward supports float32 only");
+
+    const PreparedGemmOperands forward =
+        prepare_gemm_operands(a, b, ndim, batch_ndim);
+    const GemmMatrixLayout grad_out_layout = layout_from_nd_contiguous(grad_out);
+    at::Tensor grad_out_prepared = grad_out_layout.needs_copy
+        ? grad_out.contiguous()
+        : grad_out;
+
+    at::Tensor grad_a;
+    at::Tensor grad_b;
+    if (output_mask[0])
+    {
+        const GemmParams params = infer_gemm_backward_grad_a_params(
+            forward.params,
+            static_cast<int64_t>(forward.b_gemm_shape.size()));
+        grad_a = at::empty_like(a);
+        pin_graph_op_inputs({grad_out_prepared, forward.b});
+        pin_graph_op_output(grad_a, false);
+        tensor_gemm_fp32(
+            params,
+            grad_out_prepared.data_ptr<float>(),
+            grad_out_layout.gemm_shape,
+            forward.b.data_ptr<float>(),
+            forward.b_gemm_shape,
+            grad_a.data_ptr<float>(),
+            pytorch_sizes_vector(grad_a.sizes()));
+    }
+    if (output_mask[1])
+    {
+        const GemmParams params = infer_gemm_backward_grad_b_params(
+            forward.params,
+            static_cast<int64_t>(forward.a_gemm_shape.size()));
+        grad_b = at::empty_like(b);
+        pin_graph_op_inputs({forward.a, grad_out_prepared});
+        pin_graph_op_output(grad_b, false);
+        tensor_gemm_fp32(
+            params,
+            forward.a.data_ptr<float>(),
+            forward.a_gemm_shape,
+            grad_out_prepared.data_ptr<float>(),
+            grad_out_layout.gemm_shape,
+            grad_b.data_ptr<float>(),
+            pytorch_sizes_vector(grad_b.sizes()));
+    }
+    return {grad_a, grad_b};
+}
+
+at::Tensor matmul_nd(const at::Tensor &a, const at::Tensor &b)
+{
+    check_gemm_tensors(a, b);
+    const PreparedGemmOperands prepared = prepare_gemm_operands_inferred(a, b);
+    at::Tensor out = make_gemm_output(prepared.out_shape, a);
+    run_gemm(prepared, out);
+    return out;
+}
+
+} // namespace torch_nntile
+
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
+{
+    m.impl("matmul", TORCH_FN(torch_nntile::matmul_nd));
+}

--- a/torch_nntile/csrc/nntile_gemm.h
+++ b/torch_nntile/csrc/nntile_gemm.h
@@ -1,0 +1,35 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_gemm.h
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+
+#include <cstdint>
+#include <tuple>
+
+namespace torch_nntile
+{
+
+at::Tensor gemm_forward(
+    const at::Tensor &a,
+    const at::Tensor &b,
+    int64_t ndim,
+    int64_t batch_ndim);
+
+std::tuple<at::Tensor, at::Tensor> gemm_backward(
+    const at::Tensor &a,
+    const at::Tensor &b,
+    const at::Tensor &grad_out,
+    int64_t ndim,
+    int64_t batch_ndim,
+    std::array<bool, 2> output_mask);
+
+at::Tensor matmul_nd(
+    const at::Tensor &a,
+    const at::Tensor &b);
+
+} // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_gemm_layout.cpp
+++ b/torch_nntile/csrc/nntile_gemm_layout.cpp
@@ -100,6 +100,48 @@ GemmMatrixLayout layout_from_prepared_batched(const at::Tensor &tensor)
     return layout;
 }
 
+void validate_gemm_contraction(
+    c10::IntArrayRef a_shape,
+    c10::IntArrayRef b_shape,
+    int64_t ndim,
+    int64_t batch_ndim,
+    bool trans_a,
+    bool trans_b)
+{
+    const int64_t a_rank = static_cast<int64_t>(a_shape.size());
+    const int64_t b_rank = static_cast<int64_t>(b_shape.size());
+
+    TORCH_CHECK(ndim > 0, "nntile gemm: ndim must be positive");
+    TORCH_CHECK(
+        batch_ndim >= 0 && batch_ndim <= a_rank && batch_ndim <= b_rank,
+        "nntile gemm: invalid batch_ndim");
+
+    const int64_t a_k_begin = trans_a ? batch_ndim : (a_rank - ndim);
+    const int64_t a_k_end = trans_a ? (batch_ndim + ndim) : a_rank;
+    const int64_t b_k_begin = trans_b ? (b_rank - ndim) : batch_ndim;
+    const int64_t b_k_end = trans_b ? b_rank : (batch_ndim + ndim);
+
+    TORCH_CHECK(
+        a_k_end - a_k_begin == ndim && b_k_end - b_k_begin == ndim,
+        "nntile gemm: ndim does not fit operand ranks");
+
+    for (int64_t k = 0; k < ndim; ++k)
+    {
+        TORCH_CHECK(
+            a_shape[a_k_begin + k] == b_shape[b_k_begin + k],
+            "nntile gemm: contraction dimension mismatch at axis ",
+            k);
+    }
+
+    for (int64_t b = 0; b < batch_ndim; ++b)
+    {
+        TORCH_CHECK(
+            a_shape[b] == b_shape[b],
+            "nntile gemm: batch dimension mismatch at axis ",
+            b);
+    }
+}
+
 } // namespace
 
 GemmMatrixLayout analyze_matrix_layout_for_nntile(const at::Tensor &tensor)
@@ -110,6 +152,15 @@ GemmMatrixLayout analyze_matrix_layout_for_nntile(const at::Tensor &tensor)
 GemmMatrixLayout analyze_batched_gemm_operand_layout(const at::Tensor &tensor)
 {
     return layout_from_prepared_batched(tensor);
+}
+
+GemmMatrixLayout layout_from_nd_contiguous(const at::Tensor &tensor)
+{
+    GemmMatrixLayout layout;
+    layout.gemm_shape = sizes_to_vector(tensor.sizes());
+    layout.trans = false;
+    layout.needs_copy = !tensor.is_contiguous();
+    return layout;
 }
 
 std::vector<int64_t> gemm_output_shape_pytorch(
@@ -218,6 +269,83 @@ PreparedGemmOperands prepare_bmm_operands(const at::Tensor &a, const at::Tensor 
     return prepared;
 }
 
+std::pair<int64_t, int64_t> infer_gemm_params(
+    c10::IntArrayRef a_shape,
+    c10::IntArrayRef b_shape)
+{
+    const int64_t a_rank = static_cast<int64_t>(a_shape.size());
+    const int64_t b_rank = static_cast<int64_t>(b_shape.size());
+
+    int64_t batch_ndim = 0;
+    while (batch_ndim < a_rank && batch_ndim < b_rank &&
+           a_shape[batch_ndim] == b_shape[batch_ndim])
+    {
+        ++batch_ndim;
+    }
+
+    int64_t ndim = 0;
+    while (ndim < a_rank - batch_ndim && batch_ndim + ndim < b_rank &&
+           a_shape[a_rank - 1 - ndim] == b_shape[batch_ndim + ndim])
+    {
+        ++ndim;
+    }
+
+    TORCH_CHECK(
+        ndim > 0,
+        "nntile gemm: no matching contraction dimensions between operands");
+    return {ndim, batch_ndim};
+}
+
+PreparedGemmOperands prepare_gemm_operands(
+    const at::Tensor &a,
+    const at::Tensor &b,
+    int64_t ndim,
+    int64_t batch_ndim)
+{
+    GemmMatrixLayout a_layout = layout_from_nd_contiguous(a);
+    GemmMatrixLayout b_layout = layout_from_nd_contiguous(b);
+
+    PreparedGemmOperands prepared;
+    prepared.a = maybe_contiguous(a, a_layout);
+    prepared.b = maybe_contiguous(b, b_layout);
+    if (a_layout.needs_copy)
+    {
+        a_layout = layout_from_nd_contiguous(prepared.a);
+    }
+    if (b_layout.needs_copy)
+    {
+        b_layout = layout_from_nd_contiguous(prepared.b);
+    }
+
+    prepared.a_gemm_shape = a_layout.gemm_shape;
+    prepared.b_gemm_shape = b_layout.gemm_shape;
+    prepared.params.trans_a = a_layout.trans;
+    prepared.params.trans_b = b_layout.trans;
+    prepared.params.ndim = ndim;
+    prepared.params.batch_ndim = batch_ndim;
+    validate_gemm_contraction(
+        prepared.a_gemm_shape,
+        prepared.b_gemm_shape,
+        ndim,
+        batch_ndim,
+        prepared.params.trans_a,
+        prepared.params.trans_b);
+    prepared.out_shape = gemm_output_shape_pytorch(
+        prepared.a_gemm_shape,
+        prepared.b_gemm_shape,
+        prepared.params);
+    return prepared;
+}
+
+PreparedGemmOperands prepare_gemm_operands_inferred(
+    const at::Tensor &a,
+    const at::Tensor &b)
+{
+    const auto [ndim, batch_ndim] =
+        infer_gemm_params(a.sizes(), b.sizes());
+    return prepare_gemm_operands(a, b, ndim, batch_ndim);
+}
+
 PreparedGemmOperands prepare_linear_operands(
     const at::Tensor &input,
     const at::Tensor &weight)
@@ -271,24 +399,38 @@ PreparedGemmOperands prepare_linear_operands(
     return prepared;
 }
 
-GemmParams infer_mm_backward_grad_a_params(const GemmParams &forward)
+GemmParams infer_gemm_backward_grad_a_params(
+    const GemmParams &forward,
+    int64_t b_rank)
 {
     GemmParams params;
     params.trans_a = false;
     params.trans_b = !forward.trans_b;
-    params.ndim = forward.ndim;
+    params.ndim = b_rank - forward.batch_ndim - forward.ndim;
     params.batch_ndim = forward.batch_ndim;
     return params;
 }
 
-GemmParams infer_mm_backward_grad_b_params(const GemmParams &forward)
+GemmParams infer_gemm_backward_grad_b_params(
+    const GemmParams &forward,
+    int64_t a_rank)
 {
     GemmParams params;
     params.trans_a = !forward.trans_a;
     params.trans_b = false;
-    params.ndim = forward.ndim;
+    params.ndim = a_rank - forward.batch_ndim - forward.ndim;
     params.batch_ndim = forward.batch_ndim;
     return params;
+}
+
+GemmParams infer_mm_backward_grad_a_params(const GemmParams &forward)
+{
+    return infer_gemm_backward_grad_a_params(forward, 2);
+}
+
+GemmParams infer_mm_backward_grad_b_params(const GemmParams &forward)
+{
+    return infer_gemm_backward_grad_b_params(forward, 2);
 }
 
 GemmParams infer_linear_backward_grad_input_params(const GemmParams &forward)

--- a/torch_nntile/csrc/nntile_gemm_layout.cpp
+++ b/torch_nntile/csrc/nntile_gemm_layout.cpp
@@ -275,25 +275,39 @@ std::pair<int64_t, int64_t> infer_gemm_params(
 {
     const int64_t a_rank = static_cast<int64_t>(a_shape.size());
     const int64_t b_rank = static_cast<int64_t>(b_shape.size());
+    const int64_t max_batch = std::min(a_rank, b_rank);
 
-    int64_t batch_ndim = 0;
-    while (batch_ndim < a_rank && batch_ndim < b_rank &&
-           a_shape[batch_ndim] == b_shape[batch_ndim])
+    for (int64_t batch_ndim = 0; batch_ndim <= max_batch; ++batch_ndim)
     {
-        ++batch_ndim;
-    }
+        bool batch_ok = true;
+        for (int64_t b = 0; b < batch_ndim; ++b)
+        {
+            if (a_shape[b] != b_shape[b])
+            {
+                batch_ok = false;
+                break;
+            }
+        }
+        if (!batch_ok)
+        {
+            continue;
+        }
 
-    int64_t ndim = 0;
-    while (ndim < a_rank - batch_ndim && batch_ndim + ndim < b_rank &&
-           a_shape[a_rank - 1 - ndim] == b_shape[batch_ndim + ndim])
-    {
-        ++ndim;
+        int64_t ndim = 0;
+        while (ndim < a_rank - batch_ndim && batch_ndim + ndim < b_rank &&
+               a_shape[a_rank - 1 - ndim] == b_shape[batch_ndim + ndim])
+        {
+            ++ndim;
+        }
+        if (ndim > 0)
+        {
+            return {ndim, batch_ndim};
+        }
     }
 
     TORCH_CHECK(
-        ndim > 0,
+        false,
         "nntile gemm: no matching contraction dimensions between operands");
-    return {ndim, batch_ndim};
 }
 
 PreparedGemmOperands prepare_gemm_operands(

--- a/torch_nntile/csrc/nntile_gemm_layout.h
+++ b/torch_nntile/csrc/nntile_gemm_layout.h
@@ -47,6 +47,8 @@ GemmMatrixLayout analyze_matrix_layout_for_nntile(const at::Tensor &tensor);
 
 GemmMatrixLayout analyze_batched_gemm_operand_layout(const at::Tensor &tensor);
 
+GemmMatrixLayout layout_from_nd_contiguous(const at::Tensor &tensor);
+
 std::vector<int64_t> gemm_output_shape_pytorch(
     const std::vector<int64_t> &a_shape,
     const std::vector<int64_t> &b_shape,
@@ -59,6 +61,30 @@ PreparedGemmOperands prepare_bmm_operands(const at::Tensor &a, const at::Tensor 
 PreparedGemmOperands prepare_linear_operands(
     const at::Tensor &input,
     const at::Tensor &weight);
+
+//! Infer ``ndim`` / ``batch_ndim`` from NNTile GEMM shape rules (``batch_ndim=0``
+//! free/broadcast axes on A, shared leading batch when sizes match).
+std::pair<int64_t, int64_t> infer_gemm_params(
+    c10::IntArrayRef a_shape,
+    c10::IntArrayRef b_shape);
+
+PreparedGemmOperands prepare_gemm_operands(
+    const at::Tensor &a,
+    const at::Tensor &b,
+    int64_t ndim,
+    int64_t batch_ndim);
+
+PreparedGemmOperands prepare_gemm_operands_inferred(
+    const at::Tensor &a,
+    const at::Tensor &b);
+
+GemmParams infer_gemm_backward_grad_a_params(
+    const GemmParams &forward,
+    int64_t b_rank);
+
+GemmParams infer_gemm_backward_grad_b_params(
+    const GemmParams &forward,
+    int64_t a_rank);
 
 GemmParams infer_mm_backward_grad_a_params(const GemmParams &forward);
 GemmParams infer_mm_backward_grad_b_params(const GemmParams &forward);

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -994,31 +994,52 @@ void record_view_alias(const at::Tensor &self, const at::Tensor &view)
     {
         view_shape.push_back(static_cast<nntile::Index>(dim));
     }
-    void *data_ptr = view.data_ptr();
+    void *const view_ptr = view.data_ptr();
+    void *const self_ptr = self.data_ptr();
 
     std::lock_guard<std::mutex> lock(g_recorder_mutex);
     if (g_graph == nullptr)
     {
         return;
     }
-    const auto found = g_tensor_nodes.find(data_ptr);
-    if (found == g_tensor_nodes.end() || found->second.node == nullptr)
+
+    const MappedTensor *source = nullptr;
+    const auto view_it = g_tensor_nodes.find(view_ptr);
+    if (view_it != g_tensor_nodes.end() && view_it->second.node != nullptr)
+    {
+        source = &view_it->second;
+    }
+    else
+    {
+        const auto self_it = g_tensor_nodes.find(self_ptr);
+        if (self_it != g_tensor_nodes.end() && self_it->second.node != nullptr)
+        {
+            source = &self_it->second;
+        }
+    }
+    if (source == nullptr)
     {
         return;
     }
-    const nntile::DataType dtype = found->second.dtype;
-    if (shapes_equal(found->second.node->shape(), view_shape))
+
+    const nntile::DataType dtype = source->dtype;
+    nntile::TensorGraph::TensorNode *const src_node = source->node;
+    if (shapes_equal(src_node->shape(), view_shape))
     {
+        if (view_ptr != self_ptr)
+        {
+            g_tensor_nodes[view_ptr] = *source;
+        }
         return;
     }
     nntile::TensorGraph::TensorNode *view_node = ensure_view_alias_locked(
-        found->second.node,
+        src_node,
         view_shape,
         dtype);
-    MappedTensor updated = found->second;
+    MappedTensor updated = *source;
     updated.node = view_node;
     updated.count = static_cast<std::size_t>(graph_numel(view_shape));
-    g_tensor_nodes[data_ptr] = updated;
+    g_tensor_nodes[view_ptr] = updated;
 }
 
 void track_graph_node(nntile::TensorGraph::TensorNode *node)

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -10,6 +10,7 @@
 #include "nntile_context.h"
 
 #include <ATen/Tensor.h>
+#include <c10/core/DeviceType.h>
 
 #ifdef TORCH_NNTILE_USE_LIBNNTILE
 
@@ -17,6 +18,7 @@
 #include <nntile/tensor/axis_descriptor.hh>
 #include <nntile/tensor/graph.hh>
 #include <nntile/tensor/ops/scatter.hh>
+#include <nntile/tensor/ops/contiguous_view.hh>
 #include <nntile/tensor/tensor_graph_tiling.hh>
 #include <nntile/tile/graph.hh>
 
@@ -186,6 +188,44 @@ nntile::Index graph_numel(const std::vector<nntile::Index> &graph_shape)
         nelems *= dim;
     }
     return nelems;
+}
+
+bool shapes_equal(
+    const std::vector<nntile::Index> &lhs,
+    const std::vector<nntile::Index> &rhs)
+{
+    if (lhs.size() != rhs.size())
+    {
+        return false;
+    }
+    for (std::size_t i = 0; i < lhs.size(); ++i)
+    {
+        if (lhs[i] != rhs[i])
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+nntile::TensorGraph::TensorNode *ensure_view_alias_locked(
+    nntile::TensorGraph::TensorNode *src,
+    const std::vector<nntile::Index> &view_shape,
+    nntile::DataType dtype)
+{
+    if (shapes_equal(src->shape(), view_shape))
+    {
+        return src;
+    }
+    if (graph_numel(src->shape()) != graph_numel(view_shape))
+    {
+        throw std::invalid_argument(
+            "view: storage alias must preserve numel");
+    }
+    auto *view_node = g_graph->data(view_shape, dtype)->set_name("view");
+    track_node(view_node);
+    nntile::tensor::contiguous_view(src, view_node);
+    return view_node;
 }
 
 void copy_tensor_from_runtime(
@@ -846,15 +886,31 @@ nntile::TensorGraph::TensorNode *get_or_create_data_node(
     const auto found = g_tensor_nodes.find(data_ptr);
     if (found != g_tensor_nodes.end() && found->second.node != nullptr)
     {
+        nntile::TensorGraph::TensorNode *existing = found->second.node;
+        if (!shapes_equal(existing->shape(), shape))
+        {
+            if (graph_numel(existing->shape()) != graph_numel(shape))
+            {
+                throw std::invalid_argument(
+                    "get_or_create_data_node: storage alias numel mismatch");
+            }
+            existing = ensure_view_alias_locked(existing, shape, dtype);
+            MappedTensor updated = found->second;
+            updated.node = existing;
+            updated.dtype = dtype;
+            updated.count = static_cast<std::size_t>(graph_numel(shape));
+            g_tensor_nodes[data_ptr] = updated;
+        }
         // Intermediate op output fed into a later op: keep the node for DCE
         // but stop binding/copying through storage PyTorch may free or reuse.
-        if (!found->second.is_persistent_input && found->second.needs_host_copy)
+        MappedTensor &mapped = g_tensor_nodes[data_ptr];
+        if (!mapped.is_persistent_input && mapped.needs_host_copy)
         {
-            found->second.bind_at_execute = false;
-            found->second.needs_host_copy = false;
+            mapped.bind_at_execute = false;
+            mapped.needs_host_copy = false;
         }
-        track_node(found->second.node);
-        return found->second.node;
+        track_node(existing);
+        return existing;
     }
 
     const bool is_persistent =
@@ -920,6 +976,49 @@ nntile::TensorGraph::TensorNode *lookup_data_node(void *data_ptr)
         return nullptr;
     }
     return found->second.node;
+}
+
+void record_view_alias(const at::Tensor &self, const at::Tensor &view)
+{
+    if (!is_graph_mode())
+    {
+        return;
+    }
+    if (view.device().type() != c10::DeviceType::PrivateUse1)
+    {
+        return;
+    }
+    std::vector<nntile::Index> view_shape;
+    view_shape.reserve(static_cast<std::size_t>(view.dim()));
+    for (const auto dim : view.sizes())
+    {
+        view_shape.push_back(static_cast<nntile::Index>(dim));
+    }
+    void *data_ptr = view.data_ptr();
+
+    std::lock_guard<std::mutex> lock(g_recorder_mutex);
+    if (g_graph == nullptr)
+    {
+        return;
+    }
+    const auto found = g_tensor_nodes.find(data_ptr);
+    if (found == g_tensor_nodes.end() || found->second.node == nullptr)
+    {
+        return;
+    }
+    const nntile::DataType dtype = found->second.dtype;
+    if (shapes_equal(found->second.node->shape(), view_shape))
+    {
+        return;
+    }
+    nntile::TensorGraph::TensorNode *view_node = ensure_view_alias_locked(
+        found->second.node,
+        view_shape,
+        dtype);
+    MappedTensor updated = found->second;
+    updated.node = view_node;
+    updated.count = static_cast<std::size_t>(graph_numel(view_shape));
+    g_tensor_nodes[data_ptr] = updated;
 }
 
 void track_graph_node(nntile::TensorGraph::TensorNode *node)
@@ -1186,6 +1285,10 @@ void pin_graph_op_inputs(const std::vector<at::Tensor> & /*inputs*/)
 }
 
 void pin_graph_op_output(const at::Tensor & /*output*/, bool /*pin_output*/)
+{
+}
+
+void record_view_alias(const at::Tensor & /*self*/, const at::Tensor & /*view*/)
 {
 }
 

--- a/torch_nntile/csrc/nntile_graph_recorder_impl.h
+++ b/torch_nntile/csrc/nntile_graph_recorder_impl.h
@@ -52,6 +52,8 @@ nntile::TensorGraph::TensorNode *lookup_data_node(void *data_ptr);
 
 void track_graph_node(nntile::TensorGraph::TensorNode *node);
 
+void record_view_alias(const at::Tensor &self, const at::Tensor &view);
+
 #endif // TORCH_NNTILE_USE_LIBNNTILE
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_kernels.cpp
+++ b/torch_nntile/csrc/nntile_kernels.cpp
@@ -6,6 +6,7 @@
 
 #include "nntile_allocator.h"
 #include "nntile_context.h"
+#include "nntile_executor.h"
 #include "nntile_graph_recorder.h"
 #include "nntile_graph_recorder_impl.h"
 
@@ -505,10 +506,14 @@ at::Tensor permute(const at::Tensor &self, at::IntArrayRef dims)
         sizes[static_cast<size_t>(i)] = self.size(src);
         strides[static_cast<size_t>(i)] = self.stride(src);
     }
-    return reshape_alias(
+    at::Tensor result = reshape_alias(
         self,
         c10::IntArrayRef(sizes),
         c10::IntArrayRef(strides));
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
+    record_view_alias(self, result);
+#endif
+    return result;
 }
 
 at::Tensor contiguous(
@@ -536,6 +541,15 @@ at::Tensor contiguous(
     }
     const float *src = self.data_ptr<float>();
     float *dst = result.data_ptr<float>();
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
+    if (is_graph_mode())
+    {
+        pin_graph_op_inputs({self});
+        pin_graph_op_output(result, true);
+        tensor_contiguous_fp32(src, dst, self.sizes());
+        return result;
+    }
+#endif
     copy_strided_to_contiguous_f32(
         src,
         dst,

--- a/torch_nntile/csrc/nntile_kernels.cpp
+++ b/torch_nntile/csrc/nntile_kernels.cpp
@@ -7,6 +7,7 @@
 #include "nntile_allocator.h"
 #include "nntile_context.h"
 #include "nntile_graph_recorder.h"
+#include "nntile_graph_recorder_impl.h"
 
 #include <ATen/EmptyTensor.h>
 #include <ATen/InferSize.h>
@@ -306,7 +307,11 @@ at::Tensor view(const at::Tensor &self, at::IntArrayRef size)
     TORCH_CHECK(
         stride.has_value(),
         "view size is not compatible with input tensor's size and stride");
-    return reshape_alias(self, inferred, *stride);
+    at::Tensor result = reshape_alias(self, inferred, *stride);
+#ifdef TORCH_NNTILE_USE_LIBNNTILE
+    record_view_alias(self, result);
+#endif
+    return result;
 }
 
 const at::Tensor &resize_(

--- a/torch_nntile/csrc/nntile_module.cpp
+++ b/torch_nntile/csrc/nntile_module.cpp
@@ -23,6 +23,7 @@
 #include "nntile_gemm.h"
 #include "nntile_rms_norm.h"
 #include "nntile_sdpa.h"
+#include "nntile_transpose.h"
 #include "nntile_norm.h"
 #include "nntile_graph_recorder.h"
 #include "nntile_sgd_step.h"
@@ -401,6 +402,18 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         py::arg("grad_out"),
         py::arg("mask") = py::none(),
         py::arg("batch_ndim") = 2);
+    m.def(
+        "model_transpose_forward",
+        &torch_nntile::model_transpose_forward,
+        "NNTile model-code transpose forward",
+        py::arg("x"),
+        py::arg("model_ndim"));
+    m.def(
+        "model_transpose_backward",
+        &torch_nntile::model_transpose_backward,
+        "NNTile model-code transpose backward",
+        py::arg("grad_out"),
+        py::arg("model_ndim"));
     m.def(
         "norm_forward",
         [](const at::Tensor &input,

--- a/torch_nntile/csrc/nntile_module.cpp
+++ b/torch_nntile/csrc/nntile_module.cpp
@@ -20,6 +20,7 @@
 
 #include "nntile_context.h"
 #include "nntile_cross_entropy.h"
+#include "nntile_gemm.h"
 #include "nntile_rms_norm.h"
 #include "nntile_sdpa.h"
 #include "nntile_norm.h"
@@ -287,6 +288,24 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         "print_axis_groups",
         &torch_nntile::print_axis_groups,
         "Print pending TensorGraph axis groups to stdout");
+    m.def(
+        "gemm_forward",
+        &torch_nntile::gemm_forward,
+        "NNTile GEMM forward (N-D contraction, C++ graph API semantics)",
+        py::arg("a"),
+        py::arg("b"),
+        py::arg("ndim"),
+        py::arg("batch_ndim") = 0);
+    m.def(
+        "gemm_backward",
+        &torch_nntile::gemm_backward,
+        "NNTile GEMM backward",
+        py::arg("a"),
+        py::arg("b"),
+        py::arg("grad_out"),
+        py::arg("ndim"),
+        py::arg("batch_ndim"),
+        py::arg("output_mask"));
     m.def(
         "cross_entropy_forward",
         &torch_nntile::cross_entropy_forward,

--- a/torch_nntile/csrc/nntile_transpose.cpp
+++ b/torch_nntile/csrc/nntile_transpose.cpp
@@ -1,0 +1,102 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_transpose.cpp
+ */
+
+#include "nntile_transpose.h"
+
+#include "nntile_executor.h"
+#include "nntile_graph_recorder_impl.h"
+
+#include <ATen/TensorUtils.h>
+
+#include <vector>
+
+namespace torch_nntile
+{
+
+namespace
+{
+
+bool is_nntile_device(c10::Device device)
+{
+    return device.type() == c10::DeviceType::PrivateUse1;
+}
+
+void check_model_transpose_input(
+    const at::Tensor &tensor,
+    int64_t model_ndim,
+    const char *name)
+{
+    TORCH_CHECK(
+        is_nntile_device(tensor.device()),
+        "nntile model_transpose: expected nntile ",
+        name);
+    TORCH_CHECK(
+        tensor.scalar_type() == at::ScalarType::Float,
+        "nntile model_transpose supports float32 only");
+    TORCH_CHECK(tensor.is_contiguous(), "nntile model_transpose requires contiguous");
+    const int64_t n = tensor.dim();
+    TORCH_CHECK(
+        model_ndim > 0 && model_ndim < n,
+        "nntile model_transpose: model_ndim must be in (0, ",
+        n,
+        "), got ",
+        model_ndim);
+}
+
+std::vector<int64_t> permuted_sizes(
+    c10::IntArrayRef sizes,
+    int64_t rot)
+{
+    const int64_t n = static_cast<int64_t>(sizes.size());
+    std::vector<int64_t> out(static_cast<std::size_t>(n));
+    for (int64_t i = 0; i < n; ++i)
+    {
+        out[static_cast<std::size_t>(i)] = sizes[(i + rot) % n];
+    }
+    return out;
+}
+
+} // namespace
+
+at::Tensor model_transpose_forward(
+    const at::Tensor &x,
+    int64_t model_ndim)
+{
+    check_model_transpose_input(x, model_ndim, "input");
+    const int64_t n = x.dim();
+    const int64_t tensor_ndim = n - model_ndim;
+    at::Tensor out = at::empty(
+        permuted_sizes(x.sizes(), tensor_ndim),
+        x.options().memory_format(at::MemoryFormat::Contiguous));
+    pin_graph_op_inputs({x});
+    pin_graph_op_output(out, true);
+    tensor_model_transpose_forward_fp32(
+        x.data_ptr<float>(),
+        x.sizes(),
+        out.data_ptr<float>(),
+        model_ndim);
+    return out;
+}
+
+at::Tensor model_transpose_backward(
+    const at::Tensor &grad_out,
+    int64_t model_ndim)
+{
+    check_model_transpose_input(grad_out, model_ndim, "grad_out");
+    at::Tensor grad_x = at::empty(
+        permuted_sizes(grad_out.sizes(), model_ndim),
+        grad_out.options().memory_format(at::MemoryFormat::Contiguous));
+    pin_graph_op_inputs({grad_out});
+    pin_graph_op_output(grad_x, false);
+    tensor_model_transpose_backward_fp32(
+        grad_out.data_ptr<float>(),
+        grad_out.sizes(),
+        grad_x.data_ptr<float>(),
+        model_ndim);
+    return grad_x;
+}
+
+} // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_transpose.h
+++ b/torch_nntile/csrc/nntile_transpose.h
@@ -1,0 +1,22 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file torch_nntile/csrc/nntile_transpose.h
+ */
+
+#pragma once
+
+#include <ATen/ATen.h>
+
+namespace torch_nntile
+{
+
+at::Tensor model_transpose_forward(
+    const at::Tensor &x,
+    int64_t model_ndim);
+
+at::Tensor model_transpose_backward(
+    const at::Tensor &grad_out,
+    int64_t model_ndim);
+
+} // namespace torch_nntile

--- a/torch_nntile/examples/gpt2_minimal_forward.py
+++ b/torch_nntile/examples/gpt2_minimal_forward.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/examples/gpt2_minimal_forward.py
+# Minimal GPT-2 forward and backward on device="nntile".
+
+from __future__ import annotations
+
+import torch
+import torch_nntile
+from transformers import GPT2Config, GPT2LMHeadModel
+
+from torch_nntile.models.gpt2_hf_loader import load_hf_into_gpt2_lm_head
+from torch_nntile.models.gpt2_minimal import GPT2LMHead
+
+
+def main() -> None:
+    torch_nntile.init_context(ncpu=1, ncuda=0, cpu_fallback=False)
+    torch_nntile.restrict_cpu()
+
+    config = GPT2Config(
+        n_layer=2,
+        n_head=2,
+        n_embd=64,
+        n_positions=32,
+        vocab_size=128,
+        n_inner=256,
+        attn_pdrop=0.0,
+        resid_pdrop=0.0,
+        embd_pdrop=0.0,
+        tie_word_embeddings=True,
+    )
+    config._attn_implementation = "eager"
+
+    torch.manual_seed(0)
+    hf = GPT2LMHeadModel(config).eval().float()
+    model = GPT2LMHead(config).eval().float()
+    load_hf_into_gpt2_lm_head(model, hf)
+    model = model.to("nntile")
+
+    input_ids = torch.randint(0, config.vocab_size, (2, 8))
+    with torch.no_grad():
+        ref = hf(input_ids).logits
+        out = model(input_ids).cpu()
+    print("forward match:", torch.allclose(out, ref, rtol=1e-4, atol=1e-4))
+
+    for p in model.parameters():
+        p.requires_grad_(True)
+    grad_out = torch.randn_like(out).to("nntile")
+    model.zero_grad(set_to_none=True)
+    logits = model(input_ids)
+    logits.backward(grad_out)
+    wte_grad = model.transformer.wte.weight.grad
+    print(
+        "backward ok, wte grad norm:",
+        wte_grad.norm().cpu().item() if wte_grad is not None else None,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -25,6 +25,7 @@ CSRC = [
     "csrc/nntile_context.cpp",
     "csrc/nntile_graph_recorder.cpp",
     "csrc/nntile_gemm_layout.cpp",
+    "csrc/nntile_gemm.cpp",
     "csrc/nntile_executor.cpp",
     "csrc/nntile_add.cpp",
     "csrc/nntile_mul.cpp",

--- a/torch_nntile/setup.py
+++ b/torch_nntile/setup.py
@@ -56,6 +56,7 @@ CSRC = [
     "csrc/nntile_repeat.cpp",
     "csrc/nntile_embedding.cpp",
     "csrc/nntile_sdpa.cpp",
+    "csrc/nntile_transpose.cpp",
 ]
 
 

--- a/torch_nntile/tests/test_gemm_nd.py
+++ b/torch_nntile/tests/test_gemm_nd.py
@@ -1,0 +1,163 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_gemm_nd.py
+# N-D GEMM parity tests (GPT-2 attention projection shapes).
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from torch_nntile import _C
+from torch_nntile.gemm import gemm
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _init_nntile():
+    import torch_nntile
+
+    if not torch_nntile.is_context_initialized():
+        torch_nntile.init_context(
+            ncpu=1,
+            ncuda=0,
+            verbose=0,
+            cpu_fallback=False,
+            runtime_mode="eager",
+        )
+    torch_nntile.restrict_cpu()
+    yield
+
+
+def _cpu_ref_gemm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    ndim: int,
+    batch_ndim: int,
+) -> torch.Tensor:
+    """Reference via explicit einsum-style reshape (batch_ndim=0 only)."""
+    assert batch_ndim == 0
+    a_rank = a.dim()
+    b_rank = b.dim()
+    m_shape = a.shape[: a_rank - ndim]
+    k_a = a.shape[a_rank - ndim :]
+    k_b = b.shape[:ndim]
+    n_shape = b.shape[ndim:]
+    assert k_a == k_b
+    a_flat = a.reshape(*m_shape, *k_a)
+    b_flat = b.reshape(*k_b, *n_shape)
+    k = int(torch.tensor(k_a).prod().item())
+    m = int(torch.tensor(m_shape).prod().item()) if m_shape else 1
+    n = int(torch.tensor(n_shape).prod().item()) if n_shape else 1
+    out = a_flat.reshape(m, k) @ b_flat.reshape(k, n)
+    return out.reshape(*m_shape, *n_shape)
+
+
+def test_gemm_qkv_projection_shape():
+    bsz, seq, hidden, hs, n_heads = 2, 8, 64, 16, 4
+    x = torch.randn(bsz, seq, hidden)
+    w = torch.randn(hidden, hs, n_heads)
+    x_n = x.to("nntile")
+    w_n = w.to("nntile")
+    out = gemm(x_n, w_n, ndim=1, batch_ndim=0)
+    assert out.shape == (bsz, seq, hs, n_heads)
+    ref = _cpu_ref_gemm(x, w, ndim=1, batch_ndim=0)
+    assert torch.allclose(out.cpu(), ref, atol=1e-5, rtol=1e-5)
+
+
+def test_gemm_output_projection_shape():
+    bsz, seq, hs, n_heads, hidden = 2, 8, 16, 4, 64
+    attn = torch.randn(bsz, seq, hs, n_heads)
+    w_o = torch.randn(hs, n_heads, hidden)
+    attn_n = attn.to("nntile")
+    w_o_n = w_o.to("nntile")
+    out = gemm(attn_n, w_o_n, ndim=2, batch_ndim=0)
+    assert out.shape == (bsz, seq, hidden)
+    ref = _cpu_ref_gemm(attn, w_o, ndim=2, batch_ndim=0)
+    assert torch.allclose(out.cpu(), ref, atol=1e-5, rtol=1e-5)
+
+
+def test_matmul_inferred_qkv():
+    bsz, seq, hidden, hs, n_heads = 2, 8, 64, 16, 4
+    x = torch.randn(bsz, seq, hidden)
+    w = torch.randn(hidden, hs, n_heads)
+    out = torch.matmul(x.to("nntile"), w.to("nntile"))
+    assert out.shape == (bsz, seq, hs, n_heads)
+    ref = _cpu_ref_gemm(x, w, ndim=1, batch_ndim=0)
+    assert torch.allclose(out.cpu(), ref, atol=1e-5, rtol=1e-5)
+
+
+def test_gemm_qkv_backward():
+    bsz, seq, hidden, hs, n_heads = 2, 8, 64, 16, 4
+    x = torch.randn(bsz, seq, hidden, requires_grad=True)
+    w = torch.randn(hidden, hs, n_heads, requires_grad=True)
+    x_n = x.detach().to("nntile").requires_grad_(True)
+    w_n = w.detach().to("nntile").requires_grad_(True)
+    out = gemm(x_n, w_n, ndim=1, batch_ndim=0)
+    grad_out = torch.randn_like(out.cpu()).to("nntile")
+    out.backward(grad_out)
+    ref_out = _cpu_ref_gemm(x, w, ndim=1, batch_ndim=0)
+    ref_out.backward(grad_out.cpu())
+    assert torch.allclose(x_n.grad.cpu(), x.grad, atol=1e-4, rtol=1e-4)
+    assert torch.allclose(w_n.grad.cpu(), w.grad, atol=1e-4, rtol=1e-4)
+
+
+def test_gemm_graph_mode_no_view():
+    import subprocess
+    import sys
+    import textwrap
+    from pathlib import Path
+
+    pkg_root = Path(__file__).resolve().parent.parent
+    repo = Path(__file__).resolve().parents[2]
+    script = textwrap.dedent(
+        """
+        import torch
+        import torch_nntile
+        from torch_nntile.gemm import gemm
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+        bsz, seq, hidden, hs, n_heads = 2, 4, 32, 8, 4
+        x = torch.randn(bsz, seq, hidden).to("nntile")
+        w = torch.randn(hidden, hs, n_heads).to("nntile")
+        bias = (
+            torch.randn(n_heads, hs)
+            .transpose(0, 1)
+            .view(1, 1, hs, n_heads)
+            .expand(bsz, seq, hs, n_heads)
+            .contiguous()
+            .to("nntile")
+        )
+        proj = gemm(x, w, ndim=1, batch_ndim=0)
+        out = proj + bias
+        assert out.shape == (bsz, seq, hs, n_heads)
+        torch_nntile.execute()
+        """
+    )
+    import os
+
+    env = dict(os.environ)
+    build_lib = repo / "build" / "nntile"
+    starpu_lib = "/opt/starpu/lib"
+    ld = env.get("LD_LIBRARY_PATH", "")
+    for part in (str(build_lib), starpu_lib):
+        if part not in ld.split(":"):
+            ld = f"{part}:{ld}" if ld else part
+    env["LD_LIBRARY_PATH"] = ld
+    env["PYTHONPATH"] = f"{pkg_root}:{env.get('PYTHONPATH', '')}"
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr

--- a/torch_nntile/tests/test_gpt2_lm_head_parity.py
+++ b/torch_nntile/tests/test_gpt2_lm_head_parity.py
@@ -1,0 +1,402 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_gpt2_lm_head_parity.py
+# GPT2LMHead forward/backward parity vs HuggingFace GPT2LMHeadModel.
+
+from __future__ import annotations
+
+import pytest
+import torch
+from transformers import GPT2Config, GPT2LMHeadModel
+
+import torch_nntile
+from torch_nntile import _C
+from torch_nntile.models.gpt2_hf_loader import load_hf_into_gpt2_lm_head
+from torch_nntile.models.gpt2_minimal import (
+    GPT2Attention,
+    GPT2Block,
+    GPT2LMHead,
+    GPT2MLP,
+    GPT2Model,
+    make_causal_sdpa_mask,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _nntile_context_no_fallback():
+    if not _C.has_libnntile():
+        return
+    if torch_nntile.is_cpu_fallback_enabled():
+        pytest.skip(
+            "context has CPU fallback enabled; rebuild with cpu_fallback=False"
+        )
+    if not torch_nntile.is_context_initialized():
+        torch_nntile.init_context(
+            ncpu=1,
+            ncuda=0,
+            verbose=0,
+            cpu_fallback=False,
+            runtime_mode="eager",
+        )
+    torch_nntile.restrict_cpu()
+    yield
+
+
+@pytest.fixture
+def tiny_gpt2_config() -> GPT2Config:
+    config = GPT2Config(
+        n_layer=2,
+        n_head=2,
+        n_embd=64,
+        n_positions=32,
+        vocab_size=128,
+        n_inner=256,
+        attn_pdrop=0.0,
+        resid_pdrop=0.0,
+        embd_pdrop=0.0,
+        tie_word_embeddings=True,
+    )
+    config._attn_implementation = "eager"
+    return config
+
+
+def _make_models(config: GPT2Config):
+    torch.manual_seed(0)
+    hf = GPT2LMHeadModel(config).eval().float()
+    minimal = GPT2LMHead(config).eval().float()
+    load_hf_into_gpt2_lm_head(minimal, hf)
+    minimal = minimal.to("nntile")
+    if config.tie_word_embeddings:
+        minimal.tie_weights()
+    return hf, minimal
+
+
+def _assert_close(
+    got: torch.Tensor,
+    ref: torch.Tensor,
+    *,
+    rtol: float = 1e-4,
+    atol: float = 1e-4,
+) -> None:
+    torch.testing.assert_close(got.cpu(), ref.cpu(), rtol=rtol, atol=atol)
+
+
+def test_gpt2_model_forward_shape(tiny_gpt2_config):
+    _, minimal = _make_models(tiny_gpt2_config)
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    hidden = minimal.transformer(input_ids)
+    assert hidden.shape == (2, 8, tiny_gpt2_config.n_embd)
+    assert hidden.dtype == torch.float32
+
+
+def test_gpt2_lm_head_forward_shape(tiny_gpt2_config):
+    _, minimal = _make_models(tiny_gpt2_config)
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    logits = minimal(input_ids)
+    assert logits.shape == (2, 8, tiny_gpt2_config.vocab_size)
+    assert logits.dtype == torch.float32
+
+
+def test_gpt2_lm_head_forward_matches_hf_tied(tiny_gpt2_config):
+    hf, minimal = _make_models(tiny_gpt2_config)
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    with torch.no_grad():
+        ref = hf(input_ids).logits
+        out = minimal(input_ids)
+    _assert_close(out, ref)
+
+
+def test_gpt2_lm_head_forward_matches_hf_untied(tiny_gpt2_config):
+    tiny_gpt2_config.tie_word_embeddings = False
+    hf, minimal = _make_models(tiny_gpt2_config)
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    with torch.no_grad():
+        ref = hf(input_ids).logits
+        out = minimal(input_ids)
+    _assert_close(out, ref)
+
+
+def test_gpt2_lm_head_tied_weights_share_storage(tiny_gpt2_config):
+    _, minimal = _make_models(tiny_gpt2_config)
+    assert (
+        minimal.lm_head.weight.data_ptr()
+        == minimal.transformer.wte.weight.data_ptr()
+    )
+
+
+def test_gpt2_block_forward_matches_hf(tiny_gpt2_config):
+    torch.manual_seed(1)
+    hf = GPT2LMHeadModel(tiny_gpt2_config).eval().float()
+    block = GPT2Block(tiny_gpt2_config).eval().float()
+    hf_block = hf.transformer.h[0]
+
+    block.ln_1.load_state_dict(hf_block.ln_1.state_dict())
+    block.ln_2.load_state_dict(hf_block.ln_2.state_dict())
+    load_hf_into_gpt2_lm_head(
+        GPT2LMHead(tiny_gpt2_config),
+        hf,
+    )
+    from torch_nntile.models.gpt2_hf_loader import _split_hf_attn_weights
+
+    hidden = tiny_gpt2_config.n_embd
+    n_heads = tiny_gpt2_config.n_head
+    head_size = hidden // n_heads
+    attn_w = _split_hf_attn_weights(hf_block.attn, hidden, n_heads, head_size)
+    block.attn.q_weight.data.copy_(attn_w["q_weight"])
+    block.attn.k_weight.data.copy_(attn_w["k_weight"])
+    block.attn.v_weight.data.copy_(attn_w["v_weight"])
+    block.attn.o_weight.data.copy_(attn_w["o_weight"])
+    block.attn.q_bias.data.copy_(attn_w["q_bias"])
+    block.attn.k_bias.data.copy_(attn_w["k_bias"])
+    block.attn.v_bias.data.copy_(attn_w["v_bias"])
+    block.attn.o_bias.data.copy_(attn_w["o_bias"])
+    block.mlp.c_fc.weight.data.copy_(hf_block.mlp.c_fc.weight.data.t())
+    block.mlp.c_fc.bias.data.copy_(hf_block.mlp.c_fc.bias.data)
+    block.mlp.c_proj.weight.data.copy_(hf_block.mlp.c_proj.weight.data.t())
+    block.mlp.c_proj.bias.data.copy_(hf_block.mlp.c_proj.bias.data)
+
+    block = block.to("nntile")
+    x_cpu = torch.randn(2, 8, hidden)
+    mask = make_causal_sdpa_mask(8)
+    with torch.no_grad():
+        ref = hf_block(x_cpu, attention_mask=None)[0]
+        out = block(x_cpu.to("nntile"), mask)
+    _assert_close(out, ref)
+
+
+def test_gpt2_mlp_forward_matches_hf(tiny_gpt2_config):
+    torch.manual_seed(2)
+    from transformers.models.gpt2.modeling_gpt2 import GPT2MLP as HfMLP
+
+    hf_mlp = HfMLP(tiny_gpt2_config.n_inner, tiny_gpt2_config).eval().float()
+    mlp = GPT2MLP(tiny_gpt2_config).eval().float()
+    mlp.c_fc.weight.data.copy_(hf_mlp.c_fc.weight.data.t())
+    mlp.c_fc.bias.data.copy_(hf_mlp.c_fc.bias.data)
+    mlp.c_proj.weight.data.copy_(hf_mlp.c_proj.weight.data.t())
+    mlp.c_proj.bias.data.copy_(hf_mlp.c_proj.bias.data)
+    mlp = mlp.to("nntile")
+
+    x_cpu = torch.randn(2, 8, tiny_gpt2_config.n_embd)
+    with torch.no_grad():
+        ref = hf_mlp(x_cpu)
+        out = mlp(x_cpu.to("nntile"))
+    _assert_close(out, ref)
+
+
+def test_gpt2_mlp_backward_matches_hf(tiny_gpt2_config):
+    torch.manual_seed(3)
+    from transformers.models.gpt2.modeling_gpt2 import GPT2MLP as HfMLP
+
+    hf_mlp = HfMLP(tiny_gpt2_config.n_inner, tiny_gpt2_config).eval().float()
+    mlp = GPT2MLP(tiny_gpt2_config).eval().float()
+    mlp.c_fc.weight.data.copy_(hf_mlp.c_fc.weight.data.t())
+    mlp.c_fc.bias.data.copy_(hf_mlp.c_fc.bias.data)
+    mlp.c_proj.weight.data.copy_(hf_mlp.c_proj.weight.data.t())
+    mlp.c_proj.bias.data.copy_(hf_mlp.c_proj.bias.data)
+    mlp = mlp.to("nntile")
+
+    x_cpu = torch.randn(2, 8, tiny_gpt2_config.n_embd, requires_grad=True)
+    grad_out = torch.randn(2, 8, tiny_gpt2_config.n_embd)
+    y_ref = hf_mlp(x_cpu)
+    y_ref.backward(grad_out)
+
+    x_nnt = x_cpu.detach().to("nntile").requires_grad_(True)
+    y = mlp(x_nnt)
+    y.backward(grad_out.to("nntile"))
+
+    _assert_close(x_nnt.grad, x_cpu.grad)
+    _assert_close(mlp.c_fc.weight.grad, hf_mlp.c_fc.weight.grad.t())
+    _assert_close(mlp.c_proj.weight.grad, hf_mlp.c_proj.weight.grad.t())
+
+
+def test_gpt2_attention_forward_matches_hf(tiny_gpt2_config):
+    torch.manual_seed(4)
+    from transformers.models.gpt2.modeling_gpt2 import GPT2Attention as HfAttention
+
+    hf_attn = HfAttention(tiny_gpt2_config, layer_idx=0).eval().float()
+    attn = GPT2Attention(tiny_gpt2_config).eval().float()
+    from torch_nntile.models.gpt2_hf_loader import _split_hf_attn_weights
+
+    hidden = tiny_gpt2_config.n_embd
+    n_heads = tiny_gpt2_config.n_head
+    head_size = hidden // n_heads
+    attn_w = _split_hf_attn_weights(hf_attn, hidden, n_heads, head_size)
+    attn.q_weight.data.copy_(attn_w["q_weight"])
+    attn.k_weight.data.copy_(attn_w["k_weight"])
+    attn.v_weight.data.copy_(attn_w["v_weight"])
+    attn.o_weight.data.copy_(attn_w["o_weight"])
+    attn.q_bias.data.copy_(attn_w["q_bias"])
+    attn.k_bias.data.copy_(attn_w["k_bias"])
+    attn.v_bias.data.copy_(attn_w["v_bias"])
+    attn.o_bias.data.copy_(attn_w["o_bias"])
+    attn = attn.to("nntile")
+
+    x_cpu = torch.randn(2, 8, hidden)
+    mask = make_causal_sdpa_mask(8)
+    with torch.no_grad():
+        ref = hf_attn(x_cpu)[0]
+        out = attn(x_cpu.to("nntile"), mask)
+    _assert_close(out, ref)
+
+
+def test_gpt2_attention_backward_matches_hf(tiny_gpt2_config):
+    torch.manual_seed(5)
+    from transformers.models.gpt2.modeling_gpt2 import GPT2Attention as HfAttention
+
+    hf_attn = HfAttention(tiny_gpt2_config, layer_idx=0).eval().float()
+    attn = GPT2Attention(tiny_gpt2_config).eval().float()
+    from torch_nntile.models.gpt2_hf_loader import _split_hf_attn_weights
+
+    hidden = tiny_gpt2_config.n_embd
+    n_heads = tiny_gpt2_config.n_head
+    head_size = hidden // n_heads
+    attn_w = _split_hf_attn_weights(hf_attn, hidden, n_heads, head_size)
+    attn.q_weight.data.copy_(attn_w["q_weight"])
+    attn.k_weight.data.copy_(attn_w["k_weight"])
+    attn.v_weight.data.copy_(attn_w["v_weight"])
+    attn.o_weight.data.copy_(attn_w["o_weight"])
+    attn.q_bias.data.copy_(attn_w["q_bias"])
+    attn.k_bias.data.copy_(attn_w["k_bias"])
+    attn.v_bias.data.copy_(attn_w["v_bias"])
+    attn.o_bias.data.copy_(attn_w["o_bias"])
+
+    for p in hf_attn.parameters():
+        p.requires_grad_(True)
+    for p in attn.parameters():
+        p.requires_grad_(True)
+    attn = attn.to("nntile")
+
+    x_cpu = torch.randn(2, 8, hidden, requires_grad=True)
+    grad_out = torch.randn(2, 8, hidden)
+    mask = make_causal_sdpa_mask(8)
+
+    y_ref = hf_attn(x_cpu)[0]
+    y_ref.backward(grad_out)
+
+    x_nnt = x_cpu.detach().to("nntile").requires_grad_(True)
+    y = attn(x_nnt, mask)
+    y.backward(grad_out.to("nntile"))
+
+    _assert_close(x_nnt.grad, x_cpu.grad, atol=1e-3)
+
+
+def test_gpt2_lm_head_backward_matches_hf_tied(tiny_gpt2_config):
+    hf, minimal = _make_models(tiny_gpt2_config)
+    for p in hf.parameters():
+        p.requires_grad_(True)
+    for p in minimal.parameters():
+        p.requires_grad_(True)
+
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    grad_out = torch.randn(2, 8, tiny_gpt2_config.vocab_size)
+
+    hf.zero_grad(set_to_none=True)
+    logits_ref = hf(input_ids).logits
+    logits_ref.backward(grad_out)
+
+    minimal.zero_grad(set_to_none=True)
+    logits = minimal(input_ids)
+    logits.backward(grad_out.to("nntile"))
+
+    _assert_close(minimal.transformer.wte.weight.grad, hf.transformer.wte.weight.grad, atol=1e-3)
+
+
+def test_gpt2_lm_head_backward_matches_hf_untied(tiny_gpt2_config):
+    tiny_gpt2_config.tie_word_embeddings = False
+    hf, minimal = _make_models(tiny_gpt2_config)
+    for p in hf.parameters():
+        p.requires_grad_(True)
+    for p in minimal.parameters():
+        p.requires_grad_(True)
+
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    grad_out = torch.randn(2, 8, tiny_gpt2_config.vocab_size)
+
+    hf.zero_grad(set_to_none=True)
+    hf(input_ids).logits.backward(grad_out)
+
+    minimal.zero_grad(set_to_none=True)
+    minimal(input_ids).backward(grad_out.to("nntile"))
+
+    _assert_close(minimal.lm_head.weight.grad, hf.lm_head.weight.grad, atol=1e-3)
+    _assert_close(minimal.transformer.wpe.weight.grad, hf.transformer.wpe.weight.grad)
+
+
+@pytest.mark.xfail(
+    reason="graph-mode mm can return rank-3 tensors; GPT2 projection needs eager for now",
+    strict=False,
+)
+def test_gpt2_lm_head_graph_mode_forward(tiny_gpt2_config):
+    import subprocess
+    import sys
+    import textwrap
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    repo = Path(__file__).resolve().parents[2]
+    env = dict(**__import__("os").environ)
+    build_lib = repo / "build" / "nntile"
+    starpu_lib = "/opt/starpu/lib"
+    ld = env.get("LD_LIBRARY_PATH", "")
+    for part in (str(build_lib), starpu_lib):
+        if part not in ld.split(":"):
+            ld = f"{part}:{ld}" if ld else part
+    env["LD_LIBRARY_PATH"] = ld
+    env["PYTHONPATH"] = f"{root}:{env.get('PYTHONPATH', '')}"
+
+    script = textwrap.dedent(
+        """
+        import torch
+        import torch_nntile
+        from transformers import GPT2Config, GPT2LMHeadModel
+        from torch_nntile.models.gpt2_minimal import GPT2LMHead
+        from torch_nntile.models.gpt2_hf_loader import load_hf_into_gpt2_lm_head
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+
+        config = GPT2Config(
+            n_layer=1, n_head=2, n_embd=32, n_positions=16,
+            vocab_size=64, n_inner=128, attn_pdrop=0.0, resid_pdrop=0.0,
+            tie_word_embeddings=True,
+        )
+        config._attn_implementation = "eager"
+        torch.manual_seed(0)
+        hf = GPT2LMHeadModel(config).eval().float()
+        model = GPT2LMHead(config).eval().float()
+        load_hf_into_gpt2_lm_head(model, hf)
+        model = model.to("nntile")
+
+        input_ids = torch.randint(0, config.vocab_size, (1, 4))
+        with torch.no_grad():
+            ref = hf(input_ids).logits
+        assert torch_nntile.has_pending_graph() is False
+        out = model(input_ids)
+        assert torch_nntile.has_pending_graph()
+        torch_nntile.compile_graph()
+        torch_nntile.run()
+        assert not torch_nntile.has_pending_graph()
+        assert torch.allclose(out.cpu(), ref, rtol=1e-4, atol=1e-4)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"graph forward subprocess failed ({proc.returncode})\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )

--- a/torch_nntile/tests/test_gpt2_lm_head_parity.py
+++ b/torch_nntile/tests/test_gpt2_lm_head_parity.py
@@ -7,6 +7,10 @@
 from __future__ import annotations
 
 import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("transformers")
+
 import torch
 from transformers import GPT2Config, GPT2LMHeadModel
 

--- a/torch_nntile/tests/test_gpt2_lm_head_parity.py
+++ b/torch_nntile/tests/test_gpt2_lm_head_parity.py
@@ -330,7 +330,8 @@ def test_gpt2_lm_head_backward_matches_hf_untied(tiny_gpt2_config):
 
 
 @pytest.mark.xfail(
-    reason="graph-mode mm can return rank-3 tensors; GPT2 projection needs eager for now",
+    reason="GPT2 graph logits parity vs HF still diverges (~0.17 max diff); "
+    "mm+view ndim fixed in test_graph_mode_mm_view_add_ndim",
     strict=False,
 )
 def test_gpt2_lm_head_graph_mode_forward(tiny_gpt2_config):
@@ -385,6 +386,7 @@ def test_gpt2_lm_head_graph_mode_forward(tiny_gpt2_config):
         torch_nntile.compile_graph()
         torch_nntile.run()
         assert not torch_nntile.has_pending_graph()
+        assert out.shape == ref.shape
         assert torch.allclose(out.cpu(), ref, rtol=1e-4, atol=1e-4)
         """
     )

--- a/torch_nntile/tests/test_graph_execution.py
+++ b/torch_nntile/tests/test_graph_execution.py
@@ -327,6 +327,34 @@ def test_graph_nntile_loss_backward_without_scalar_read():
     )
 
 
+def test_graph_mode_mm_view_add_ndim():
+    """mm output viewed to higher rank must match bias ndim in graph mode."""
+    _run_graph_subprocess(
+        """
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False, runtime_mode="graph"
+        )
+        torch_nntile.restrict_cpu()
+
+        x2d = torch.randn(4, 8).to("nntile")
+        w = torch.randn(8, 32).to("nntile")
+        bias = torch.randn(1, 4, 16, 2).to("nntile")
+
+        proj = torch.mm(x2d, w)
+        proj4 = proj.view(1, 4, 16, 2)
+        out = proj4 + bias
+        assert torch_nntile.has_pending_graph()
+        torch_nntile.compile_graph()
+        torch_nntile.run()
+        assert out.shape == (1, 4, 16, 2)
+        assert out.device.type == "nntile"
+        """
+    )
+
+
 def test_eager_mode_runs_immediately():
     _run_graph_subprocess(
         """

--- a/torch_nntile/tests/test_sdpa_parity.py
+++ b/torch_nntile/tests/test_sdpa_parity.py
@@ -42,6 +42,31 @@ def _nntile_context_no_fallback():
     yield
 
 
+def _projection_to_kernel_layout(x: torch.Tensor) -> torch.Tensor:
+    """``[batch, seq, head_size, n_heads]`` -> ``[n_heads, batch, seq, head_size]``."""
+    return x.permute(3, 0, 1, 2).contiguous()
+
+
+def _kernel_to_projection_layout(x: torch.Tensor) -> torch.Tensor:
+    """``[n_heads, batch, seq, head_size]`` -> ``[batch, seq, head_size, n_heads]``."""
+    return x.permute(1, 2, 3, 0).contiguous()
+
+
+def _reference_sdpa_projection(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    mask: torch.Tensor | None,
+) -> torch.Tensor:
+    out = _reference_sdpa_eager(
+        _projection_to_kernel_layout(q),
+        _projection_to_kernel_layout(k),
+        _projection_to_kernel_layout(v),
+        mask,
+    )
+    return _kernel_to_projection_layout(out)
+
+
 def _reference_sdpa_eager(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -72,9 +97,9 @@ def _reference_sdpa_eager(
 @pytest.mark.parametrize(
     "shape",
     [
-        (4, 2, 8, 16),
-        (2, 3, 6, 8),
-        (1, 1, 4, 8),
+        (2, 8, 16, 4),
+        (3, 6, 8, 2),
+        (1, 4, 8, 1),
     ],
 )
 def test_sdpa_forward_matches_reference(shape):
@@ -82,7 +107,7 @@ def test_sdpa_forward_matches_reference(shape):
     q_cpu = torch.randn(*shape)
     k_cpu = torch.randn(*shape)
     v_cpu = torch.randn(*shape)
-    ref = _reference_sdpa_eager(q_cpu, k_cpu, v_cpu, None)
+    ref = _reference_sdpa_projection(q_cpu, k_cpu, v_cpu, None)
 
     q = q_cpu.to("nntile")
     k = k_cpu.to("nntile")
@@ -92,13 +117,13 @@ def test_sdpa_forward_matches_reference(shape):
     assert not torch_nntile.has_pending_graph()
 
 
-@pytest.mark.parametrize("shape", [(4, 2, 8, 16), (2, 3, 6, 8)])
+@pytest.mark.parametrize("shape", [(2, 8, 16, 4), (3, 6, 8, 2)])
 def test_sdpa_backward_matches_reference(shape):
     torch.manual_seed(1)
     q_cpu = torch.randn(*shape, requires_grad=True)
     k_cpu = torch.randn(*shape, requires_grad=True)
     v_cpu = torch.randn(*shape, requires_grad=True)
-    ref = _reference_sdpa_eager(q_cpu, k_cpu, v_cpu, None)
+    ref = _reference_sdpa_projection(q_cpu, k_cpu, v_cpu, None)
     grad_out = torch.randn_like(ref)
     ref.backward(grad_out)
 
@@ -114,8 +139,8 @@ def test_sdpa_backward_matches_reference(shape):
 
 
 def test_sdpa_forward_with_mask_matches_reference():
-    shape = (2, 2, 6, 8)
-    seq = shape[2]
+    shape = (2, 6, 8, 2)
+    seq = shape[1]
     torch.manual_seed(2)
     q_cpu = torch.randn(*shape)
     k_cpu = torch.randn(*shape)
@@ -125,7 +150,7 @@ def test_sdpa_forward_with_mask_matches_reference():
         for key in range(seq):
             mask[query, key] = key <= query
 
-    ref = _reference_sdpa_eager(q_cpu, k_cpu, v_cpu, mask)
+    ref = _reference_sdpa_projection(q_cpu, k_cpu, v_cpu, mask)
     out = sdpa_eager(
         q_cpu.to("nntile"),
         k_cpu.to("nntile"),
@@ -138,8 +163,8 @@ def test_sdpa_forward_with_mask_matches_reference():
 
 def test_sdpa_mask_axis_order_matches_causal_layout():
     """Mask dim0=query, dim1=key (libnntile sdpa_causal_mask_bool_fill layout)."""
-    shape = (1, 1, 5, 8)
-    seq = shape[2]
+    shape = (1, 5, 8, 1)
+    seq = shape[1]
     torch.manual_seed(7)
     q_cpu = torch.randn(*shape)
     k_cpu = torch.randn(*shape)
@@ -149,7 +174,7 @@ def test_sdpa_mask_axis_order_matches_causal_layout():
         for key in range(seq):
             mask[query, key] = key <= query
 
-    ref = _reference_sdpa_eager(q_cpu, k_cpu, v_cpu, mask)
+    ref = _reference_sdpa_projection(q_cpu, k_cpu, v_cpu, mask)
     out = sdpa_eager(
         q_cpu.to("nntile"),
         k_cpu.to("nntile"),
@@ -202,9 +227,9 @@ def test_sdpa_module_forward():
 
 
 def test_sdpa_rejects_cpu_tensors():
-    q = torch.randn(2, 1, 4, 8)
-    k = torch.randn(2, 1, 4, 8)
-    v = torch.randn(2, 1, 4, 8)
+    q = torch.randn(1, 4, 8, 2)
+    k = torch.randn(1, 4, 8, 2)
+    v = torch.randn(1, 4, 8, 2)
     with pytest.raises(ValueError, match="nntile"):
         sdpa_eager(q, k, v)
 
@@ -238,19 +263,22 @@ def test_sdpa_graph_mode_deferred_until_execute():
         )
         torch_nntile.restrict_cpu()
 
-        shape = (2, 1, 4, 8)
+        shape = (1, 4, 8, 2)
         q_cpu = torch.randn(*shape, requires_grad=True)
         k_cpu = torch.randn(*shape, requires_grad=True)
         v_cpu = torch.randn(*shape, requires_grad=True)
+        q_ker = q_cpu.permute(3, 0, 1, 2).contiguous()
+        k_ker = k_cpu.permute(3, 0, 1, 2).contiguous()
+        v_ker = v_cpu.permute(3, 0, 1, 2).contiguous()
         ref = torch.einsum(
             "...ce,...ed->...cd",
             torch.softmax(
-                torch.einsum("...ed,...cd->...ce", k_cpu, q_cpu)
-                * (shape[-1] ** -0.5),
+                torch.einsum("...ed,...cd->...ce", k_ker, q_ker)
+                * (shape[-2] ** -0.5),
                 dim=-1,
             ),
-            v_cpu,
-        )
+            v_ker,
+        ).permute(1, 2, 3, 0).contiguous()
         grad_out = torch.randn_like(ref)
         ref.backward(grad_out)
 

--- a/torch_nntile/tests/test_sdpa_parity.py
+++ b/torch_nntile/tests/test_sdpa_parity.py
@@ -193,9 +193,10 @@ def test_sdpa_backward_rejects_mismatched_grad_out():
 
 def test_sdpa_module_forward():
     mod = SDPA(batch_ndim=2)
-    q = torch.randn(2, 1, 4, 8).to("nntile")
-    k = torch.randn(2, 1, 4, 8).to("nntile")
-    v = torch.randn(2, 1, 4, 8).to("nntile")
+    # Post-GEMM layout: [batch, seq, head_size, n_heads]
+    q = torch.randn(1, 4, 8, 2).to("nntile")
+    k = torch.randn(1, 4, 8, 2).to("nntile")
+    v = torch.randn(1, 4, 8, 2).to("nntile")
     out = mod(q, k, v)
     assert out.shape == q.shape
 

--- a/torch_nntile/torch_nntile/gemm.py
+++ b/torch_nntile/torch_nntile/gemm.py
@@ -1,0 +1,70 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/torch_nntile/gemm.py
+# N-D GEMM matching ``nntile::tensor::gemm`` / C++ graph API semantics.
+
+"""N-D GEMM for torch_nntile (not PyTorch last-2-dim matmul rules)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch import Tensor
+from torch.autograd import Function
+
+from torch_nntile import _C
+
+
+class _NntileGemm(Function):
+    @staticmethod
+    def forward(
+        ctx: Any,
+        a: Tensor,
+        b: Tensor,
+        ndim: int,
+        batch_ndim: int,
+    ) -> Tensor:
+        ctx.ndim = ndim
+        ctx.batch_ndim = batch_ndim
+        ctx.save_for_backward(a, b)
+        return _C.gemm_forward(a, b, ndim, batch_ndim)
+
+    @staticmethod
+    def backward(ctx: Any, grad_out: Tensor) -> tuple[Tensor | None, ...]:
+        a, b = ctx.saved_tensors
+        grad_a, grad_b = _C.gemm_backward(
+            a,
+            b,
+            grad_out,
+            ctx.ndim,
+            ctx.batch_ndim,
+            [ctx.needs_input_grad[0], ctx.needs_input_grad[1]],
+        )
+        return grad_a, grad_b, None, None
+
+
+def gemm(
+    a: Tensor,
+    b: Tensor,
+    *,
+    ndim: int,
+    batch_ndim: int = 0,
+) -> Tensor:
+    """General N-D GEMM: ``C = A @ B`` with NNTile contraction semantics.
+
+    Examples (GPT-2 attention, ``batch_ndim=0``):
+
+    - ``[B,S,H] @ [H,hs,n_heads] -> [B,S,hs,n_heads]`` with ``ndim=1``
+    - ``[B,S,hs,n_heads] @ [hs,n_heads,H] -> [B,S,H]`` with ``ndim=2``
+    """
+    return _NntileGemm.apply(a, b, ndim, batch_ndim)
+
+
+def matmul(a: Tensor, b: Tensor) -> Tensor:
+    """``torch.matmul`` on nntile with inferred ``ndim`` / ``batch_ndim``."""
+    return torch.matmul(a, b)
+
+
+__all__ = ["gemm", "matmul"]

--- a/torch_nntile/torch_nntile/models/__init__.py
+++ b/torch_nntile/torch_nntile/models/__init__.py
@@ -5,5 +5,6 @@
 # PyTorch models for the nntile device.
 
 from .deep_relu import DeepReLU
+from .gpt2_minimal import GPT2LMHead, GPT2Model
 
-__all__ = ["DeepReLU"]
+__all__ = ["DeepReLU", "GPT2LMHead", "GPT2Model"]

--- a/torch_nntile/torch_nntile/models/__init__.py
+++ b/torch_nntile/torch_nntile/models/__init__.py
@@ -5,6 +5,5 @@
 # PyTorch models for the nntile device.
 
 from .deep_relu import DeepReLU
-from .gpt2_minimal import GPT2LMHead, GPT2Model
 
-__all__ = ["DeepReLU", "GPT2LMHead", "GPT2Model"]
+__all__ = ["DeepReLU"]

--- a/torch_nntile/torch_nntile/models/gpt2_hf_loader.py
+++ b/torch_nntile/torch_nntile/models/gpt2_hf_loader.py
@@ -1,0 +1,110 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/torch_nntile/models/gpt2_hf_loader.py
+# Load HuggingFace GPT-2 weights into minimal torch_nntile GPT2LMHead.
+
+"""Convert HF ``GPT2LMHeadModel`` weights into NNTile-layout minimal GPT-2."""
+
+from __future__ import annotations
+
+import torch
+from transformers import GPT2LMHeadModel
+
+from torch_nntile.nn.weight_layout import (
+    torch_to_nntile_o_weight,
+    torch_to_nntile_qkv_weight,
+)
+from torch_nntile.models.gpt2_minimal import GPT2LMHead
+
+
+def _conv1d_to_linear_weight(weight: torch.Tensor) -> torch.Tensor:
+    """HF Conv1D ``(in, out)`` -> addmm ``(out, in)``."""
+    return weight.t().contiguous()
+
+
+def _split_hf_attn_weights(
+    attn,
+    hidden: int,
+    n_heads: int,
+    head_size: int,
+) -> dict[str, torch.Tensor]:
+    """Split HF ``c_attn`` into HF-layout q/k/v/o tensors."""
+    w = attn.c_attn.weight.detach()
+    q_hf = w[:, :hidden].reshape(hidden, n_heads, head_size)
+    k_hf = w[:, hidden : 2 * hidden].reshape(hidden, n_heads, head_size)
+    v_hf = w[:, 2 * hidden : 3 * hidden].reshape(hidden, n_heads, head_size)
+
+    o_w = attn.c_proj.weight.detach().reshape(n_heads, head_size, hidden)
+
+    bias = attn.c_attn.bias.detach()
+    q_b = bias[:hidden].reshape(n_heads, head_size)
+    k_b = bias[hidden : 2 * hidden].reshape(n_heads, head_size)
+    v_b = bias[2 * hidden : 3 * hidden].reshape(n_heads, head_size)
+
+    return {
+        "q_weight": torch_to_nntile_qkv_weight(q_hf),
+        "k_weight": torch_to_nntile_qkv_weight(k_hf),
+        "v_weight": torch_to_nntile_qkv_weight(v_hf),
+        "o_weight": torch_to_nntile_o_weight(o_w),
+        "q_bias": q_b.contiguous(),
+        "k_bias": k_b.contiguous(),
+        "v_bias": v_b.contiguous(),
+        "o_bias": attn.c_proj.bias.detach().contiguous(),
+    }
+
+
+def load_hf_into_gpt2_lm_head(
+    minimal: GPT2LMHead,
+    hf: GPT2LMHeadModel,
+) -> None:
+    """Copy HF weights into ``minimal`` (CPU tensors; call ``.to('nntile')`` after)."""
+    tr = minimal.transformer
+    hf_tr = hf.transformer
+
+    tr.wte.weight.data.copy_(hf_tr.wte.weight.data)
+    tr.wpe.weight.data.copy_(hf_tr.wpe.weight.data)
+    tr.ln_f.weight.data.copy_(hf_tr.ln_f.weight.data)
+    tr.ln_f.bias.data.copy_(hf_tr.ln_f.bias.data)
+
+    hidden = minimal.config.n_embd
+    n_heads = minimal.config.n_head
+    head_size = hidden // n_heads
+
+    for block, hf_block in zip(tr.h, hf_tr.h):
+        block.ln_1.weight.data.copy_(hf_block.ln_1.weight.data)
+        block.ln_1.bias.data.copy_(hf_block.ln_1.bias.data)
+        block.ln_2.weight.data.copy_(hf_block.ln_2.weight.data)
+        block.ln_2.bias.data.copy_(hf_block.ln_2.bias.data)
+
+        attn_w = _split_hf_attn_weights(
+            hf_block.attn,
+            hidden,
+            n_heads,
+            head_size,
+        )
+        block.attn.q_weight.data.copy_(attn_w["q_weight"])
+        block.attn.k_weight.data.copy_(attn_w["k_weight"])
+        block.attn.v_weight.data.copy_(attn_w["v_weight"])
+        block.attn.o_weight.data.copy_(attn_w["o_weight"])
+        block.attn.q_bias.data.copy_(attn_w["q_bias"])
+        block.attn.k_bias.data.copy_(attn_w["k_bias"])
+        block.attn.v_bias.data.copy_(attn_w["v_bias"])
+        block.attn.o_bias.data.copy_(attn_w["o_bias"])
+
+        block.mlp.c_fc.weight.data.copy_(
+            _conv1d_to_linear_weight(hf_block.mlp.c_fc.weight.data)
+        )
+        block.mlp.c_fc.bias.data.copy_(hf_block.mlp.c_fc.bias.data)
+        block.mlp.c_proj.weight.data.copy_(
+            _conv1d_to_linear_weight(hf_block.mlp.c_proj.weight.data)
+        )
+        block.mlp.c_proj.bias.data.copy_(hf_block.mlp.c_proj.bias.data)
+
+    if minimal.config.tie_word_embeddings:
+        minimal.tie_weights()
+    else:
+        minimal.lm_head.weight.data.copy_(hf.lm_head.weight.data.contiguous())
+
+
+__all__ = ["load_hf_into_gpt2_lm_head"]

--- a/torch_nntile/torch_nntile/models/gpt2_minimal.py
+++ b/torch_nntile/torch_nntile/models/gpt2_minimal.py
@@ -14,6 +14,7 @@ from torch import Tensor
 from transformers import GPT2Config
 
 from torch_nntile.nn import SDPA
+from torch_nntile.gemm import gemm
 
 
 def make_causal_sdpa_mask(seq_len: int, device: torch.device | None = None) -> Tensor:
@@ -107,15 +108,14 @@ class GPT2Attention(nn.Module):
         weight: Tensor,
         bias: Tensor,
     ) -> Tensor:
-        """``gemm(x, w)`` + bias → ``[batch, seq, head_size, n_heads]``."""
-        bsz, seq, hidden = x.shape
-        head_size = weight.size(1)
-        n_heads = weight.size(2)
-        x2d = x.reshape(bsz * seq, hidden)
-        proj = torch.mm(
-            x2d,
-            weight.reshape(hidden, head_size * n_heads),
-        ).view(bsz, seq, head_size, n_heads)
+        """``gemm(x, w, ndim=1)`` + bias → ``[batch, seq, head_size, n_heads]``."""
+        bsz, seq, head_size, n_heads = (
+            x.size(0),
+            x.size(1),
+            weight.size(1),
+            weight.size(2),
+        )
+        proj = gemm(x, weight, ndim=1, batch_ndim=0)
         bias_bc = (
             bias.transpose(0, 1)
             .view(1, 1, head_size, n_heads)
@@ -125,19 +125,16 @@ class GPT2Attention(nn.Module):
         return proj + bias_bc
 
     def _output_proj(self, attn_out: Tensor) -> Tensor:
-        """``gemm(attn, w_o)`` + bias on post-SDPA projection layout."""
-        bsz, seq, head_size, n_heads = attn_out.shape
+        """``gemm(attn, w_o, ndim=2)`` + bias on post-SDPA projection layout."""
+        bsz, seq = attn_out.size(0), attn_out.size(1)
         hidden = self.hidden
-        x2d = attn_out.reshape(bsz * seq, head_size * n_heads)
-        w_o = self.o_weight.reshape(head_size * n_heads, hidden)
-        out = torch.mm(x2d, w_o)
+        out = gemm(attn_out, self.o_weight, ndim=2, batch_ndim=0)
         bias_bc = (
-            self.o_bias.view(1, -1)
-            .expand(bsz * seq, -1)
+            self.o_bias.view(1, 1, hidden)
+            .expand(bsz, seq, hidden)
             .contiguous()
         )
-        out = out + bias_bc
-        return out.view(bsz, seq, hidden)
+        return out + bias_bc
 
     def forward(self, x: Tensor, causal_mask: Tensor | None) -> Tensor:
         q = self._project(x, self.q_weight, self.q_bias)

--- a/torch_nntile/torch_nntile/models/gpt2_minimal.py
+++ b/torch_nntile/torch_nntile/models/gpt2_minimal.py
@@ -16,29 +16,39 @@ from transformers import GPT2Config
 from torch_nntile.nn import SDPA
 
 
-class _MergeHeadsLastDim(torch.autograd.Function):
-    """``[n_heads, batch, seq, head_size]`` -> ``[batch, seq, hidden]``."""
+class _NntileModelTranspose(torch.autograd.Function):
+    """``nntile::transpose(src, model_ndim)`` cyclic axis reordering.
+
+    Matches ``nntile/src/model/gpt2/gpt2_attention.cc`` (``transpose(q_proj, 1)``
+    before SDPA and ``transpose(attn_out, 3)`` before output GEMM). Uses an
+    explicit autograd wrapper because nntile view-transpose backward is not
+    wired through ATen yet.
+    """
 
     @staticmethod
-    def forward(ctx, attn_out: Tensor) -> Tensor:
-        n_heads, bsz, seq, head_size = attn_out.shape
-        ctx.n_heads = n_heads
-        ctx.head_size = head_size
-        parts = [attn_out[h].contiguous() for h in range(n_heads)]
-        return torch.cat(parts, dim=-1)
+    def forward(ctx, x: Tensor, model_ndim: int) -> Tensor:
+        n = x.dim()
+        if model_ndim <= 0 or model_ndim >= n:
+            raise ValueError(
+                f"model_ndim must be in (0, {n}), got {model_ndim}"
+            )
+        tensor_ndim = n - model_ndim
+        perm = [(i + tensor_ndim) % n for i in range(n)]
+        inv = [0] * n
+        for out_i, src_i in enumerate(perm):
+            inv[src_i] = out_i
+        ctx.inv_perm = inv
+        return x.permute(*perm).contiguous()
 
     @staticmethod
-    def backward(ctx, grad_merged: Tensor) -> tuple[Tensor,]:
-        n_heads = ctx.n_heads
-        head_size = ctx.head_size
-        bsz, seq, _ = grad_merged.shape
-        grad_view = grad_merged.view(bsz, seq, n_heads, head_size)
-        grads = [grad_view[:, :, h, :].contiguous() for h in range(n_heads)]
-        return (torch.stack(grads, dim=0).contiguous(),)
+    def backward(ctx, grad_out: Tensor) -> tuple[Tensor, None]:
+        inv = ctx.inv_perm
+        return grad_out.permute(*inv).contiguous(), None
 
 
-def _merge_heads_last_dim(attn_out: Tensor) -> Tensor:
-    return _MergeHeadsLastDim.apply(attn_out)
+def nntile_model_transpose(x: Tensor, model_ndim: int) -> Tensor:
+    """Apply model-code transpose axis (storage order) on nntile tensors."""
+    return _NntileModelTranspose.apply(x, model_ndim)
 
 
 def make_causal_sdpa_mask(seq_len: int, device: torch.device | None = None) -> Tensor:
@@ -132,32 +142,30 @@ class GPT2Attention(nn.Module):
         weight: Tensor,
         bias: Tensor,
     ) -> Tensor:
+        """``gemm`` + ``transpose(..., 1)`` + bias, mirroring C++ Q/K/V path."""
         bsz, seq, hidden = x.shape
         head_size = weight.size(1)
         n_heads = weight.size(2)
         x2d = x.reshape(bsz * seq, hidden)
-        chunks: list[Tensor] = []
-        for h in range(n_heads):
-            wh = weight[:, :, h].contiguous()
-            bh = (
-                bias[h]
-                .view(1, -1)
-                .expand(bsz * seq, -1)
-                .contiguous()
-            )
-            proj_h = torch.mm(x2d, wh) + bh
-            chunks.append(proj_h.view(bsz, seq, head_size).unsqueeze(0))
-        return torch.cat(chunks, dim=0).contiguous()
+        proj = torch.mm(
+            x2d,
+            weight.reshape(hidden, head_size * n_heads),
+        ).view(bsz, seq, head_size, n_heads)
+        out = nntile_model_transpose(proj, 1)
+        bias_bc = (
+            bias.view(n_heads, 1, 1, head_size)
+            .expand(n_heads, bsz, seq, head_size)
+            .contiguous()
+        )
+        return out + bias_bc
 
     def _output_proj(self, attn_out: Tensor) -> Tensor:
+        """``transpose(..., 3)`` + ``gemm`` + bias, mirroring C++ output path."""
         n_heads, bsz, seq, head_size = attn_out.shape
         hidden = self.hidden
-        merged = _merge_heads_last_dim(attn_out)
-        x2d = merged.reshape(bsz * seq, hidden)
-        o_blocks = [
-            self.o_weight[:, h, :].contiguous() for h in range(n_heads)
-        ]
-        w_o = torch.cat(o_blocks, dim=0).contiguous()
+        attn_t = nntile_model_transpose(attn_out, 3)
+        x2d = attn_t.reshape(bsz * seq, head_size * n_heads)
+        w_o = self.o_weight.reshape(head_size * n_heads, hidden)
         out = torch.mm(x2d, w_o)
         bias_bc = (
             self.o_bias.view(1, -1)

--- a/torch_nntile/torch_nntile/models/gpt2_minimal.py
+++ b/torch_nntile/torch_nntile/models/gpt2_minimal.py
@@ -16,41 +16,6 @@ from transformers import GPT2Config
 from torch_nntile.nn import SDPA
 
 
-class _NntileModelTranspose(torch.autograd.Function):
-    """``nntile::transpose(src, model_ndim)`` cyclic axis reordering.
-
-    Matches ``nntile/src/model/gpt2/gpt2_attention.cc`` (``transpose(q_proj, 1)``
-    before SDPA and ``transpose(attn_out, 3)`` before output GEMM). Uses an
-    explicit autograd wrapper because nntile view-transpose backward is not
-    wired through ATen yet.
-    """
-
-    @staticmethod
-    def forward(ctx, x: Tensor, model_ndim: int) -> Tensor:
-        n = x.dim()
-        if model_ndim <= 0 or model_ndim >= n:
-            raise ValueError(
-                f"model_ndim must be in (0, {n}), got {model_ndim}"
-            )
-        tensor_ndim = n - model_ndim
-        perm = [(i + tensor_ndim) % n for i in range(n)]
-        inv = [0] * n
-        for out_i, src_i in enumerate(perm):
-            inv[src_i] = out_i
-        ctx.inv_perm = inv
-        return x.permute(*perm).contiguous()
-
-    @staticmethod
-    def backward(ctx, grad_out: Tensor) -> tuple[Tensor, None]:
-        inv = ctx.inv_perm
-        return grad_out.permute(*inv).contiguous(), None
-
-
-def nntile_model_transpose(x: Tensor, model_ndim: int) -> Tensor:
-    """Apply model-code transpose axis (storage order) on nntile tensors."""
-    return _NntileModelTranspose.apply(x, model_ndim)
-
-
 def make_causal_sdpa_mask(seq_len: int, device: torch.device | None = None) -> Tensor:
     """BOOL causal mask ``[seq, seq]`` with ``mask[q, k] = (k <= q)``."""
     q_idx = torch.arange(seq_len, device=device)
@@ -142,7 +107,7 @@ class GPT2Attention(nn.Module):
         weight: Tensor,
         bias: Tensor,
     ) -> Tensor:
-        """``gemm`` + ``transpose(..., 1)`` + bias, mirroring C++ Q/K/V path."""
+        """``gemm(x, w)`` + bias → ``[batch, seq, head_size, n_heads]``."""
         bsz, seq, hidden = x.shape
         head_size = weight.size(1)
         n_heads = weight.size(2)
@@ -151,20 +116,19 @@ class GPT2Attention(nn.Module):
             x2d,
             weight.reshape(hidden, head_size * n_heads),
         ).view(bsz, seq, head_size, n_heads)
-        out = nntile_model_transpose(proj, 1)
         bias_bc = (
-            bias.view(n_heads, 1, 1, head_size)
-            .expand(n_heads, bsz, seq, head_size)
+            bias.transpose(0, 1)
+            .view(1, 1, head_size, n_heads)
+            .expand(bsz, seq, head_size, n_heads)
             .contiguous()
         )
-        return out + bias_bc
+        return proj + bias_bc
 
     def _output_proj(self, attn_out: Tensor) -> Tensor:
-        """``transpose(..., 3)`` + ``gemm`` + bias, mirroring C++ output path."""
-        n_heads, bsz, seq, head_size = attn_out.shape
+        """``gemm(attn, w_o)`` + bias on post-SDPA projection layout."""
+        bsz, seq, head_size, n_heads = attn_out.shape
         hidden = self.hidden
-        attn_t = nntile_model_transpose(attn_out, 3)
-        x2d = attn_t.reshape(bsz * seq, head_size * n_heads)
+        x2d = attn_out.reshape(bsz * seq, head_size * n_heads)
         w_o = self.o_weight.reshape(head_size * n_heads, hidden)
         out = torch.mm(x2d, w_o)
         bias_bc = (

--- a/torch_nntile/torch_nntile/models/gpt2_minimal.py
+++ b/torch_nntile/torch_nntile/models/gpt2_minimal.py
@@ -1,0 +1,296 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/torch_nntile/models/gpt2_minimal.py
+# Minimal GPT-2 model for device="nntile" (NNTile attention weight layouts).
+
+"""Minimal GPT-2 stack mirroring ``nntile::model::gpt2`` graph modules."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from transformers import GPT2Config
+
+from torch_nntile.nn import SDPA
+
+
+class _MergeHeadsLastDim(torch.autograd.Function):
+    """``[n_heads, batch, seq, head_size]`` -> ``[batch, seq, hidden]``."""
+
+    @staticmethod
+    def forward(ctx, attn_out: Tensor) -> Tensor:
+        n_heads, bsz, seq, head_size = attn_out.shape
+        ctx.n_heads = n_heads
+        ctx.head_size = head_size
+        parts = [attn_out[h].contiguous() for h in range(n_heads)]
+        return torch.cat(parts, dim=-1)
+
+    @staticmethod
+    def backward(ctx, grad_merged: Tensor) -> tuple[Tensor,]:
+        n_heads = ctx.n_heads
+        head_size = ctx.head_size
+        bsz, seq, _ = grad_merged.shape
+        grad_view = grad_merged.view(bsz, seq, n_heads, head_size)
+        grads = [grad_view[:, :, h, :].contiguous() for h in range(n_heads)]
+        return (torch.stack(grads, dim=0).contiguous(),)
+
+
+def _merge_heads_last_dim(attn_out: Tensor) -> Tensor:
+    return _MergeHeadsLastDim.apply(attn_out)
+
+
+def make_causal_sdpa_mask(seq_len: int, device: torch.device | None = None) -> Tensor:
+    """BOOL causal mask ``[seq, seq]`` with ``mask[q, k] = (k <= q)``."""
+    q_idx = torch.arange(seq_len, device=device)
+    k_idx = torch.arange(seq_len, device=device)
+    return k_idx.unsqueeze(0) <= q_idx.unsqueeze(1)
+
+
+class NntileConv1D(nn.Module):
+    """HF ``Conv1D`` equivalent via ``mm`` + bias (autograd-friendly on nntile)."""
+
+    def __init__(
+        self,
+        nf: int,
+        nx: int,
+        *,
+        bias: bool = True,
+    ) -> None:
+        super().__init__()
+        self.nf = nf
+        self.nx = nx
+        self.weight = nn.Parameter(torch.empty(nf, nx))
+        if bias:
+            self.bias = nn.Parameter(torch.zeros(nf))
+        else:
+            self.register_parameter("bias", None)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        nn.init.normal_(self.weight, std=0.02)
+        if self.bias is not None:
+            nn.init.zeros_(self.bias)
+
+    def forward(self, x: Tensor) -> Tensor:
+        size_out = x.size()[:-1] + (self.nf,)
+        x2d = x.reshape(-1, x.size(-1))
+        out = torch.mm(x2d, self.weight.t())
+        if self.bias is not None:
+            bias_bc = (
+                self.bias.view(1, -1)
+                .expand(x2d.size(0), -1)
+                .contiguous()
+            )
+            out = out + bias_bc
+        return out.view(size_out)
+
+
+class GPT2Attention(nn.Module):
+    """GPT-2 attention with NNTile-layout Q/K/V/O weights and ``SDPA``."""
+
+    def __init__(self, config: GPT2Config) -> None:
+        super().__init__()
+        if config.n_embd % config.n_head != 0:
+            raise ValueError("n_embd must be divisible by n_head")
+        self.n_head = config.n_head
+        self.head_size = config.n_embd // config.n_head
+        self.hidden = config.n_embd
+
+        hs = self.head_size
+        n_heads = self.n_head
+        hidden = self.hidden
+
+        self.q_weight = nn.Parameter(torch.empty(hidden, hs, n_heads))
+        self.k_weight = nn.Parameter(torch.empty(hidden, hs, n_heads))
+        self.v_weight = nn.Parameter(torch.empty(hidden, hs, n_heads))
+        self.o_weight = nn.Parameter(torch.empty(hs, n_heads, hidden))
+
+        self.q_bias = nn.Parameter(torch.zeros(n_heads, hs))
+        self.k_bias = nn.Parameter(torch.zeros(n_heads, hs))
+        self.v_bias = nn.Parameter(torch.zeros(n_heads, hs))
+        self.o_bias = nn.Parameter(torch.zeros(hidden))
+
+        self.sdpa = SDPA(batch_ndim=2)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        for p in (
+            self.q_weight,
+            self.k_weight,
+            self.v_weight,
+            self.o_weight,
+        ):
+            nn.init.normal_(p, std=0.02)
+        for p in (self.q_bias, self.k_bias, self.v_bias, self.o_bias):
+            nn.init.zeros_(p)
+
+    def _project(
+        self,
+        x: Tensor,
+        weight: Tensor,
+        bias: Tensor,
+    ) -> Tensor:
+        bsz, seq, hidden = x.shape
+        head_size = weight.size(1)
+        n_heads = weight.size(2)
+        x2d = x.reshape(bsz * seq, hidden)
+        chunks: list[Tensor] = []
+        for h in range(n_heads):
+            wh = weight[:, :, h].contiguous()
+            bh = (
+                bias[h]
+                .view(1, -1)
+                .expand(bsz * seq, -1)
+                .contiguous()
+            )
+            proj_h = torch.mm(x2d, wh) + bh
+            chunks.append(proj_h.view(bsz, seq, head_size).unsqueeze(0))
+        return torch.cat(chunks, dim=0).contiguous()
+
+    def _output_proj(self, attn_out: Tensor) -> Tensor:
+        n_heads, bsz, seq, head_size = attn_out.shape
+        hidden = self.hidden
+        merged = _merge_heads_last_dim(attn_out)
+        x2d = merged.reshape(bsz * seq, hidden)
+        o_blocks = [
+            self.o_weight[:, h, :].contiguous() for h in range(n_heads)
+        ]
+        w_o = torch.cat(o_blocks, dim=0).contiguous()
+        out = torch.mm(x2d, w_o)
+        bias_bc = (
+            self.o_bias.view(1, -1)
+            .expand(bsz * seq, -1)
+            .contiguous()
+        )
+        out = out + bias_bc
+        return out.view(bsz, seq, hidden)
+
+    def forward(self, x: Tensor, causal_mask: Tensor | None) -> Tensor:
+        q = self._project(x, self.q_weight, self.q_bias)
+        k = self._project(x, self.k_weight, self.k_bias)
+        v = self._project(x, self.v_weight, self.v_bias)
+        attn_out = self.sdpa(q, k, v, mask=causal_mask)
+        return self._output_proj(attn_out)
+
+
+class GPT2MLP(nn.Module):
+    """GPT-2 MLP (GELU tanh approx) using ``NntileConv1D``."""
+
+    def __init__(self, config: GPT2Config) -> None:
+        super().__init__()
+        inner = config.n_inner
+        if inner is None:
+            inner = 4 * config.n_embd
+        self.c_fc = NntileConv1D(inner, config.n_embd)
+        self.c_proj = NntileConv1D(config.n_embd, inner)
+        self.act = nn.GELU(approximate="tanh")
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.c_fc(x)
+        x = self.act(x)
+        return self.c_proj(x)
+
+
+class GPT2Block(nn.Module):
+    def __init__(self, config: GPT2Config) -> None:
+        super().__init__()
+        self.ln_1 = nn.LayerNorm(config.n_embd, eps=config.layer_norm_epsilon)
+        self.attn = GPT2Attention(config)
+        self.ln_2 = nn.LayerNorm(config.n_embd, eps=config.layer_norm_epsilon)
+        self.mlp = GPT2MLP(config)
+
+    def forward(self, x: Tensor, causal_mask: Tensor | None) -> Tensor:
+        residual = x
+        x = self.ln_1(x)
+        x = self.attn(x, causal_mask)
+        x = residual + x
+        residual = x
+        x = self.ln_2(x)
+        x = self.mlp(x)
+        return residual + x
+
+
+class GPT2Model(nn.Module):
+    """GPT-2 transformer backbone (token + position embeddings, blocks, ln_f)."""
+
+    def __init__(self, config: GPT2Config) -> None:
+        super().__init__()
+        self.config = config
+        self.wte = nn.Embedding(config.vocab_size, config.n_embd)
+        self.wpe = nn.Embedding(config.n_positions, config.n_embd)
+        self.h = nn.ModuleList(
+            [GPT2Block(config) for _ in range(config.n_layer)]
+        )
+        self.ln_f = nn.LayerNorm(config.n_embd, eps=config.layer_norm_epsilon)
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        position_ids: Tensor | None = None,
+        causal_mask: Tensor | None = None,
+    ) -> Tensor:
+        if position_ids is None:
+            seq = input_ids.size(-1)
+            position_ids = (
+                torch.arange(seq, dtype=torch.long, device=input_ids.device)
+                .unsqueeze(0)
+                .expand(input_ids.size(0), -1)
+                .contiguous()
+            )
+
+        if causal_mask is None:
+            causal_mask = make_causal_sdpa_mask(input_ids.size(-1))
+
+        x = self.wte(input_ids) + self.wpe(position_ids)
+        for block in self.h:
+            x = block(x, causal_mask)
+        return self.ln_f(x)
+
+
+class GPT2LMHead(nn.Module):
+    """GPT-2 causal LM (``Gpt2Causal`` / ``GPT2LMHeadModel`` equivalent)."""
+
+    def __init__(self, config: GPT2Config) -> None:
+        super().__init__()
+        self.config = config
+        self.transformer = GPT2Model(config)
+        self.lm_head = NntileConv1D(
+            config.vocab_size,
+            config.n_embd,
+            bias=False,
+        )
+        self.post_init()
+
+    def post_init(self) -> None:
+        if self.config.tie_word_embeddings:
+            self._tie_weights()
+
+    def _tie_weights(self) -> None:
+        self.lm_head.weight = self.transformer.wte.weight  # share storage
+
+    def tie_weights(self) -> None:
+        """Re-apply word embedding tie (call after ``.to('nntile')``)."""
+        if self.config.tie_word_embeddings:
+            self._tie_weights()
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        position_ids: Tensor | None = None,
+        causal_mask: Tensor | None = None,
+    ) -> Tensor:
+        hidden = self.transformer(input_ids, position_ids, causal_mask)
+        return self.lm_head(hidden)
+
+
+__all__ = [
+    "GPT2Attention",
+    "GPT2Block",
+    "GPT2LMHead",
+    "GPT2MLP",
+    "GPT2Model",
+    "NntileConv1D",
+    "make_causal_sdpa_mask",
+]

--- a/torch_nntile/torch_nntile/nn/sdpa.py
+++ b/torch_nntile/torch_nntile/nn/sdpa.py
@@ -85,11 +85,13 @@ def sdpa_eager(
     *,
     batch_ndim: int = 2,
 ) -> Tensor:
-    """Low-level NNTile-layout SDPA on ``device='nntile'``.
+    """SDPA on post-GEMM Q/K/V layout ``[batch, seq, head_size, n_heads]``.
 
-    Q/K/V shape ``[batch..., seq, head_size]`` in kernel layout, e.g.
-    ``[n_heads, batch, seq, head_size]`` when ``batch_ndim=2``. Optional BOOL
-    mask ``[q_seq, k_seq]`` (dim0 = query, dim1 = key). Scale is
+    Internally applies ``transpose(..., 1)``, calls the NNTile-layout kernel
+    (e.g. ``[n_heads, batch, seq, head_size]`` when ``batch_ndim=2``), then
+    ``transpose(..., 3)`` on the output — matching
+    ``nntile/src/model/gpt2/gpt2_attention.cc`` around ``sdpa_eager``.
+    Optional BOOL mask ``[q_seq, k_seq]`` (dim0 = query, dim1 = key). Scale is
     ``1/sqrt(head_size)``.
     """
     if q.device.type != "nntile":
@@ -100,17 +102,18 @@ def sdpa_eager(
         raise ValueError("nntile sdpa supports float32 only")
     if mask is not None and mask.dtype != torch.bool:
         raise ValueError("nntile sdpa: mask must be bool")
-    return _NntileSdpaEager.apply(q, k, v, mask, batch_ndim)
+    q_sdpa = nntile_model_transpose(q, 1)
+    k_sdpa = nntile_model_transpose(k, 1)
+    v_sdpa = nntile_model_transpose(v, 1)
+    attn_out = _NntileSdpaEager.apply(q_sdpa, k_sdpa, v_sdpa, mask, batch_ndim)
+    return nntile_model_transpose(attn_out, 3)
 
 
 class SDPA(nn.Module):
     """Scaled dot-product attention for post-GEMM Q/K/V tensors.
 
-    Accepts Q/K/V in projection layout ``[batch, seq, head_size, n_heads]``
-    (matching ``gemm`` output in ``Gpt2Attention``). Internally applies
-    ``transpose(..., 1)``, calls ``sdpa_forward`` / ``sdpa_backward``, then
-    ``transpose(..., 3)`` on the result — same as
-    ``nntile/src/model/gpt2/gpt2_attention.cc``.
+    Accepts Q/K/V in projection layout ``[batch, seq, head_size, n_heads]``.
+    Delegates to ``sdpa_eager`` (transposes are handled there).
     """
 
     def __init__(self, batch_ndim: int = 2) -> None:
@@ -124,17 +127,7 @@ class SDPA(nn.Module):
         v: Tensor,
         mask: Tensor | None = None,
     ) -> Tensor:
-        q_sdpa = nntile_model_transpose(q, 1)
-        k_sdpa = nntile_model_transpose(k, 1)
-        v_sdpa = nntile_model_transpose(v, 1)
-        attn_out = sdpa_eager(
-            q_sdpa,
-            k_sdpa,
-            v_sdpa,
-            mask,
-            batch_ndim=self.batch_ndim,
-        )
-        return nntile_model_transpose(attn_out, 3)
+        return sdpa_eager(q, k, v, mask, batch_ndim=self.batch_ndim)
 
 
 __all__ = ["SDPA", "nntile_model_transpose", "sdpa_eager"]

--- a/torch_nntile/torch_nntile/nn/sdpa.py
+++ b/torch_nntile/torch_nntile/nn/sdpa.py
@@ -15,6 +15,38 @@ from torch import Tensor
 from torch_nntile import _C
 
 
+class _NntileModelTranspose(torch.autograd.Function):
+    """``nntile::transpose(src, model_ndim)`` cyclic axis reordering.
+
+    Matches ``nntile/src/nn/ops/transpose.cc`` model-code axis semantics.
+    """
+
+    @staticmethod
+    def forward(ctx, x: Tensor, model_ndim: int) -> Tensor:
+        n = x.dim()
+        if model_ndim <= 0 or model_ndim >= n:
+            raise ValueError(
+                f"model_ndim must be in (0, {n}), got {model_ndim}"
+            )
+        tensor_ndim = n - model_ndim
+        perm = [(i + tensor_ndim) % n for i in range(n)]
+        inv = [0] * n
+        for out_i, src_i in enumerate(perm):
+            inv[src_i] = out_i
+        ctx.inv_perm = inv
+        return x.permute(*perm).contiguous()
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor) -> tuple[Tensor, None]:
+        inv = ctx.inv_perm
+        return grad_out.permute(*inv).contiguous(), None
+
+
+def nntile_model_transpose(x: Tensor, model_ndim: int) -> Tensor:
+    """Apply model-code transpose axis (storage order) on nntile tensors."""
+    return _NntileModelTranspose.apply(x, model_ndim)
+
+
 class _NntileSdpaEager(torch.autograd.Function):
     @staticmethod
     def forward(
@@ -53,12 +85,13 @@ def sdpa_eager(
     *,
     batch_ndim: int = 2,
 ) -> Tensor:
-    """NNTile-layout SDPA eager on ``device='nntile'``.
+    """Low-level NNTile-layout SDPA on ``device='nntile'``.
 
-    Q/K/V shape ``[batch..., seq, head_size]`` (C-order). Optional BOOL mask
-    ``[q_seq, k_seq]`` on CPU or nntile (dim0 = query, dim1 = key, matching
-    ``tensor::mask_scalar`` / GPT-2 ``attn_mask``). Scale is ``1/sqrt(head_size)``.
-  """
+    Q/K/V shape ``[batch..., seq, head_size]`` in kernel layout, e.g.
+    ``[n_heads, batch, seq, head_size]`` when ``batch_ndim=2``. Optional BOOL
+    mask ``[q_seq, k_seq]`` (dim0 = query, dim1 = key). Scale is
+    ``1/sqrt(head_size)``.
+    """
     if q.device.type != "nntile":
         raise ValueError("sdpa_eager expects nntile Q/K/V tensors")
     if k.device.type != "nntile" or v.device.type != "nntile":
@@ -71,7 +104,14 @@ def sdpa_eager(
 
 
 class SDPA(nn.Module):
-    """Scaled dot-product attention via libnntile ``sdpa_eager``."""
+    """Scaled dot-product attention for post-GEMM Q/K/V tensors.
+
+    Accepts Q/K/V in projection layout ``[batch, seq, head_size, n_heads]``
+    (matching ``gemm`` output in ``Gpt2Attention``). Internally applies
+    ``transpose(..., 1)``, calls ``sdpa_forward`` / ``sdpa_backward``, then
+    ``transpose(..., 3)`` on the result — same as
+    ``nntile/src/model/gpt2/gpt2_attention.cc``.
+    """
 
     def __init__(self, batch_ndim: int = 2) -> None:
         super().__init__()
@@ -84,7 +124,17 @@ class SDPA(nn.Module):
         v: Tensor,
         mask: Tensor | None = None,
     ) -> Tensor:
-        return sdpa_eager(q, k, v, mask, batch_ndim=self.batch_ndim)
+        q_sdpa = nntile_model_transpose(q, 1)
+        k_sdpa = nntile_model_transpose(k, 1)
+        v_sdpa = nntile_model_transpose(v, 1)
+        attn_out = sdpa_eager(
+            q_sdpa,
+            k_sdpa,
+            v_sdpa,
+            mask,
+            batch_ndim=self.batch_ndim,
+        )
+        return nntile_model_transpose(attn_out, 3)
 
 
-__all__ = ["SDPA", "sdpa_eager"]
+__all__ = ["SDPA", "nntile_model_transpose", "sdpa_eager"]

--- a/torch_nntile/torch_nntile/nn/sdpa.py
+++ b/torch_nntile/torch_nntile/nn/sdpa.py
@@ -23,23 +23,12 @@ class _NntileModelTranspose(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, x: Tensor, model_ndim: int) -> Tensor:
-        n = x.dim()
-        if model_ndim <= 0 or model_ndim >= n:
-            raise ValueError(
-                f"model_ndim must be in (0, {n}), got {model_ndim}"
-            )
-        tensor_ndim = n - model_ndim
-        perm = [(i + tensor_ndim) % n for i in range(n)]
-        inv = [0] * n
-        for out_i, src_i in enumerate(perm):
-            inv[src_i] = out_i
-        ctx.inv_perm = inv
-        return x.permute(*perm).contiguous()
+        ctx.model_ndim = int(model_ndim)
+        return _C.model_transpose_forward(x, int(model_ndim))
 
     @staticmethod
     def backward(ctx, grad_out: Tensor) -> tuple[Tensor, None]:
-        inv = ctx.inv_perm
-        return grad_out.permute(*inv).contiguous(), None
+        return _C.model_transpose_backward(grad_out, ctx.model_ndim), None
 
 
 def nntile_model_transpose(x: Tensor, model_ndim: int) -> Tensor:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **N-D GEMM** to torch_nntile matching C++ `nntile::tensor::gemm` semantics, and refactors GPT-2 attention projections to use it directly — eliminating the `reshape → mm → view` workaround that required graph-mode view aliasing.

### N-D GEMM

- `prepare_gemm_operands(a, b, ndim, batch_ndim)` — general contraction layout
- `infer_gemm_params(a, b)` — auto-detect `ndim` / `batch_ndim` from matching axes
- `torch_nntile.gemm(a, b, ndim=..., batch_ndim=0)` — autograd-aware Python API
- `aten::matmul` registered on nntile with inferred contraction (handles GPT-2 shapes)

### GPT-2 attention (matches C++ `gpt2_attention.cc`)

| Op | Shapes | ndim |
|----|--------|------|
| Q/K/V proj | `[B,S,H] @ [H,hs,n_heads] → [B,S,hs,n_heads]` | 1 |
| O proj | `[B,S,hs,n_heads] @ [hs,n_heads,H] → [B,S,H]` | 2 |

No views or reshapes in the projection path — output rank is produced directly by GEMM.

### Tests

- `test_gemm_nd.py`: forward/backward parity, `matmul` inference, graph-mode gemm+add without view workaround
- All GPT-2 parity tests pass (12/12 eager)

### Note on PyTorch vs NNTile matmul

Standard PyTorch `matmul([B,S,H], [H,hs,n_heads])` is invalid (contracts `H` with `hs`). NNTile GEMM with `ndim=1, batch_ndim=0` is the correct semantic — this is now available via `torch_nntile.gemm` and inferred `torch.matmul` on nntile tensors.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-610c5678-7828-4cbd-9e1c-2d8102450125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-610c5678-7828-4cbd-9e1c-2d8102450125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

