### PR TITLE
Require explicit nntile device for integer tensor inputs

### DIFF
--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -147,8 +147,8 @@ PyTorch C-order shapes are converted to TensorGraph storage layout internally.
 Gradients use **PyTorch autograd** (not `NNGraph` autograd).
 
 **Embedding v1 limits:** `float32` weights only; `padding_idx` must be `-1`
-(default); `scale_grad_by_freq=False` and `sparse=False` only. Indices may stay
-on CPU while weights are on `device="nntile"`.
+(default); `scale_grad_by_freq=False` and `sparse=False` only. Indices must be
+on `device="nntile"` (use `.to("nntile")` explicitly).
 
 **SDPA v1 limits:** `float32` only. Two entry points share one ATen kernel:
 
@@ -162,7 +162,7 @@ on CPU while weights are on `device="nntile"`.
 - **`torch_nntile.nn.sdpa_eager` / `SDPA`**: projection layout
   `[batch, seq, head_size, n_heads]`; internally transposes to kernel layout, calls
   `F.scaled_dot_product_attention`, transposes back. Optional BOOL mask `[q_seq, k_seq]`
-  on CPU or nntile (dim0 = query, dim1 = key).
+  on `device="nntile"` (dim0 = query, dim1 = key).
 
 Works in both eager and graph runtime modes (graph defers execution until
 ``compile_graph()`` / ``run()`` or ``execute()``). Use
@@ -302,7 +302,8 @@ Train `DeepReLU.mnist()` on all **60 000** MNIST training images in one batch,
 comparing CPU PyTorch vs `device="nntile"` with the same weight initialization.
 
 Cross-entropy is evaluated on nntile via `torch_nntile.training.cross_entropy`
-(same tensor-op chain as `NNCrossEntropyOp` in libnntile). Logits use **class
+(same tensor-op chain as `NNCrossEntropyOp` in libnntile). Logits and labels must
+both be on `device="nntile"` (use `.to("nntile")` explicitly). Logits use **class
 dim last** (`[..., C]`); labels match logits without the class axis (`...`).
 The scalar loss lives on ``device="nntile"``; use ``loss.to("cpu")`` after
 ``compile_graph()`` and ``run()`` in graph mode. Backward keeps ``grad_output`` as a

--- a/torch_nntile/csrc/nntile_cross_entropy.cpp
+++ b/torch_nntile/csrc/nntile_cross_entropy.cpp
@@ -32,8 +32,8 @@ void check_cross_entropy_inputs(
         target.scalar_type() == at::ScalarType::Long,
         "nntile cross_entropy: target must be int64");
     TORCH_CHECK(
-        target.is_cpu() || is_nntile_device(target.device()),
-        "nntile cross_entropy: target must be CPU or nntile");
+        is_nntile_device(target.device()),
+        "nntile cross_entropy: target must be on device nntile");
     TORCH_CHECK(logits.dim() >= 2, "nntile cross_entropy: logits must be >= 2D");
     TORCH_CHECK(
         target.dim() + 1 == logits.dim(),

--- a/torch_nntile/csrc/nntile_embedding.cpp
+++ b/torch_nntile/csrc/nntile_embedding.cpp
@@ -54,8 +54,8 @@ void check_embedding_forward_inputs(
         indices.scalar_type() == at::ScalarType::Long,
         "nntile embedding: indices must be int64");
     TORCH_CHECK(
-        indices.is_cpu() || is_nntile_device(indices.device()),
-        "nntile embedding: indices must be CPU or nntile");
+        is_nntile_device(indices.device()),
+        "nntile embedding: indices must be on device nntile");
     TORCH_CHECK(weight.dim() == 2, "nntile embedding: weight must be 2D");
     TORCH_CHECK(
         weight.scalar_type() == at::ScalarType::Float,
@@ -77,8 +77,8 @@ void check_embedding_backward_inputs(
         indices.scalar_type() == at::ScalarType::Long,
         "nntile embedding_dense_backward: indices must be int64");
     TORCH_CHECK(
-        indices.is_cpu() || is_nntile_device(indices.device()),
-        "nntile embedding_dense_backward: indices must be CPU or nntile");
+        is_nntile_device(indices.device()),
+        "nntile embedding_dense_backward: indices must be on device nntile");
     TORCH_CHECK(
         grad_output.scalar_type() == at::ScalarType::Float,
         "nntile embedding_dense_backward supports float32 only");

--- a/torch_nntile/csrc/nntile_sdpa.cpp
+++ b/torch_nntile/csrc/nntile_sdpa.cpp
@@ -70,8 +70,8 @@ void check_sdpa_mask(
         mask.is_contiguous(),
         "nntile sdpa: mask must be contiguous");
     TORCH_CHECK(
-        mask.is_cpu() || is_nntile_device(mask.device()),
-        "nntile sdpa: mask must be on CPU or nntile");
+        is_nntile_device(mask.device()),
+        "nntile sdpa: mask must be on device nntile");
     const int64_t q_ndim = q.dim();
     const int64_t k_ndim = k.dim();
     const int64_t q_seq = q.size(q_ndim - 2);

