### PR TITLE
Add CUDA implementation for swap_two_axes kernel

### DIFF
--- a/nntile/include/nntile/kernel/swap_two_axes.hh
+++ b/nntile/include/nntile/kernel/swap_two_axes.hh
@@ -10,6 +10,10 @@
 #pragma once
 
 #include <nntile/kernel/swap_two_axes/cpu.hh>
+#include <nntile/defs.h>
+#ifdef NNTILE_USE_CUDA
+#include <nntile/kernel/swap_two_axes/cuda.hh>
+#endif // NNTILE_USE_CUDA
 
 namespace nntile::kernel::swap_two_axes
 {

--- a/nntile/include/nntile/kernel/swap_two_axes/cuda.hh
+++ b/nntile/include/nntile/kernel/swap_two_axes/cuda.hh
@@ -1,0 +1,29 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file include/nntile/kernel/swap_two_axes/cuda.hh
+ * Swap axes 1 and 3 in a 5D buffer on CUDA.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include <nntile/base_types.hh>
+#include <cuda_runtime.h>
+
+namespace nntile::kernel::swap_two_axes
+{
+
+template<typename T>
+void cuda(
+    cudaStream_t stream,
+    Index d0,
+    Index d1,
+    Index d2,
+    Index d3,
+    Index d4,
+    const T *src,
+    T *dst) noexcept;
+
+} // namespace nntile::kernel::swap_two_axes

--- a/nntile/include/nntile/starpu/swap_two_axes.hh
+++ b/nntile/include/nntile/starpu/swap_two_axes.hh
@@ -47,7 +47,15 @@ public:
         cpu
     };
 
+#ifdef NNTILE_USE_CUDA
+    static void cuda(void *buffers[], void *cl_args) noexcept;
+
+    static constexpr func_array cuda_funcs = {
+        cuda
+    };
+#else // NNTILE_USE_CUDA
     static constexpr func_array cuda_funcs = {};
+#endif // NNTILE_USE_CUDA
 
     void submit(
         int starpu_worker_hint,

--- a/nntile/src/CMakeLists.txt
+++ b/nntile/src/CMakeLists.txt
@@ -161,6 +161,7 @@ if(NOT HAVE_STARPU_SIMGRID)
             "kernel/sumprod_slice/cuda.cu"
             "kernel/total_sum_accum/cuda.cu"
             "kernel/transpose/cuda.cu"
+            "kernel/swap_two_axes/cuda.cu"
             "kernel/isfinite/cuda.cu"
         )
         if(NNTILE_USE_FLASH_SDPA)

--- a/nntile/src/kernel/swap_two_axes/cuda.cu
+++ b/nntile/src/kernel/swap_two_axes/cuda.cu
@@ -1,0 +1,125 @@
+/*! @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *
+ * @file src/kernel/swap_two_axes/cuda.cu
+ * Swap axes 1 and 3 in a 5D buffer on CUDA.
+ *
+ * @version 1.1.0
+ * */
+
+#include "nntile/kernel/swap_two_axes/cuda.hh"
+
+#include "nntile/kernel/cuda.hh"
+
+namespace nntile::kernel::swap_two_axes
+{
+
+namespace
+{
+
+constexpr int warp_size = 32;
+
+} // namespace
+
+template<typename T>
+static __global__
+void cuda_kernel(
+    Index d0,
+    Index d1,
+    Index d2,
+    Index d3,
+    Index d4,
+    const T *src,
+    T *dst)
+{
+    const Index fiber = blockIdx.x;
+    Index rem = fiber;
+    const Index i3 = rem % d3;
+    rem /= d3;
+    const Index i2 = rem % d2;
+    rem /= d2;
+    const Index i1 = rem % d1;
+    const Index i0 = rem / d1;
+    if (i0 >= d0)
+    {
+        return;
+    }
+    const Index src_base =
+        ((((i0 * d1 + i1) * d2 + i2) * d3 + i3) * d4);
+    const Index dst_base =
+        ((((i0 * d3 + i3) * d2 + i2) * d1 + i1) * d4);
+    for (Index i4 = threadIdx.x; i4 < d4; i4 += warp_size)
+    {
+        dst[dst_base + i4] = src[src_base + i4];
+    }
+}
+
+template<typename T>
+void cuda(
+    cudaStream_t stream,
+    Index d0,
+    Index d1,
+    Index d2,
+    Index d3,
+    Index d4,
+    const T *src,
+    T *dst) noexcept
+{
+    const Index n_fibers = d0 * d1 * d2 * d3;
+    dim3 blocks(static_cast<unsigned>(n_fibers));
+    dim3 threads(warp_size);
+    (cuda_kernel<T>)<<<blocks, threads, 0, stream>>>(
+        d0,
+        d1,
+        d2,
+        d3,
+        d4,
+        src,
+        dst);
+}
+
+template
+void cuda<fp32_t>(
+    cudaStream_t stream,
+    Index d0,
+    Index d1,
+    Index d2,
+    Index d3,
+    Index d4,
+    const fp32_t *src,
+    fp32_t *dst) noexcept;
+
+template
+void cuda<fp64_t>(
+    cudaStream_t stream,
+    Index d0,
+    Index d1,
+    Index d2,
+    Index d3,
+    Index d4,
+    const fp64_t *src,
+    fp64_t *dst) noexcept;
+
+template
+void cuda<bf16_t>(
+    cudaStream_t stream,
+    Index d0,
+    Index d1,
+    Index d2,
+    Index d3,
+    Index d4,
+    const bf16_t *src,
+    bf16_t *dst) noexcept;
+
+template
+void cuda<fp16_t>(
+    cudaStream_t stream,
+    Index d0,
+    Index d1,
+    Index d2,
+    Index d3,
+    Index d4,
+    const fp16_t *src,
+    fp16_t *dst) noexcept;
+
+} // namespace nntile::kernel::swap_two_axes

