### PR TITLE
Add GPT-2 minimal train step and cross-entropy backward tests

### DIFF
--- a/torch_nntile/examples/gpt2_minimal_train_step.py
+++ b/torch_nntile/examples/gpt2_minimal_train_step.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/examples/gpt2_minimal_train_step.py
+# Tiny GPT-2: forward, cross-entropy loss, backward, and SGD on device="nntile".
+
+from __future__ import annotations
+
+import torch
+import torch_nntile
+from transformers import GPT2Config, GPT2LMHeadModel
+
+from torch_nntile.models.gpt2_hf_loader import load_hf_into_gpt2_lm_head
+from torch_nntile.models.gpt2_minimal import GPT2LMHead
+from torch_nntile.training import SGD, cross_entropy
+
+
+def main() -> None:
+    torch_nntile.init_context(ncpu=1, ncuda=0, cpu_fallback=False)
+    torch_nntile.restrict_cpu()
+
+    config = GPT2Config(
+        n_layer=2,
+        n_head=2,
+        n_embd=64,
+        n_positions=32,
+        vocab_size=128,
+        n_inner=256,
+        attn_pdrop=0.0,
+        resid_pdrop=0.0,
+        embd_pdrop=0.0,
+        tie_word_embeddings=True,
+    )
+    config._attn_implementation = "eager"
+
+    torch.manual_seed(0)
+    hf = GPT2LMHeadModel(config).eval().float()
+    model = GPT2LMHead(config).eval().float()
+    load_hf_into_gpt2_lm_head(model, hf)
+    model = model.to("nntile")
+    model.tie_weights()
+
+    for param in model.parameters():
+        param.requires_grad_(True)
+
+    input_ids = torch.randint(0, config.vocab_size, (2, 8))
+    labels = input_ids.clone()
+
+    with torch.no_grad():
+        ref_logits = hf(input_ids).logits
+        ref_loss = torch.nn.functional.cross_entropy(
+            ref_logits.view(-1, config.vocab_size),
+            labels.view(-1),
+        )
+
+    model.zero_grad(set_to_none=True)
+    logits = model(input_ids)
+    loss = cross_entropy(logits, labels, reduction="mean")
+    loss.backward()
+
+    optimizer = SGD([p for p in model.parameters() if p.requires_grad], lr=1e-3)
+    optimizer.step()
+    torch_nntile.wait()
+
+    loss_cpu = loss.to("cpu")
+    print(
+        "forward match:",
+        torch.allclose(logits.cpu(), ref_logits, rtol=1e-4, atol=1e-4),
+    )
+    print(
+        "loss match:",
+        torch.allclose(loss_cpu, ref_loss, rtol=1e-4, atol=1e-4),
+    )
+    wte_grad = model.transformer.wte.weight.grad
+    print(
+        "backward ok, wte grad norm:",
+        wte_grad.norm().cpu().item() if wte_grad is not None else None,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/torch_nntile/tests/test_gpt2_lm_head_parity.py
+++ b/torch_nntile/tests/test_gpt2_lm_head_parity.py
@@ -17,6 +17,7 @@ from transformers import GPT2Config, GPT2LMHeadModel
 import torch_nntile
 from torch_nntile import _C
 from torch_nntile.models.gpt2_hf_loader import load_hf_into_gpt2_lm_head
+from torch_nntile.training import cross_entropy, train_full_batch_step
 from torch_nntile.models.gpt2_minimal import (
     GPT2Attention,
     GPT2Block,
@@ -331,6 +332,50 @@ def test_gpt2_lm_head_backward_matches_hf_untied(tiny_gpt2_config):
 
     _assert_close(minimal.lm_head.weight.grad, hf.lm_head.weight.grad, atol=1e-3)
     _assert_close(minimal.transformer.wpe.weight.grad, hf.transformer.wpe.weight.grad)
+
+
+def test_gpt2_lm_head_cross_entropy_backward_matches_hf(tiny_gpt2_config):
+    hf, minimal = _make_models(tiny_gpt2_config)
+    for param in hf.parameters():
+        param.requires_grad_(True)
+    for param in minimal.parameters():
+        param.requires_grad_(True)
+
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    labels = input_ids.clone()
+
+    hf.zero_grad(set_to_none=True)
+    ref_logits = hf(input_ids).logits
+    ref_loss = torch.nn.functional.cross_entropy(
+        ref_logits.view(-1, tiny_gpt2_config.vocab_size),
+        labels.view(-1),
+    )
+    ref_loss.backward()
+
+    minimal.zero_grad(set_to_none=True)
+    logits = minimal(input_ids)
+    loss = cross_entropy(logits, labels, reduction="mean")
+    loss.backward()
+
+    _assert_close(loss.to("cpu"), ref_loss, atol=1e-3)
+    _assert_close(
+        minimal.transformer.wte.weight.grad,
+        hf.transformer.wte.weight.grad,
+        atol=1e-3,
+    )
+
+
+def test_gpt2_lm_head_train_full_batch_step_cpu_inputs(tiny_gpt2_config):
+    _, minimal = _make_models(tiny_gpt2_config)
+    for param in minimal.parameters():
+        param.requires_grad_(True)
+
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    labels = input_ids.clone()
+
+    loss = train_full_batch_step(minimal, input_ids, labels, learning_rate=1e-3)
+    assert loss > 0.0
+    assert minimal.transformer.wte.weight.grad is not None
 
 
 @pytest.mark.xfail(

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -522,7 +522,7 @@ def train_full_batch_step(
         param.grad = None
 
     logits = model(inputs)
-    if inputs.device.type == "nntile":
+    if logits.device.type == "nntile":
         loss = cross_entropy(logits, targets)
         loss.backward()
         _nntile_optimizer_for(model, learning_rate).step()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the GPT-2 on `device="nntile"` feasibility follow-up by wiring forward, cross-entropy loss, backward, and an optimizer step end-to-end for the minimal GPT-2 model.

## Changes

- **`torch_nntile/examples/gpt2_minimal_train_step.py`** — new example running forward, `cross_entropy`, `backward`, and `SGD.step()` on a tiny GPT-2 config (parity-checked against CPU HuggingFace reference).
- **`torch_nntile/tests/test_gpt2_lm_head_parity.py`**
  - `test_gpt2_lm_head_cross_entropy_backward_matches_hf` — autograd through loss (not just external `grad_out`)
  - `test_gpt2_lm_head_train_full_batch_step_cpu_inputs` — `train_full_batch_step` with CPU `input_ids` and nntile logits
- **`torch_nntile/torch_nntile/training.py`** — `train_full_batch_step` now branches on `logits.device` instead of `inputs.device`, so models like GPT-2 (CPU index tensors, nntile activations) use the nntile loss path.

## Validation

```bash
export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
export STARPU_SILENT=1 STARPU_FXT_TRACE=0 STARPU_WORKERS_NOBIND=1

python torch_nntile/examples/gpt2_minimal_forward.py
python torch_nntile/examples/gpt2_minimal_train_step.py
pytest torch_nntile/tests/test_gpt2_lm_head_parity.py -vv
pytest torch_nntile/tests/test_graph_execution.py::test_train_full_batch_step_graph_mode -vv
```

All 14 GPT-2 parity tests pass (1 xfail for graph-mode forward as before).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3206-e89d-7951-82d9-d00c0bb0ecb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3206-e89d-7951-82d9-d00c0bb0ecb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