--- a/torch_nntile/csrc/nntile_sdpa.cpp
+++ b/torch_nntile/csrc/nntile_sdpa.cpp
@@ -83,6 +83,20 @@ void check_sdpa_mask(
         "nntile sdpa: mask shape must be [q_seq, k_seq]");
 }
 
+at::Tensor mask_to_uint8_nntile(const at::Tensor &mask)
+{
+    if (mask.scalar_type() == at::ScalarType::Byte)
+    {
+        return mask.contiguous();
+    }
+    at::Tensor mask_u8 = mask.cpu().to(at::kByte);
+    if (is_nntile_device(mask.device()))
+    {
+        mask_u8 = mask_u8.to(mask.device());
+    }
+    return mask_u8.contiguous();
+}
+
 } // namespace
 
 at::Tensor sdpa_forward(
@@ -107,14 +121,7 @@ at::Tensor sdpa_forward(
     std::vector<at::Tensor> inputs = {q, k, v};
     if (mask.has_value())
     {
-        if (mask->scalar_type() == at::ScalarType::Bool)
-        {
-            mask_u8 = mask->to(at::kByte);
-        }
-        else
-        {
-            mask_u8 = *mask;
-        }
+        mask_u8 = mask_to_uint8_nntile(*mask);
         inputs.push_back(mask_u8);
     }
     pin_graph_op_inputs(inputs);
@@ -172,14 +179,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> sdpa_backward(
     std::vector<at::Tensor> inputs = {q, k, v, grad_out};
     if (mask.has_value())
     {
-        if (mask->scalar_type() == at::ScalarType::Bool)
-        {
-            mask_u8 = mask->to(at::kByte);
-        }
-        else
-        {
-            mask_u8 = *mask;
-        }
+        mask_u8 = mask_to_uint8_nntile(*mask);
         inputs.push_back(mask_u8);
     }
     pin_graph_op_inputs(inputs);

--- a/torch_nntile/csrc/nntile_sdpa_aten.cpp
+++ b/torch_nntile/csrc/nntile_sdpa_aten.cpp
@@ -79,12 +79,20 @@ bool sdpa_inputs_supported(
     return true;
 }
 
-at::Tensor make_causal_mask(int64_t q_seq, int64_t k_seq)
+at::Tensor make_causal_mask(
+    int64_t q_seq,
+    int64_t k_seq,
+    const c10::Device &device)
 {
     const auto idx_opts = at::TensorOptions().dtype(at::kLong);
     const at::Tensor k_idx = at::arange(k_seq, idx_opts);
     const at::Tensor q_idx = at::arange(q_seq, idx_opts);
-    return k_idx.unsqueeze(0) <= q_idx.unsqueeze(1);
+    at::Tensor mask = k_idx.unsqueeze(0) <= q_idx.unsqueeze(1);
+    if (mask.device() != device)
+    {
+        mask = mask.to(device);
+    }
+    return mask.contiguous();
 }
 
 constexpr float kFloatMaskThreshold = -1e20f;
@@ -135,15 +143,15 @@ at::Tensor broadcastable_attn_bias_to_2d(
     if (bias.scalar_type() == at::ScalarType::Bool)
     {
         TORCH_CHECK(
-            at::equal(bias, expanded),
+            at::equal(bias.cpu(), expanded.cpu()),
             "nntile sdpa: bool attn_bias must broadcast to [q_seq, k_seq]");
     }
     else
     {
         TORCH_CHECK(
             at::allclose(
-                bias.to(at::kFloat),
-                expanded.to(at::kFloat)),
+                bias.to(at::kFloat).cpu(),
+                expanded.to(at::kFloat).cpu()),
             "nntile sdpa: float attn_bias must broadcast to [q_seq, k_seq]");
     }
     return canonical.contiguous();
@@ -172,11 +180,12 @@ std::optional<at::Tensor> convert_attn_bias_to_mask(
     const std::optional<at::Tensor> &attn_bias,
     bool is_causal,
     int64_t q_seq,
-    int64_t k_seq)
+    int64_t k_seq,
+    const c10::Device &device)
 {
     if (is_causal)
     {
-        return make_causal_mask(q_seq, k_seq);
+        return make_causal_mask(q_seq, k_seq, device);
     }
     if (!attn_bias.has_value() || !attn_bias->defined() ||
         attn_bias->numel() == 0)
@@ -200,6 +209,10 @@ std::optional<at::Tensor> convert_attn_bias_to_mask(
     else
     {
         bool_mask = float_attn_bias_to_bool(bias_2d);
+    }
+    if (bool_mask.device() != device)
+    {
+        bool_mask = bool_mask.to(device);
     }
     return bool_mask.contiguous();
 }
@@ -280,7 +293,8 @@ sdpa_overrideable_forward(
         attn_bias,
         is_causal,
         q_seq.expect_int(),
-        k_seq.expect_int());
+        k_seq.expect_int(),
+        query.device());
 
     const at::Tensor out = sdpa_forward(
         query,
@@ -372,7 +386,8 @@ sdpa_overrideable_backward(
         attn_bias_opt,
         is_causal,
         query.size(-2),
-        key.size(-2));
+        key.size(-2),
+        query.device());
 
     const at::Tensor grad_out_c = ensure_contiguous_nntile(grad_out);
     auto grad_qkv = sdpa_backward(

--- a/torch_nntile/examples/gpt2_hf_out_of_box.py
+++ b/torch_nntile/examples/gpt2_hf_out_of_box.py
@@ -47,7 +47,7 @@ def main() -> None:
     for param in ref.parameters():
         param.requires_grad_(True)
 
-    input_ids = torch.randint(0, config.vocab_size, (2, 8))
+    input_ids = torch.randint(0, config.vocab_size, (2, 8)).to("nntile")
     labels = input_ids.clone()
 
     with torch.no_grad():

--- a/torch_nntile/examples/gpt2_hf_out_of_box.py
+++ b/torch_nntile/examples/gpt2_hf_out_of_box.py
@@ -47,14 +47,16 @@ def main() -> None:
     for param in ref.parameters():
         param.requires_grad_(True)
 
-    input_ids = torch.randint(0, config.vocab_size, (2, 8)).to("nntile")
-    labels = input_ids.clone()
+    input_ids_cpu = torch.randint(0, config.vocab_size, (2, 8))
+    labels_cpu = input_ids_cpu.clone()
+    input_ids = input_ids_cpu.to("nntile")
+    labels = labels_cpu.to("nntile")
 
     with torch.no_grad():
-        ref_logits = ref(input_ids).logits
+        ref_logits = ref(input_ids_cpu).logits
         ref_loss = torch.nn.functional.cross_entropy(
             ref_logits.view(-1, config.vocab_size),
-            labels.view(-1),
+            labels_cpu.view(-1),
         )
 
     model.zero_grad(set_to_none=True)

--- a/torch_nntile/examples/gpt2_minimal_forward.py
+++ b/torch_nntile/examples/gpt2_minimal_forward.py
@@ -39,9 +39,10 @@ def main() -> None:
     load_hf_into_gpt2_lm_head(model, hf)
     model = model.to("nntile")
 
-    input_ids = torch.randint(0, config.vocab_size, (2, 8)).to("nntile")
+    input_ids_cpu = torch.randint(0, config.vocab_size, (2, 8))
+    input_ids = input_ids_cpu.to("nntile")
     with torch.no_grad():
-        ref = hf(input_ids).logits
+        ref = hf(input_ids_cpu).logits
         out = model(input_ids).cpu()
     print("forward match:", torch.allclose(out, ref, rtol=1e-4, atol=1e-4))
 

--- a/torch_nntile/examples/gpt2_minimal_forward.py
+++ b/torch_nntile/examples/gpt2_minimal_forward.py
@@ -39,7 +39,7 @@ def main() -> None:
     load_hf_into_gpt2_lm_head(model, hf)
     model = model.to("nntile")
 
-    input_ids = torch.randint(0, config.vocab_size, (2, 8))
+    input_ids = torch.randint(0, config.vocab_size, (2, 8)).to("nntile")
     with torch.no_grad():
         ref = hf(input_ids).logits
         out = model(input_ids).cpu()

--- a/torch_nntile/tests/test_cross_entropy_parity.py
+++ b/torch_nntile/tests/test_cross_entropy_parity.py
@@ -26,7 +26,7 @@ def test_cross_entropy_forward_mean_matches_cpu():
 
     loss_cpu = F.cross_entropy(logits_cpu, target, reduction="mean")
     logits_nnt = logits_cpu.detach().to("nntile")
-    loss_nnt = cross_entropy(logits_nnt, target, reduction="mean")
+    loss_nnt = cross_entropy(logits_nnt, target.to("nntile"), reduction="mean")
 
     assert torch.allclose(
         loss_nnt.detach().cpu(),
@@ -44,7 +44,7 @@ def test_cross_entropy_forward_sum_matches_cpu():
 
     loss_cpu = F.cross_entropy(logits_cpu, target, reduction="sum")
     logits_nnt = logits_cpu.detach().to("nntile")
-    loss_nnt = cross_entropy(logits_nnt, target, reduction="sum")
+    loss_nnt = cross_entropy(logits_nnt, target.to("nntile"), reduction="sum")
 
     assert torch.allclose(
         loss_nnt.detach().cpu(),
@@ -65,7 +65,7 @@ def test_cross_entropy_backward_matches_cpu():
     grad_cpu = logits_cpu.grad.detach().clone()
 
     logits_nnt = logits_cpu.detach().clone().to("nntile").requires_grad_(True)
-    loss_nnt = cross_entropy(logits_nnt, target, reduction="mean")
+    loss_nnt = cross_entropy(logits_nnt, target.to("nntile"), reduction="mean")
     loss_nnt.backward()
     grad_nnt = logits_nnt.grad.cpu()
 
@@ -92,7 +92,7 @@ def test_cross_entropy_backward_multidim_labels_matches_cpu():
         .to("nntile")
         .requires_grad_(True)
     )
-    loss_nnt = cross_entropy(logits_nnt, target, reduction="mean")
+    loss_nnt = cross_entropy(logits_nnt, target.to("nntile"), reduction="mean")
     loss_nnt.backward()
     grad_nnt = logits_nnt.grad.cpu().permute(0, 2, 1).contiguous()
 
@@ -115,7 +115,7 @@ def test_cross_entropy_ignore_index_matches_cpu():
     logits_nnt = logits_cpu.detach().to("nntile")
     loss_nnt = cross_entropy(
         logits_nnt,
-        target,
+        target.to("nntile"),
         reduction="mean",
         ignore_index=ignore_index,
     )
@@ -126,3 +126,10 @@ def test_cross_entropy_ignore_index_matches_cpu():
         rtol=1e-4,
         atol=1e-4,
     )
+
+
+def test_cross_entropy_rejects_cpu_target():
+    logits_nnt = torch.randn(4, 5, dtype=torch.float32).to("nntile")
+    target = torch.randint(0, 5, (4,))
+    with pytest.raises(ValueError, match="nntile target"):
+        cross_entropy(logits_nnt, target, reduction="mean")

--- a/torch_nntile/tests/test_embedding_parity.py
+++ b/torch_nntile/tests/test_embedding_parity.py
@@ -146,10 +146,10 @@ def test_embedding_graph_mode():
         num_embeddings, embed_dim = 8, 4
         indices = torch.randint(0, num_embeddings, (2, 3)).to("nntile")
         weight_cpu = torch.randn(num_embeddings, embed_dim, dtype=torch.float32)
-        out_cpu = F.embedding(indices, weight_cpu)
+        out_cpu = F.embedding(indices.cpu(), weight_cpu)
 
         weight_nnt = weight_cpu.detach().to("nntile")
-        out_nnt = F.embedding(indices.to("nntile"), weight_nnt)
+        out_nnt = F.embedding(indices, weight_nnt)
         assert torch_nntile.has_pending_graph()
         torch_nntile.compile_graph()
         torch_nntile.run()

--- a/torch_nntile/tests/test_embedding_parity.py
+++ b/torch_nntile/tests/test_embedding_parity.py
@@ -60,7 +60,7 @@ def test_embedding_forward_matches_cpu(index_shape):
 
     out_cpu = F.embedding(indices, weight_cpu)
     weight_nnt = weight_cpu.detach().to("nntile")
-    out_nnt = F.embedding(indices, weight_nnt)
+    out_nnt = F.embedding(indices.to("nntile"), weight_nnt)
 
     assert torch.allclose(out_nnt.detach().cpu(), out_cpu, rtol=1e-5, atol=1e-5)
 
@@ -83,7 +83,7 @@ def test_embedding_backward_matches_cpu():
         weight_nnt.weight.copy_(weight_cpu.weight.detach())
     weight_nnt.weight.requires_grad_(True)
 
-    out_nnt = weight_nnt(indices)
+    out_nnt = weight_nnt(indices.to("nntile"))
     grad_out = torch.ones_like(out_cpu).to("nntile")
     torch.autograd.backward([out_nnt], [grad_out])
     grad_nnt = weight_nnt.weight.grad.cpu()
@@ -109,7 +109,7 @@ def test_embedding_duplicate_indices():
         weight_nnt.weight.copy_(weight_cpu.weight.detach())
     weight_nnt.weight.requires_grad_(True)
 
-    out_nnt = weight_nnt(indices)
+    out_nnt = weight_nnt(indices.to("nntile"))
     grad_out = torch.ones_like(out_cpu).to("nntile")
     torch.autograd.backward([out_nnt], [grad_out])
     grad_nnt = weight_nnt.weight.grad.cpu()
@@ -117,18 +117,17 @@ def test_embedding_duplicate_indices():
     assert torch.allclose(grad_nnt, grad_cpu, rtol=1e-5, atol=1e-5)
 
 
-def test_embedding_indices_on_cpu():
+def test_embedding_rejects_cpu_indices():
     torch.manual_seed(3)
     num_embeddings, embed_dim = 10, 5
     indices = torch.randint(0, num_embeddings, (3, 3))
-    weight_cpu = torch.randn(num_embeddings, embed_dim, dtype=torch.float32)
-
-    out_cpu = F.embedding(indices, weight_cpu)
-    weight_nnt = weight_cpu.detach().to("nntile")
-    out_nnt = F.embedding(indices, weight_nnt)
+    weight_nnt = torch.randn(num_embeddings, embed_dim, dtype=torch.float32).to(
+        "nntile"
+    )
 
     assert indices.device.type == "cpu"
-    assert torch.allclose(out_nnt.detach().cpu(), out_cpu, rtol=1e-5, atol=1e-5)
+    with pytest.raises(RuntimeError, match="indices must be on device nntile"):
+        F.embedding(indices, weight_nnt)
 
 
 def test_embedding_graph_mode():
@@ -145,12 +144,12 @@ def test_embedding_graph_mode():
         torch_nntile.restrict_cpu()
 
         num_embeddings, embed_dim = 8, 4
-        indices = torch.randint(0, num_embeddings, (2, 3))
+        indices = torch.randint(0, num_embeddings, (2, 3)).to("nntile")
         weight_cpu = torch.randn(num_embeddings, embed_dim, dtype=torch.float32)
         out_cpu = F.embedding(indices, weight_cpu)
 
         weight_nnt = weight_cpu.detach().to("nntile")
-        out_nnt = F.embedding(indices, weight_nnt)
+        out_nnt = F.embedding(indices.to("nntile"), weight_nnt)
         assert torch_nntile.has_pending_graph()
         torch_nntile.compile_graph()
         torch_nntile.run()

--- a/torch_nntile/tests/test_gpt2_lm_head_parity.py
+++ b/torch_nntile/tests/test_gpt2_lm_head_parity.py
@@ -94,7 +94,7 @@ def _assert_close(
 
 def test_gpt2_model_forward_shape(tiny_gpt2_config):
     _, minimal = _make_models(tiny_gpt2_config)
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     hidden = minimal.transformer(input_ids)
     assert hidden.shape == (2, 8, tiny_gpt2_config.n_embd)
     assert hidden.dtype == torch.float32
@@ -102,7 +102,7 @@ def test_gpt2_model_forward_shape(tiny_gpt2_config):
 
 def test_gpt2_lm_head_forward_shape(tiny_gpt2_config):
     _, minimal = _make_models(tiny_gpt2_config)
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     logits = minimal(input_ids)
     assert logits.shape == (2, 8, tiny_gpt2_config.vocab_size)
     assert logits.dtype == torch.float32
@@ -110,9 +110,9 @@ def test_gpt2_lm_head_forward_shape(tiny_gpt2_config):
 
 def test_gpt2_lm_head_forward_matches_hf_tied(tiny_gpt2_config):
     hf, minimal = _make_models(tiny_gpt2_config)
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     with torch.no_grad():
-        ref = hf(input_ids).logits
+        ref = hf(input_ids.cpu()).logits
         out = minimal(input_ids)
     _assert_close(out, ref)
 
@@ -120,9 +120,9 @@ def test_gpt2_lm_head_forward_matches_hf_tied(tiny_gpt2_config):
 def test_gpt2_lm_head_forward_matches_hf_untied(tiny_gpt2_config):
     tiny_gpt2_config.tie_word_embeddings = False
     hf, minimal = _make_models(tiny_gpt2_config)
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     with torch.no_grad():
-        ref = hf(input_ids).logits
+        ref = hf(input_ids.cpu()).logits
         out = minimal(input_ids)
     _assert_close(out, ref)
 
@@ -168,7 +168,7 @@ def test_gpt2_block_forward_matches_hf(tiny_gpt2_config):
 
     block = block.to("nntile")
     x_cpu = torch.randn(2, 8, hidden)
-    mask = make_causal_sdpa_mask(8)
+    mask = make_causal_sdpa_mask(8).to("nntile")
     with torch.no_grad():
         ref = hf_block(x_cpu, attention_mask=None)[0]
         out = block(x_cpu.to("nntile"), mask)
@@ -243,7 +243,7 @@ def test_gpt2_attention_forward_matches_hf(tiny_gpt2_config):
     attn = attn.to("nntile")
 
     x_cpu = torch.randn(2, 8, hidden)
-    mask = make_causal_sdpa_mask(8)
+    mask = make_causal_sdpa_mask(8).to("nntile")
     with torch.no_grad():
         ref = hf_attn(x_cpu)[0]
         out = attn(x_cpu.to("nntile"), mask)
@@ -279,7 +279,7 @@ def test_gpt2_attention_backward_matches_hf(tiny_gpt2_config):
 
     x_cpu = torch.randn(2, 8, hidden, requires_grad=True)
     grad_out = torch.randn(2, 8, hidden)
-    mask = make_causal_sdpa_mask(8)
+    mask = make_causal_sdpa_mask(8).to("nntile")
 
     y_ref = hf_attn(x_cpu)[0]
     y_ref.backward(grad_out)
@@ -298,11 +298,11 @@ def test_gpt2_lm_head_backward_matches_hf_tied(tiny_gpt2_config):
     for p in minimal.parameters():
         p.requires_grad_(True)
 
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     grad_out = torch.randn(2, 8, tiny_gpt2_config.vocab_size)
 
     hf.zero_grad(set_to_none=True)
-    logits_ref = hf(input_ids).logits
+    logits_ref = hf(input_ids.cpu()).logits
     logits_ref.backward(grad_out)
 
     minimal.zero_grad(set_to_none=True)
@@ -320,11 +320,11 @@ def test_gpt2_lm_head_backward_matches_hf_untied(tiny_gpt2_config):
     for p in minimal.parameters():
         p.requires_grad_(True)
 
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     grad_out = torch.randn(2, 8, tiny_gpt2_config.vocab_size)
 
     hf.zero_grad(set_to_none=True)
-    hf(input_ids).logits.backward(grad_out)
+    hf(input_ids.cpu()).logits.backward(grad_out)
 
     minimal.zero_grad(set_to_none=True)
     minimal(input_ids).backward(grad_out.to("nntile"))
@@ -381,9 +381,9 @@ def test_gpt2_lm_head_graph_mode_forward(tiny_gpt2_config):
         load_hf_into_gpt2_lm_head(model, hf)
         model = model.to("nntile")
 
-        input_ids = torch.randint(0, config.vocab_size, (1, 4))
+        input_ids = torch.randint(0, config.vocab_size, (1, 4)).to("nntile")
         with torch.no_grad():
-            ref = hf(input_ids).logits
+            ref = hf(input_ids.cpu()).logits
         assert torch_nntile.has_pending_graph() is False
         out = model(input_ids)
         assert torch_nntile.has_pending_graph()

--- a/torch_nntile/tests/test_graph_execution.py
+++ b/torch_nntile/tests/test_graph_execution.py
@@ -211,11 +211,12 @@ def test_graph_cross_entropy_backward_and_sgd():
         batch, classes, features = 4, 3, 5
         w_cpu = torch.randn(classes, features)
         x_cpu = torch.randn(batch, features)
-        target = torch.randint(0, classes, (batch,))
+        target = torch.randint(0, classes, (batch,)).to("nntile")
+        target_cpu = target.cpu()
 
         w_ref = w_cpu.clone().requires_grad_(True)
         logits_ref = x_cpu @ w_ref.t()
-        loss_ref = torch.nn.functional.cross_entropy(logits_ref, target)
+        loss_ref = torch.nn.functional.cross_entropy(logits_ref, target_cpu)
         loss_ref.backward()
         torch.optim.SGD([w_ref], lr=0.1).step()
         w_after_ref = w_ref.detach().clone()
@@ -313,7 +314,8 @@ def test_graph_nntile_loss_backward_without_scalar_read():
         torch_nntile.restrict_cpu()
 
         logits_cpu = torch.randn(8, 5)
-        target = torch.randint(0, 5, (8,))
+        target = torch.randint(0, 5, (8,)).to("nntile")
+        target_cpu = target.cpu()
         logits_nnt = logits_cpu.to("nntile").requires_grad_(True)
         loss = cross_entropy(logits_nnt, target, reduction="mean")
         assert loss.device.type == "nntile"
@@ -321,7 +323,9 @@ def test_graph_nntile_loss_backward_without_scalar_read():
         loss.backward()
         assert torch_nntile.has_pending_graph()
         torch_nntile.execute()
-        ref = torch.nn.functional.cross_entropy(logits_cpu, target, reduction="mean")
+        ref = torch.nn.functional.cross_entropy(
+            logits_cpu, target_cpu, reduction="mean"
+        )
         assert torch.allclose(loss.detach().cpu(), ref, rtol=1e-4, atol=1e-4)
         """
     )

--- a/torch_nntile/tests/test_hf_gpt2_stock_on_nntile.py
+++ b/torch_nntile/tests/test_hf_gpt2_stock_on_nntile.py
@@ -74,9 +74,9 @@ def _make_stock_models(config: GPT2Config):
 
 def test_hf_gpt2_forward_matches_cpu(tiny_gpt2_config):
     ref, model = _make_stock_models(tiny_gpt2_config)
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     with torch.no_grad():
-        ref_logits = ref(input_ids).logits
+        ref_logits = ref(input_ids.cpu()).logits
         out = model(input_ids).logits
     torch.testing.assert_close(out.cpu(), ref_logits, rtol=1e-4, atol=1e-4)
 
@@ -88,14 +88,14 @@ def test_hf_gpt2_cross_entropy_backward_matches_cpu(tiny_gpt2_config):
     for param in model.parameters():
         param.requires_grad_(True)
 
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     labels = input_ids.clone()
 
     ref.zero_grad(set_to_none=True)
-    ref_logits = ref(input_ids).logits
+    ref_logits = ref(input_ids.cpu()).logits
     ref_loss = torch.nn.functional.cross_entropy(
         ref_logits.view(-1, tiny_gpt2_config.vocab_size),
-        labels.view(-1),
+        labels.cpu().view(-1),
     )
     ref_loss.backward()
 
@@ -113,12 +113,12 @@ def test_hf_gpt2_cross_entropy_backward_matches_cpu(tiny_gpt2_config):
     )
 
 
-def test_hf_gpt2_train_full_batch_step_cpu_inputs(tiny_gpt2_config):
+def test_hf_gpt2_train_full_batch_step_nntile_inputs(tiny_gpt2_config):
     _, model = _make_stock_models(tiny_gpt2_config)
     for param in model.parameters():
         param.requires_grad_(True)
 
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8))
+    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     labels = input_ids.clone()
     loss = train_full_batch_step(model, input_ids, labels, learning_rate=1e-3)
     assert loss > 0.0

--- a/torch_nntile/tests/test_sdpa_parity.py
+++ b/torch_nntile/tests/test_sdpa_parity.py
@@ -155,7 +155,7 @@ def test_sdpa_forward_with_mask_matches_reference():
         q_cpu.to("nntile"),
         k_cpu.to("nntile"),
         v_cpu.to("nntile"),
-        mask,
+        mask.to("nntile"),
         batch_ndim=2,
     )
     assert torch.allclose(out.cpu(), ref, rtol=1e-4, atol=1e-4)
@@ -179,7 +179,7 @@ def test_sdpa_mask_axis_order_matches_causal_layout():
         q_cpu.to("nntile"),
         k_cpu.to("nntile"),
         v_cpu.to("nntile"),
-        mask,
+        mask.to("nntile"),
         batch_ndim=2,
     )
     assert torch.allclose(out.cpu(), ref, rtol=1e-4, atol=1e-4)
@@ -191,14 +191,14 @@ def test_sdpa_mask_axis_order_matches_causal_layout():
         q_cpu.to("nntile"),
         k_cpu.to("nntile"),
         v_cpu.to("nntile"),
-        mask_sparse,
+        mask_sparse.to("nntile"),
         batch_ndim=2,
     )
     out_transposed_mask = sdpa_eager(
         q_cpu.to("nntile"),
         k_cpu.to("nntile"),
         v_cpu.to("nntile"),
-        mask_sparse.t().contiguous(),
+        mask_sparse.t().contiguous().to("nntile"),
         batch_ndim=2,
     )
     assert not torch.allclose(

--- a/torch_nntile/torch_nntile/models/gpt2_minimal.py
+++ b/torch_nntile/torch_nntile/models/gpt2_minimal.py
@@ -21,7 +21,7 @@ def make_causal_sdpa_mask(seq_len: int, device: torch.device | None = None) -> T
     """BOOL causal mask ``[seq, seq]`` with ``mask[q, k] = (k <= q)``."""
     q_idx = torch.arange(seq_len, dtype=torch.long, device="cpu")
     k_idx = torch.arange(seq_len, dtype=torch.long, device="cpu")
-    mask = k_idx.unsqueeze(0) <= q_idx.unsqueeze(1)
+    mask = (k_idx.unsqueeze(0) <= q_idx.unsqueeze(1)).contiguous()
     if device is not None and device.type != "cpu":
         mask = mask.to(device)
     return mask
@@ -207,10 +207,10 @@ class GPT2Model(nn.Module):
             seq = input_ids.size(-1)
             position_ids = (
                 torch.arange(seq, dtype=torch.long, device="cpu")
-                .to(input_ids.device)
                 .unsqueeze(0)
                 .expand(input_ids.size(0), -1)
                 .contiguous()
+                .to(input_ids.device)
             )
 
         if causal_mask is None:

--- a/torch_nntile/torch_nntile/models/gpt2_minimal.py
+++ b/torch_nntile/torch_nntile/models/gpt2_minimal.py
@@ -210,7 +210,10 @@ class GPT2Model(nn.Module):
             )
 
         if causal_mask is None:
-            causal_mask = make_causal_sdpa_mask(input_ids.size(-1))
+            causal_mask = make_causal_sdpa_mask(
+                input_ids.size(-1),
+                device=input_ids.device,
+            )
 
         x = self.wte(input_ids) + self.wpe(position_ids)
         for block in self.h:

--- a/torch_nntile/torch_nntile/models/gpt2_minimal.py
+++ b/torch_nntile/torch_nntile/models/gpt2_minimal.py
@@ -19,9 +19,12 @@ from torch_nntile.gemm import gemm
 
 def make_causal_sdpa_mask(seq_len: int, device: torch.device | None = None) -> Tensor:
     """BOOL causal mask ``[seq, seq]`` with ``mask[q, k] = (k <= q)``."""
-    q_idx = torch.arange(seq_len, device=device)
-    k_idx = torch.arange(seq_len, device=device)
-    return k_idx.unsqueeze(0) <= q_idx.unsqueeze(1)
+    q_idx = torch.arange(seq_len, dtype=torch.long, device="cpu")
+    k_idx = torch.arange(seq_len, dtype=torch.long, device="cpu")
+    mask = k_idx.unsqueeze(0) <= q_idx.unsqueeze(1)
+    if device is not None and device.type != "cpu":
+        mask = mask.to(device)
+    return mask
 
 
 class NntileConv1D(nn.Module):
@@ -203,7 +206,8 @@ class GPT2Model(nn.Module):
         if position_ids is None:
             seq = input_ids.size(-1)
             position_ids = (
-                torch.arange(seq, dtype=torch.long, device=input_ids.device)
+                torch.arange(seq, dtype=torch.long, device="cpu")
+                .to(input_ids.device)
                 .unsqueeze(0)
                 .expand(input_ids.size(0), -1)
                 .contiguous()

--- a/torch_nntile/torch_nntile/nn/sdpa.py
+++ b/torch_nntile/torch_nntile/nn/sdpa.py
@@ -37,6 +37,35 @@ def nntile_model_transpose(x: Tensor, model_ndim: int) -> Tensor:
     return _NntileModelTranspose.apply(x, model_ndim)
 
 
+class _NntileSdpaKernel(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q: Tensor,
+        k: Tensor,
+        v: Tensor,
+        mask: Tensor,
+        batch_ndim: int,
+    ) -> Tensor:
+        out = _C.sdpa_forward(q, k, v, mask, int(batch_ndim))
+        ctx.save_for_backward(q, k, v, mask)
+        ctx.batch_ndim = int(batch_ndim)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor):
+        q, k, v, mask = ctx.saved_tensors
+        grad_q, grad_k, grad_v = _C.sdpa_backward(
+            q,
+            k,
+            v,
+            grad_out,
+            mask,
+            ctx.batch_ndim,
+        )
+        return grad_q, grad_k, grad_v, None, None
+
+
 def sdpa_eager(
     q: Tensor,
     k: Tensor,
@@ -65,18 +94,29 @@ def sdpa_eager(
         raise ValueError("nntile sdpa supports float32 only")
     if mask is not None and mask.dtype != torch.bool:
         raise ValueError("nntile sdpa: mask must be bool")
+    if mask is not None and mask.device.type != "nntile":
+        raise ValueError("nntile sdpa: mask must be on device nntile")
     q_sdpa = nntile_model_transpose(q, 1)
     k_sdpa = nntile_model_transpose(k, 1)
     v_sdpa = nntile_model_transpose(v, 1)
-    attn_out = F.scaled_dot_product_attention(
-        q_sdpa,
-        k_sdpa,
-        v_sdpa,
-        attn_mask=mask,
-        dropout_p=0.0,
-        is_causal=False,
-        scale=None,
-    )
+    if mask is None:
+        attn_out = F.scaled_dot_product_attention(
+            q_sdpa,
+            k_sdpa,
+            v_sdpa,
+            attn_mask=None,
+            dropout_p=0.0,
+            is_causal=False,
+            scale=None,
+        )
+    else:
+        attn_out = _NntileSdpaKernel.apply(
+            q_sdpa,
+            k_sdpa,
+            v_sdpa,
+            mask,
+            batch_ndim,
+        )
     return nntile_model_transpose(attn_out, 3)
 
 

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -72,6 +72,7 @@ def cross_entropy(
 ) -> torch.Tensor:
     """Cross-entropy on ``device='nntile'`` via libnntile tensor ops.
 
+    ``logits`` and ``target`` must both be on ``device='nntile'``.
     ``logits`` shape ``[..., C]`` (class dim last). ``target`` is int64 with
     shape matching logits without ``C``. Supports ``reduction='mean'`` or
     ``'sum'`` and ``ignore_index`` (default ``-100``).
@@ -84,8 +85,8 @@ def cross_entropy(
         reduction_enum = _REDUCTION_SUM
     else:
         raise ValueError("nntile cross_entropy supports reduction 'mean' or 'sum'")
-    if target.device.type not in ("cpu", "nntile"):
-        target = target.cpu()
+    if target.device.type != "nntile":
+        raise ValueError("cross_entropy expects nntile target")
     return _NntileCrossEntropy.apply(
         logits, target, reduction_enum, ignore_index
     )
@@ -517,7 +518,11 @@ def train_full_batch_step(
     axis_group_tiling: Mapping[str, int | list[int] | tuple[int, ...]] | None = None,
     print_axis_groups: bool = False,
 ) -> float:
-    """One full-batch SGD step; returns scalar loss."""
+    """One full-batch SGD step; returns scalar loss.
+
+    When the model runs on ``device='nntile'``, ``inputs`` and ``targets`` must
+    already be on nntile (use ``.to('nntile')`` explicitly).
+    """
     for param in model.parameters():
         param.grad = None
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enforces the policy that all NNTile kernel inputs must already be on `device="nntile"`. Host→nntile transfers are no longer implicit for integer/metadata tensors.

## Changes

### Kernel input validation (C++)
- **Cross-entropy**: `target` must be on nntile (was CPU or nntile)
- **Embedding**: `indices` must be on nntile (forward and backward)
- **SDPA**: optional `mask` must be on nntile

### Python
- `torch_nntile.training.cross_entropy` rejects CPU targets instead of silently calling `.cpu()`
- `GPT2Model` creates causal masks on the same device as `input_ids`
- `train_full_batch_step` docstring documents the nntile input requirement

### Examples & tests
- GPT-2 examples and tests now use explicit `.to("nntile")` for `input_ids`, `labels`, `indices`, and masks
- `test_embedding_indices_on_cpu` replaced with `test_embedding_rejects_cpu_indices`
- Added `test_cross_entropy_rejects_cpu_target`

### Docs
- README updated: embedding indices, SDPA masks, and cross-entropy labels must be on nntile

## Migration

Before:
```python
labels = torch.randint(0, vocab_size, (batch, seq))  # CPU OK
loss = cross_entropy(logits_nnt, labels)
```

After:
```python
labels = torch.randint(0, vocab_size, (batch, seq)).to("nntile")
loss = cross_entropy(logits_nnt, labels)
```

Explicit `.to("nntile")` / `.cpu()` remain the supported transfer paths.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-223282dc-9aa8-4799-a118-9a2b0e36758f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-223282dc-9aa8-4799-a118-9a2b0e36758f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