--- a/nntile/src/starpu/swap_two_axes.cc
+++ b/nntile/src/starpu/swap_two_axes.cc
@@ -68,6 +68,55 @@ void SwapTwoAxes<std::tuple<fp32_fast_bf16_t>>::cpu(
     SwapTwoAxes<std::tuple<fp32_t>>::cpu(buffers, cl_args);
 }
 
+#ifdef NNTILE_USE_CUDA
+template<typename T>
+void SwapTwoAxes<std::tuple<T>>::cuda(
+    void *buffers[],
+    void *cl_args) noexcept
+{
+#ifndef STARPU_SIMGRID
+    auto args = reinterpret_cast<args_t *>(cl_args);
+    auto interfaces = reinterpret_cast<VariableInterface **>(buffers);
+    const T *src = interfaces[0]->get_ptr<T>();
+    T *dst = interfaces[1]->get_ptr<T>();
+    cudaStream_t stream = starpu_cuda_get_local_stream();
+    kernel::swap_two_axes::cuda<T>(
+        stream,
+        args->d0,
+        args->d1,
+        args->d2,
+        args->d3,
+        args->d4,
+        src,
+        dst);
+#endif
+}
+
+template<>
+void SwapTwoAxes<std::tuple<fp32_fast_tf32_t>>::cuda(
+    void *buffers[],
+    void *cl_args) noexcept
+{
+    SwapTwoAxes<std::tuple<fp32_t>>::cuda(buffers, cl_args);
+}
+
+template<>
+void SwapTwoAxes<std::tuple<fp32_fast_fp16_t>>::cuda(
+    void *buffers[],
+    void *cl_args) noexcept
+{
+    SwapTwoAxes<std::tuple<fp32_t>>::cuda(buffers, cl_args);
+}
+
+template<>
+void SwapTwoAxes<std::tuple<fp32_fast_bf16_t>>::cuda(
+    void *buffers[],
+    void *cl_args) noexcept
+{
+    SwapTwoAxes<std::tuple<fp32_t>>::cuda(buffers, cl_args);
+}
+#endif // NNTILE_USE_CUDA
+
 template<typename T>
 uint32_t SwapTwoAxes<std::tuple<T>>::footprint(struct starpu_task *task)
 {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a CUDA implementation for the `swap_two_axes` kernel, which swaps axes 1 and 3 in a 5D buffer (matching the existing CPU kernel).

## Approach

The CUDA kernel uses a simple warp-based strategy:
- One CUDA block is launched per `(i0, i1, i2, i3)` fiber (`d0 * d1 * d2 * d3` blocks total).
- Each block uses a single warp (32 threads) to copy the entire contiguous `d4` dimension.
- Threads stride over `d4` with step 32: `for (i4 = threadIdx.x; i4 < d4; i4 += 32)`.

This assumes `d4` is large enough to keep a warp busy (typical for tiled tensor layouts where the innermost dimension is the tile fiber size).

## Changes

- `nntile/include/nntile/kernel/swap_two_axes/cuda.hh` — CUDA kernel declaration
- `nntile/src/kernel/swap_two_axes/cuda.cu` — warp-based kernel implementation
- `nntile/include/nntile/kernel/swap_two_axes.hh` — include CUDA header when `NNTILE_USE_CUDA`
- `nntile/include/nntile/starpu/swap_two_axes.hh` — register `cuda_funcs`
- `nntile/src/starpu/swap_two_axes.cc` — StarPU CUDA wrapper (with fast-type fallbacks to FP32)
- `nntile/src/CMakeLists.txt` — add `kernel/swap_two_axes/cuda.cu` to CUDA sources

## Testing

Not run on this agent (CPU-only VM, `USE_CUDA=OFF`). Existing CPU tests in `tests/core/swap_two_axes.cc` cover correctness; CUDA path follows the same indexing as the CPU kernel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-223282dc-9aa8-4799-a118-9a2b0e36758f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-223282dc-9aa8-4799-a118-9a2b0e36758f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

