### PR TITLE
fix(torch_nntile): axis-tiling + optional CPU torch parity

### DIFF
--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -209,7 +209,6 @@ on CPU tensors):
 ```bash
 STARPU_NCPU=4 STARPU_NCUDA=0 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
-    --runtime-mode graph \
     --epochs 5
 ```
 
@@ -218,7 +217,6 @@ Optional graph tiling and axis-group dump:
 ```bash
 STARPU_NCPU=4 STARPU_NCUDA=0 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
-    --runtime-mode graph \
     --epochs 5 \
     --print-axis-groups \
     --axis-tiling batch=15000,15000,15000,15000 \
@@ -226,7 +224,7 @@ STARPU_NCPU=4 STARPU_NCUDA=0 \
     --axis-tiling hidden=128,128
 ```
 
-**Expected tail output (CPU workers, graph mode, 5 epochs):**
+**Expected tail output (CPU workers, 5 epochs):**
 
 ```
 Loss comparison (cpu vs nntile):
@@ -248,7 +246,6 @@ Pin nntile kernels to CUDA workers (`--restrict-cuda`):
 ```bash
 STARPU_NCPU=0 STARPU_NCUDA=2 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
-    --runtime-mode graph \
     --restrict-cuda \
     --epochs 5 \
     --axis-tiling batch=15000,15000,15000,15000 \
@@ -256,7 +253,7 @@ STARPU_NCPU=0 STARPU_NCUDA=2 \
     --axis-tiling hidden=128,128
 ```
 
-**Expected tail output (CUDA workers, graph mode, 5 epochs, with tiling above):**
+**Expected tail output (CUDA workers, 5 epochs, with tiling above):**
 
 ```
 Loss comparison (cpu vs nntile):
@@ -278,15 +275,11 @@ down StarPU cleanly in a `finally` block.
 
 | Flag | Purpose |
 |------|---------|
-| `--runtime-mode graph` | Record full step, then `compile_graph()` + `run()` |
 | `--restrict-cuda` | `restrict_cuda()` — CUDA workers only |
 | `--verbose` | Verbose StarPU / NNTile context logging |
 | `--hidden-dim`, `--depth` | Model size (default 256, 5) |
-| `--axis-tiling NAME=SIZES` | Repeatable; auto-switches to graph mode |
-| `--print-axis-groups` | Dump axis groups after epoch 1 (graph mode) |
-
-`--axis-tiling` and `--print-axis-groups` switch to graph mode automatically if
-omitted from `--runtime-mode`.
+| `--axis-tiling NAME=SIZES` | Repeatable; apply named axis-group tiling before `compile_graph()` |
+| `--print-axis-groups` | Dump axis groups after epoch 1 |
 
 Integration test (downloads MNIST, 3 epochs, CPU workers):
 

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -224,6 +224,11 @@ STARPU_NCPU=4 STARPU_NCUDA=0 \
     --axis-tiling hidden=128,128
 ```
 
+Do not call ``.cpu()`` / ``clone_model_weights()`` on nntile parameters
+**before** the first ``compile_graph()`` that applies ``--axis-tiling``:
+that seals the default (untiled) layout and later tiling raises
+``layout_fingerprint mismatch``. The example compares weights only after
+training.
 **Expected tail output (CPU workers, 5 epochs):**
 
 ```
@@ -242,9 +247,12 @@ Per-epoch loss diffs at or below **~1e-6** are typical on CPU.
 ### CUDA workers only
 
 Pin nntile kernels to CUDA workers (`--restrict-cuda`). Optionally run the
-reference PyTorch path on CUDA too (`--torch-device cuda`). The example runs
-the torch CUDA path **before** ``init_context()`` so StarPU does not break
-PyTorch autograd streams:
+reference PyTorch path on CUDA too (`--torch-device cuda`). PyTorch >= 2.8
+treats a registered PrivateUse1 backend as the global accelerator, so CUDA
+``loss.backward()`` fails after ``import torch_nntile``
+([pytorch#161129](https://github.com/pytorch/pytorch/issues/161129)). The
+example therefore runs the CUDA torch reference in a **subprocess that never
+imports** ``torch_nntile``:
 
 ```bash
 STARPU_NCPU=0 STARPU_NCUDA=2 \
@@ -280,7 +288,7 @@ down StarPU cleanly in a `finally` block.
 
 | Flag | Purpose |
 |------|---------|
-| `--torch-device DEVICE` | Reference PyTorch device: `cpu` (default), `cuda`, or `cuda:N` (torch CUDA runs before StarPU init) |
+| `--torch-device DEVICE` | Reference PyTorch device: `cpu` (default), `cuda`, or `cuda:N` (CUDA uses a subprocess without PrivateUse1) |
 | `--restrict-cuda` | `restrict_cuda()` — CUDA workers only |
 | `--verbose` | Verbose StarPU / NNTile context logging |
 | `--hidden-dim`, `--depth` | Model size (default 256, 5) |

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -203,8 +203,8 @@ The script calls `init_context(ncpu=-1, ncuda=-1, …)` so those env vars apply.
 
 ### CPU workers only
 
-Use CPU StarPU workers for the nntile path (reference PyTorch path always runs
-on CPU tensors):
+Use CPU StarPU workers for the nntile path. The reference PyTorch path defaults
+to CPU (`--torch-device cpu`):
 
 ```bash
 STARPU_NCPU=4 STARPU_NCUDA=0 \
@@ -227,43 +227,46 @@ STARPU_NCPU=4 STARPU_NCUDA=0 \
 **Expected tail output (CPU workers, 5 epochs):**
 
 ```
-Loss comparison (cpu vs nntile):
-  epoch 1: cpu=2.302172  nntile=2.302172  diff=2.384e-07
-  epoch 2: cpu=2.302079  nntile=2.302080  diff=4.768e-07
-  epoch 3: cpu=2.301987  nntile=2.301987  diff=0.000e+00
-  epoch 4: cpu=2.301894  nntile=2.301895  diff=4.768e-07
-  epoch 5: cpu=2.301802  nntile=2.301802  diff=0.000e+00
+Loss comparison (torch/cpu vs nntile):
+  epoch 1: torch=2.302172  nntile=2.302172  diff=2.384e-07
+  epoch 2: torch=2.302079  nntile=2.302080  diff=4.768e-07
+  epoch 3: torch=2.301987  nntile=2.301987  diff=0.000e+00
+  epoch 4: torch=2.301894  nntile=2.301895  diff=4.768e-07
+  epoch 5: torch=2.301802  nntile=2.301802  diff=0.000e+00
 
-Final weight max |cpu - nntile| = 1.118e-08
+Final weight max |torch - nntile| = 1.118e-08
 ```
 
 Per-epoch loss diffs at or below **~1e-6** are typical on CPU.
 
 ### CUDA workers only
 
-Pin nntile kernels to CUDA workers (`--restrict-cuda`):
+Pin nntile kernels to CUDA workers (`--restrict-cuda`). Optionally run the
+reference PyTorch path on CUDA too (`--torch-device cuda`):
 
 ```bash
 STARPU_NCPU=0 STARPU_NCUDA=2 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
     --restrict-cuda \
+    --torch-device cuda \
     --epochs 5 \
     --axis-tiling batch=15000,15000,15000,15000 \
     --axis-tiling features=392,392 \
     --axis-tiling hidden=128,128
 ```
 
-**Expected tail output (CUDA workers, 5 epochs, with tiling above):**
+**Expected tail output (CUDA workers, torch CPU reference, 5 epochs, with
+tiling above):**
 
 ```
-Loss comparison (cpu vs nntile):
-  epoch 1: cpu=2.302172  nntile=2.302095  diff=7.701e-05
-  epoch 2: cpu=2.302079  nntile=2.301964  diff=1.152e-04
-  epoch 3: cpu=2.301987  nntile=2.301834  diff=1.538e-04
-  epoch 4: cpu=2.301894  nntile=2.301818  diff=7.653e-05
-  epoch 5: cpu=2.301802  nntile=2.301495  diff=3.073e-04
+Loss comparison (torch/cpu vs nntile):
+  epoch 1: torch=2.302172  nntile=2.302095  diff=7.701e-05
+  epoch 2: torch=2.302079  nntile=2.301964  diff=1.152e-04
+  epoch 3: torch=2.301987  nntile=2.301834  diff=1.538e-04
+  epoch 4: torch=2.301894  nntile=2.301818  diff=7.653e-05
+  epoch 5: torch=2.301802  nntile=2.301495  diff=3.073e-04
 
-Final weight max |cpu - nntile| = 1.583e-08
+Final weight max |torch - nntile| = 1.583e-08
 ```
 
 On CUDA, per-epoch **loss** diffs of order **1e-4** are normal (cuBLAS / TF32 /
@@ -275,6 +278,7 @@ down StarPU cleanly in a `finally` block.
 
 | Flag | Purpose |
 |------|---------|
+| `--torch-device DEVICE` | Reference PyTorch device: `cpu` (default), `cuda`, or `cuda:N` |
 | `--restrict-cuda` | `restrict_cuda()` — CUDA workers only |
 | `--verbose` | Verbose StarPU / NNTile context logging |
 | `--hidden-dim`, `--depth` | Model size (default 256, 5) |

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -203,8 +203,8 @@ The script calls `init_context(ncpu=-1, ncuda=-1, …)` so those env vars apply.
 
 ### CPU workers only
 
-Use CPU StarPU workers for the nntile path. The reference PyTorch path defaults
-to CPU (`--torch-device cpu`):
+Use CPU StarPU workers for the nntile path. The reference PyTorch path is
+always CPU:
 
 ```bash
 STARPU_NCPU=4 STARPU_NCUDA=0 \
@@ -229,6 +229,7 @@ Do not call ``.cpu()`` / ``clone_model_weights()`` on nntile parameters
 that seals the default (untiled) layout and later tiling raises
 ``layout_fingerprint mismatch``. The example compares weights only after
 training.
+
 **Expected tail output (CPU workers, 5 epochs):**
 
 ```
@@ -246,19 +247,15 @@ Per-epoch loss diffs at or below **~1e-6** are typical on CPU.
 
 ### CUDA workers only
 
-Pin nntile kernels to CUDA workers (`--restrict-cuda`). Optionally run the
-reference PyTorch path on CUDA too (`--torch-device cuda`). PyTorch >= 2.8
-treats a registered PrivateUse1 backend as the global accelerator, so CUDA
-``loss.backward()`` fails after ``import torch_nntile``
-([pytorch#161129](https://github.com/pytorch/pytorch/issues/161129)). The
-example therefore runs the CUDA torch reference in a **subprocess that never
-imports** ``torch_nntile``:
+Pin nntile kernels to CUDA workers (`--restrict-cuda`). The torch reference
+stays on CPU (a CUDA torch reference is not supported: registering PrivateUse1
+breaks CUDA autograd on PyTorch >= 2.8,
+[pytorch#161129](https://github.com/pytorch/pytorch/issues/161129)):
 
 ```bash
 STARPU_NCPU=0 STARPU_NCUDA=2 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
     --restrict-cuda \
-    --torch-device cuda \
     --epochs 5 \
     --axis-tiling batch=15000,15000,15000,15000 \
     --axis-tiling features=392,392 \
@@ -288,7 +285,6 @@ down StarPU cleanly in a `finally` block.
 
 | Flag | Purpose |
 |------|---------|
-| `--torch-device DEVICE` | Reference PyTorch device: `cpu` (default), `cuda`, or `cuda:N` (CUDA uses a subprocess without PrivateUse1) |
 | `--restrict-cuda` | `restrict_cuda()` — CUDA workers only |
 | `--verbose` | Verbose StarPU / NNTile context logging |
 | `--hidden-dim`, `--depth` | Model size (default 256, 5) |

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -242,7 +242,9 @@ Per-epoch loss diffs at or below **~1e-6** are typical on CPU.
 ### CUDA workers only
 
 Pin nntile kernels to CUDA workers (`--restrict-cuda`). Optionally run the
-reference PyTorch path on CUDA too (`--torch-device cuda`):
+reference PyTorch path on CUDA too (`--torch-device cuda`). The example runs
+the torch CUDA path **before** ``init_context()`` so StarPU does not break
+PyTorch autograd streams:
 
 ```bash
 STARPU_NCPU=0 STARPU_NCUDA=2 \
@@ -278,7 +280,7 @@ down StarPU cleanly in a `finally` block.
 
 | Flag | Purpose |
 |------|---------|
-| `--torch-device DEVICE` | Reference PyTorch device: `cpu` (default), `cuda`, or `cuda:N` |
+| `--torch-device DEVICE` | Reference PyTorch device: `cpu` (default), `cuda`, or `cuda:N` (torch CUDA runs before StarPU init) |
 | `--restrict-cuda` | `restrict_cuda()` — CUDA workers only |
 | `--verbose` | Verbose StarPU / NNTile context logging |
 | `--hidden-dim`, `--depth` | Model size (default 256, 5) |

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -306,7 +306,7 @@ down StarPU cleanly in a `finally` block.
 |------|---------|
 | `--compare-torch` | Also train CPU PyTorch reference and print loss/weight parity |
 | `--restrict-cuda` | `restrict_cuda()` — CUDA workers only |
-| `--verbose` | Verbose StarPU / NNTile context logging |
+| `--verbose` | Verbose StarPU / NNTile logging; also print weight norms under `torch.no_grad()` |
 | `--hidden-dim`, `--depth` | Model size (default 256, 5) |
 | `--axis-tiling NAME=SIZES` | Repeatable; apply named axis-group tiling before `compile_graph()` |
 | `--print-axis-groups` | Dump axis groups after epoch 1 |

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -172,8 +172,9 @@ example script provides naming.
 ## DeepReLU MNIST example
 
 [`torch_nntile/examples/train_deep_relu_mnist.py`](../torch_nntile/examples/train_deep_relu_mnist.py)
-trains `DeepReLU.mnist()` on the full MNIST training set (60k batch), comparing
-CPU PyTorch vs `device="nntile"`.
+trains `DeepReLU.mnist()` on the full MNIST training set (60k batch) on
+`device="nntile"`. By default it is nntile-only; ``--compare-torch`` adds a CPU
+PyTorch reference for loss/weight parity.
 
 Default model: **5 linear layers** (`--depth 5`), **4 hidden blocks** with output
 width `--hidden-dim 256` (784→256, then three 256→256, then 256→10 logits).
@@ -201,10 +202,12 @@ export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
 StarPU worker counts come from the environment (`STARPU_NCPU`, `STARPU_NCUDA`).
 The script calls `init_context(ncpu=-1, ncuda=-1, …)` so those env vars apply.
 
-### CPU workers only
+By default the script trains **nntile only**. Pass ``--compare-torch`` to also
+run a CPU PyTorch reference and print per-epoch loss / final weight parity.
+A CUDA torch reference is not supported (PrivateUse1 breaks CUDA autograd on
+PyTorch >= 2.8, [pytorch#161129](https://github.com/pytorch/pytorch/issues/161129)).
 
-Use CPU StarPU workers for the nntile path. The reference PyTorch path is
-always CPU:
+### Nntile-only (CPU StarPU workers)
 
 ```bash
 STARPU_NCPU=4 STARPU_NCUDA=0 \
@@ -227,8 +230,16 @@ STARPU_NCPU=4 STARPU_NCUDA=0 \
 Do not call ``.cpu()`` / ``clone_model_weights()`` on nntile parameters
 **before** the first ``compile_graph()`` that applies ``--axis-tiling``:
 that seals the default (untiled) layout and later tiling raises
-``layout_fingerprint mismatch``. The example compares weights only after
+``layout_fingerprint mismatch``. The example gathers weights only after
 training.
+
+### CPU torch parity (`--compare-torch`)
+
+```bash
+STARPU_NCPU=4 STARPU_NCUDA=0 \
+  python torch_nntile/examples/train_deep_relu_mnist.py \
+    --compare-torch --epochs 5
+```
 
 **Expected tail output (CPU workers, 5 epochs):**
 
@@ -245,14 +256,14 @@ Final weight max |torch - nntile| = 1.118e-08
 
 Per-epoch loss diffs at or below **~1e-6** are typical on CPU.
 
-### CUDA workers only
+### CUDA workers only (nntile-only or with parity)
 
-Pin nntile kernels to CUDA workers (`--restrict-cuda`). The torch reference
-stays on CPU (a CUDA torch reference is not supported: registering PrivateUse1
-breaks CUDA autograd on PyTorch >= 2.8,
-[pytorch#161129](https://github.com/pytorch/pytorch/issues/161129)):
+Pin nntile kernels to CUDA workers (`--restrict-cuda`). Use without
+``--compare-torch`` for larger tiled multi-GPU runs; add ``--compare-torch``
+when you want loss parity against the CPU reference:
 
 ```bash
+# Parallel nntile training (no torch reference)
 STARPU_NCPU=0 STARPU_NCUDA=2 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
     --restrict-cuda \
@@ -260,10 +271,18 @@ STARPU_NCPU=0 STARPU_NCUDA=2 \
     --axis-tiling batch=15000,15000,15000,15000 \
     --axis-tiling features=392,392 \
     --axis-tiling hidden=128,128
+
+# Same setup + CPU torch parity
+STARPU_NCPU=0 STARPU_NCUDA=2 \
+  python torch_nntile/examples/train_deep_relu_mnist.py \
+    --restrict-cuda --compare-torch \
+    --epochs 5 \
+    --axis-tiling batch=15000,15000,15000,15000 \
+    --axis-tiling features=392,392 \
+    --axis-tiling hidden=128,128
 ```
 
-**Expected tail output (CUDA workers, torch CPU reference, 5 epochs, with
-tiling above):**
+**Expected tail with ``--compare-torch`` (CUDA workers, 5 epochs, tiling above):**
 
 ```
 Loss comparison (torch/cpu vs nntile):
@@ -285,6 +304,7 @@ down StarPU cleanly in a `finally` block.
 
 | Flag | Purpose |
 |------|---------|
+| `--compare-torch` | Also train CPU PyTorch reference and print loss/weight parity |
 | `--restrict-cuda` | `restrict_cuda()` — CUDA workers only |
 | `--verbose` | Verbose StarPU / NNTile context logging |
 | `--hidden-dim`, `--depth` | Model size (default 256, 5) |

--- a/nntile/src/tile/ops/copy_intersection.cc
+++ b/nntile/src/tile/ops/copy_intersection.cc
@@ -83,10 +83,16 @@ void TileCopyIntersectionOp::execute(Runtime& runtime) const
             run<nntile::bf16_t>(runtime, src_offset, dst_offset, src, dst, scratch);
             break;
         case DataType::INT64:
+            run<nntile::int64_t>(
+                runtime, src_offset, dst_offset, src, dst, scratch);
+            break;
         case DataType::BOOL:
-            throw std::runtime_error("copy_intersection");
+            run<nntile::bool_t>(
+                runtime, src_offset, dst_offset, src, dst, scratch);
+            break;
         default:
-            throw std::runtime_error("copy_intersection");
+            throw std::runtime_error(
+                "Unsupported data type for tile copy_intersection");
     }
 }
 } // namespace nntile::tile

--- a/nntile/tests/tensor/ops/copy_intersection.cc
+++ b/nntile/tests/tensor/ops/copy_intersection.cc
@@ -24,6 +24,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
+#include <memory>
 #include <numeric>
 
 using namespace nntile;
@@ -221,6 +222,86 @@ TEST_CASE_METHOD(nntile::test::ContextFixture,
         runtime.execute();
         runtime.wait();
         tiled_result = runtime.get_output<std::int64_t>(dst_node);
+    }
+
+    REQUIRE(tiled_result.size() == untiled_result.size());
+    for (size_t i = 0; i < tiled_result.size(); ++i)
+    {
+        REQUIRE(tiled_result[i] == untiled_result[i]);
+    }
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "TensorGraph copy_intersection BOOL tiled matches untiled",
+    "[graph][tensor]")
+{
+    const std::vector<Index> shape{8, 3};
+    const std::vector<Index> src_off{0, 0};
+    const std::vector<Index> dst_off{0, 0};
+    const Index nelems = 24;
+
+    // Avoid std::vector<bool> (no .data()); bind via contiguous bool buffer.
+    std::unique_ptr<bool[]> src_data(new bool[static_cast<size_t>(nelems)]);
+    std::unique_ptr<bool[]> dst_data(new bool[static_cast<size_t>(nelems)]);
+    for (Index i = 0; i < nelems; ++i)
+    {
+        src_data[static_cast<size_t>(i)] = (i % 3) != 0;
+        dst_data[static_cast<size_t>(i)] = false;
+    }
+
+    std::vector<bool> untiled_result;
+    {
+        TensorGraph graph("copy_intersection_bool_untiled");
+        auto *src_node =
+            graph.data(shape, DataType::BOOL)->set_name("src");
+        auto *dst_node =
+            graph.data(shape, DataType::BOOL)->set_name("dst");
+        src_node->mark_input(true);
+        dst_node->mark_input(true);
+        dst_node->mark_output(true);
+        gt::copy_intersection(src_node, src_off, dst_node, dst_off);
+        TileGraph tile_graph = TileGraph::from_tensor_graph(graph);
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(
+            src_node, src_data.get(), static_cast<size_t>(nelems));
+        runtime.bind_data(
+            dst_node, dst_data.get(), static_cast<size_t>(nelems));
+        runtime.execute();
+        runtime.wait();
+        untiled_result = runtime.get_output<bool>(dst_node);
+    }
+
+    for (Index i = 0; i < nelems; ++i)
+    {
+        dst_data[static_cast<size_t>(i)] = false;
+    }
+
+    std::vector<bool> tiled_result;
+    {
+        TensorGraph graph("copy_intersection_bool_tiled");
+        auto *src_node =
+            graph.data(shape, DataType::BOOL)->set_name("src");
+        auto *dst_node =
+            graph.data(shape, DataType::BOOL)->set_name("dst");
+        src_node->mark_input(true);
+        dst_node->mark_input(true);
+        dst_node->mark_output(true);
+        gt::copy_intersection(src_node, src_off, dst_node, dst_off);
+        for (auto *ag : graph.axis_groups())
+        {
+            ag->set_tiling((ag->extent + 1) / 2);
+        }
+        TileGraph tile_graph = TileGraph::from_tensor_graph(graph);
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(
+            src_node, src_data.get(), static_cast<size_t>(nelems));
+        runtime.bind_data(
+            dst_node, dst_data.get(), static_cast<size_t>(nelems));
+        runtime.execute();
+        runtime.wait();
+        tiled_result = runtime.get_output<bool>(dst_node);
     }
 
     REQUIRE(tiled_result.size() == untiled_result.size());

--- a/nntile/tests/tensor/ops/copy_intersection.cc
+++ b/nntile/tests/tensor/ops/copy_intersection.cc
@@ -19,6 +19,7 @@
 #include "nntile/tensor/axis_descriptor.hh"
 #include "nntile/tile.hh"
 #include "nntile/tensor/ops/copy_intersection.hh"
+#include "nntile/tensor/ops/scatter.hh"
 #include "nntile/tensor.hh"
 
 #include <catch2/catch_test_macros.hpp>
@@ -157,5 +158,111 @@ TEST_CASE_METHOD(nntile::test::ContextFixture,
     for (size_t i = 0; i < tiled_result.size(); ++i)
     {
         REQUIRE(std::abs(tiled_result[i] - untiled_result[i]) < tol);
+    }
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "TensorGraph copy_intersection INT64 tiled matches untiled",
+    "[graph][tensor]")
+{
+    const std::vector<Index> shape{8, 3};
+    const std::vector<Index> src_off{0, 0};
+    const std::vector<Index> dst_off{0, 0};
+    const Index nelems = 24;
+
+    std::vector<std::int64_t> src_data(nelems);
+    std::vector<std::int64_t> dst_data(nelems, 0);
+    for (Index i = 0; i < nelems; ++i)
+    {
+        src_data[static_cast<size_t>(i)] = static_cast<std::int64_t>(i + 1);
+    }
+
+    std::vector<std::int64_t> untiled_result;
+    {
+        TensorGraph graph("copy_intersection_int64_untiled");
+        auto *src_node =
+            graph.data(shape, DataType::INT64)->set_name("src");
+        auto *dst_node =
+            graph.data(shape, DataType::INT64)->set_name("dst");
+        src_node->mark_input(true);
+        dst_node->mark_input(true);
+        dst_node->mark_output(true);
+        gt::copy_intersection(src_node, src_off, dst_node, dst_off);
+        TileGraph tile_graph = TileGraph::from_tensor_graph(graph);
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(src_node, src_data);
+        runtime.bind_data(dst_node, dst_data);
+        runtime.execute();
+        runtime.wait();
+        untiled_result = runtime.get_output<std::int64_t>(dst_node);
+    }
+
+    std::vector<std::int64_t> tiled_result;
+    {
+        TensorGraph graph("copy_intersection_int64_tiled");
+        auto *src_node =
+            graph.data(shape, DataType::INT64)->set_name("src");
+        auto *dst_node =
+            graph.data(shape, DataType::INT64)->set_name("dst");
+        src_node->mark_input(true);
+        dst_node->mark_input(true);
+        dst_node->mark_output(true);
+        gt::copy_intersection(src_node, src_off, dst_node, dst_off);
+        for (auto *ag : graph.axis_groups())
+        {
+            ag->set_tiling((ag->extent + 1) / 2);
+        }
+        TileGraph tile_graph = TileGraph::from_tensor_graph(graph);
+        Runtime runtime(tile_graph);
+        runtime.compile();
+        runtime.bind_data(src_node, src_data);
+        runtime.bind_data(dst_node, dst_data);
+        runtime.execute();
+        runtime.wait();
+        tiled_result = runtime.get_output<std::int64_t>(dst_node);
+    }
+
+    REQUIRE(tiled_result.size() == untiled_result.size());
+    for (size_t i = 0; i < tiled_result.size(); ++i)
+    {
+        REQUIRE(tiled_result[i] == untiled_result[i]);
+    }
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "TensorGraph scatter INT64 into tiled logical",
+    "[graph][tensor]")
+{
+    // Mirrors torch_nntile label ingress: single-tile INT64 staging scatters
+    // into a multi-tile logical (axes are not merged by scatter).
+    const std::vector<Index> shape{8};
+    std::vector<std::int64_t> src_data(8);
+    for (Index i = 0; i < 8; ++i)
+    {
+        src_data[static_cast<size_t>(i)] = static_cast<std::int64_t>(i + 1);
+    }
+
+    TensorGraph graph("scatter_int64_tiled");
+    auto *staging = graph.data(shape, DataType::INT64)->set_name("staging");
+    auto *logical = graph.data(shape, DataType::INT64)->set_name("logical");
+    staging->mark_input(true);
+    logical->mark_output(true);
+    gt::scatter(staging, logical);
+    // Tile only the logical axis group; staging stays single-tile.
+    logical->axis(0)->set_tiling(std::vector<Index>{4, 4});
+
+    TileGraph tile_graph = TileGraph::from_tensor_graph(graph);
+    Runtime runtime(tile_graph);
+    runtime.compile();
+    runtime.bind_data(staging, src_data);
+    runtime.execute();
+    runtime.wait();
+
+    const auto out = runtime.get_output<std::int64_t>(logical);
+    REQUIRE(out.size() == src_data.size());
+    for (size_t i = 0; i < out.size(); ++i)
+    {
+        REQUIRE(out[i] == src_data[i]);
     }
 }

--- a/nntile/tests/tile/ops/copy_intersection.cc
+++ b/nntile/tests/tile/ops/copy_intersection.cc
@@ -60,3 +60,76 @@ TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph copy_intersection", "[
       L.release(); }
     nntile::test::require_relative_element_error(gout, tr);
 }
+
+TEST_CASE_METHOD(
+    nntile::test::ContextFixture,
+    "TileGraph copy_intersection INT64",
+    "[graph][tile]")
+{
+    const std::vector<Index> sh = {4, 3};
+    const std::vector<Index> sc = {4};
+    const Index n = 12;
+    TileGraph g("g_int64");
+    auto *s = g.data(sh, "s", DataType::INT64);
+    auto *d = g.data(sh, "d", DataType::INT64);
+    auto *scra = g.data(sc, "scratch", DataType::INT64);
+    s->mark_input(true);
+    d->mark_input(true);
+    d->mark_output(true);
+    scra->mark_input(true);
+    // Partial overlap: copy src[1:, :] into dst[0:, :] starting at dst offset 0.
+    tg::copy_intersection(s, {1, 0}, d, {0, 0}, scra);
+    Runtime r(g);
+    r.compile();
+    std::vector<std::int64_t> sv(n), dv(n, 0);
+    for (Index i = 0; i < n; ++i)
+    {
+        sv[static_cast<size_t>(i)] = static_cast<std::int64_t>(i + 10);
+    }
+    std::vector<std::int64_t> scv(4, 0);
+    r.bind_data(s, sv);
+    r.bind_data(d, dv);
+    r.bind_data(scra, scv);
+    r.execute();
+    r.wait();
+    const auto gout = r.get_output<std::int64_t>(d);
+
+    nntile::core::Tile<nntile::int64_t> S(sh), D(sh);
+    nntile::core::Tile<nntile::int64_t> Sc(sc);
+    {
+        auto a = S.acquire(STARPU_W), b = D.acquire(STARPU_W);
+        for (Index i = 0; i < n; ++i)
+        {
+            a[i] = sv[static_cast<size_t>(i)];
+            b[i] = 0;
+        }
+        a.release();
+        b.release();
+    }
+    {
+        auto L = Sc.acquire(STARPU_W);
+        for (Index j = 0; j < 4; ++j)
+        {
+            L[j] = 0;
+        }
+        L.release();
+    }
+    nntile::core::copy_intersection<nntile::int64_t>(
+        -1, S, {1, 0}, D, {0, 0}, Sc);
+    starpu_task_wait_for_all();
+    std::vector<std::int64_t> tr(n);
+    {
+        auto L = D.acquire(STARPU_R);
+        for (Index i = 0; i < n; ++i)
+        {
+            tr[static_cast<size_t>(i)] =
+                static_cast<std::int64_t>(L[i]);
+        }
+        L.release();
+    }
+    REQUIRE(gout.size() == tr.size());
+    for (size_t i = 0; i < gout.size(); ++i)
+    {
+        REQUIRE(gout[i] == tr[i]);
+    }
+}

--- a/nntile/tests/tile/ops/copy_intersection.cc
+++ b/nntile/tests/tile/ops/copy_intersection.cc
@@ -20,6 +20,7 @@
 #include "nntile/tile.hh"
 #include "nntile/core/copy_intersection.hh"
 #include "nntile/core/tile.hh"
+#include <memory>
 using namespace nntile; using namespace nntile; namespace tg = nntile::tile;
 TEST_CASE_METHOD(nntile::test::ContextFixture, "TileGraph copy_intersection", "[graph][tile]")
 {
@@ -124,6 +125,81 @@ TEST_CASE_METHOD(
         {
             tr[static_cast<size_t>(i)] =
                 static_cast<std::int64_t>(L[i]);
+        }
+        L.release();
+    }
+    REQUIRE(gout.size() == tr.size());
+    for (size_t i = 0; i < gout.size(); ++i)
+    {
+        REQUIRE(gout[i] == tr[i]);
+    }
+}
+
+TEST_CASE_METHOD(
+    nntile::test::ContextFixture,
+    "TileGraph copy_intersection BOOL",
+    "[graph][tile]")
+{
+    const std::vector<Index> sh = {4, 3};
+    const std::vector<Index> sc = {4};
+    const Index n = 12;
+    TileGraph g("g_bool");
+    auto *s = g.data(sh, "s", DataType::BOOL);
+    auto *d = g.data(sh, "d", DataType::BOOL);
+    auto *scra = g.data(sc, "scratch", DataType::INT64);
+    s->mark_input(true);
+    d->mark_input(true);
+    d->mark_output(true);
+    scra->mark_input(true);
+    // Partial overlap: copy src[1:, :] into dst[0:, :] starting at dst offset 0.
+    tg::copy_intersection(s, {1, 0}, d, {0, 0}, scra);
+    Runtime r(g);
+    r.compile();
+    // Avoid std::vector<bool> (no .data()); bind via contiguous bool buffer.
+    std::unique_ptr<bool[]> sv(new bool[static_cast<size_t>(n)]);
+    std::unique_ptr<bool[]> dv(new bool[static_cast<size_t>(n)]);
+    for (Index i = 0; i < n; ++i)
+    {
+        sv[static_cast<size_t>(i)] = (i % 2) == 0;
+        dv[static_cast<size_t>(i)] = false;
+    }
+    std::vector<std::int64_t> scv(4, 0);
+    r.bind_data(s, sv.get(), static_cast<size_t>(n));
+    r.bind_data(d, dv.get(), static_cast<size_t>(n));
+    r.bind_data(scra, scv);
+    r.execute();
+    r.wait();
+    const auto gout = r.get_output<bool>(d);
+
+    nntile::core::Tile<nntile::bool_t> S(sh), D(sh);
+    nntile::core::Tile<nntile::int64_t> Sc(sc);
+    {
+        auto a = S.acquire(STARPU_W), b = D.acquire(STARPU_W);
+        for (Index i = 0; i < n; ++i)
+        {
+            a[i] = nntile::bool_t(sv[static_cast<size_t>(i)]);
+            b[i] = nntile::bool_t(false);
+        }
+        a.release();
+        b.release();
+    }
+    {
+        auto L = Sc.acquire(STARPU_W);
+        for (Index j = 0; j < 4; ++j)
+        {
+            L[j] = 0;
+        }
+        L.release();
+    }
+    nntile::core::copy_intersection<nntile::bool_t>(
+        -1, S, {1, 0}, D, {0, 0}, Sc);
+    starpu_task_wait_for_all();
+    std::vector<bool> tr(static_cast<size_t>(n));
+    {
+        auto L = D.acquire(STARPU_R);
+        for (Index i = 0; i < n; ++i)
+        {
+            tr[static_cast<size_t>(i)] = static_cast<bool>(L[i]);
         }
         L.release();
     }

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -361,6 +361,9 @@ STARPU_NCPU=0 STARPU_NCUDA=2 \
     --axis-tiling hidden=128,128
 ```
 
+Do not ``.cpu()`` nntile weights before the first tiled ``compile_graph()``
+(``layout_fingerprint mismatch``); the example compares weights after training.
+
 **Parity expectations:** with CPU workers, per-epoch loss diffs are ~1e-6 or
 smaller. With CUDA workers, **loss** diffs of ~1e-4 are acceptable; **weights**
 should still agree to ~1e-8. See [docs/torch_nntile.md](../docs/torch_nntile.md)
@@ -452,8 +455,9 @@ When CUDA workers are enabled (`STARPU_NCUDA > 0`), use ``--restrict-cuda`` in
 the MNIST example (or call ``restrict_cuda()``) and shut StarPU down at exit.
 The example calls ``torch_nntile.wait()`` and ``torch_nntile.shutdown_context()``
 in a ``finally`` block; ``init_context()`` also registers an ``atexit`` hook.
-With ``--torch-device cuda``, the example finishes the PyTorch CUDA reference
-**before** ``init_context()`` to avoid StarPU/PyTorch CUDA stream conflicts.
+With ``--torch-device cuda``, the example runs the PyTorch CUDA reference in a
+subprocess that never imports ``torch_nntile``, because registering PrivateUse1
+breaks CUDA autograd streams on PyTorch >= 2.8 (pytorch/pytorch#161129).
 
 ## macOS / PyTorch cpu_fallback ABI
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -350,12 +350,12 @@ export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
 # CPU StarPU workers (nntile path); reference PyTorch path is always CPU
 STARPU_NCPU=4 STARPU_NCUDA=0 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
-    --runtime-mode graph --epochs 5
+    --epochs 5
 
 # CUDA StarPU workers only
 STARPU_NCPU=0 STARPU_NCUDA=2 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
-    --runtime-mode graph --restrict-cuda --epochs 5 \
+    --restrict-cuda --epochs 5 \
     --axis-tiling batch=15000,15000,15000,15000 \
     --axis-tiling features=392,392 \
     --axis-tiling hidden=128,128

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -347,12 +347,17 @@ expected output.
 ```bash
 export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
 
-# CPU StarPU workers (nntile path); torch reference is always CPU
+# Nntile-only (CPU StarPU workers)
 STARPU_NCPU=4 STARPU_NCUDA=0 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
     --epochs 5
 
-# CUDA StarPU workers (nntile); torch reference stays on CPU
+# Optional CPU torch parity
+STARPU_NCPU=4 STARPU_NCUDA=0 \
+  python torch_nntile/examples/train_deep_relu_mnist.py \
+    --compare-torch --epochs 5
+
+# CUDA StarPU workers, nntile-only (larger tiled runs)
 STARPU_NCPU=0 STARPU_NCUDA=2 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
     --restrict-cuda --epochs 5 \
@@ -362,12 +367,11 @@ STARPU_NCPU=0 STARPU_NCUDA=2 \
 ```
 
 Do not ``.cpu()`` nntile weights before the first tiled ``compile_graph()``
-(``layout_fingerprint mismatch``); the example compares weights after training.
+(``layout_fingerprint mismatch``); the example gathers weights after training.
 
-**Parity expectations:** with CPU workers, per-epoch loss diffs are ~1e-6 or
-smaller. With CUDA workers, **loss** diffs of ~1e-4 are acceptable; **weights**
-should still agree to ~1e-8. See [docs/torch_nntile.md](../docs/torch_nntile.md)
-for sample output.
+**Parity expectations** (with ``--compare-torch``): CPU workers → loss diffs
+~1e-6; CUDA workers → loss diffs ~1e-4, weights ~1e-8. See
+[docs/torch_nntile.md](../docs/torch_nntile.md).
 
 Integration test (downloads MNIST, 3 epochs, compares losses and weights):
 
@@ -455,9 +459,10 @@ When CUDA workers are enabled (`STARPU_NCUDA > 0`), use ``--restrict-cuda`` in
 the MNIST example (or call ``restrict_cuda()``) and shut StarPU down at exit.
 The example calls ``torch_nntile.wait()`` and ``torch_nntile.shutdown_context()``
 in a ``finally`` block; ``init_context()`` also registers an ``atexit`` hook.
-The MNIST torch reference is always CPU: a CUDA torch reference is not
-supported because registering PrivateUse1 breaks CUDA autograd on PyTorch
->= 2.8 (pytorch/pytorch#161129).
+The MNIST example is nntile-only by default; ``--compare-torch`` adds a CPU
+PyTorch reference for loss/weight parity. A CUDA torch reference is not
+supported (PrivateUse1 breaks CUDA autograd on PyTorch >= 2.8,
+pytorch/pytorch#161129).
 
 ## macOS / PyTorch cpu_fallback ABI
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -347,15 +347,15 @@ expected output.
 ```bash
 export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
 
-# CPU StarPU workers (nntile path); reference PyTorch path is always CPU
+# CPU StarPU workers (nntile path); reference PyTorch path defaults to CPU
 STARPU_NCPU=4 STARPU_NCUDA=0 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
     --epochs 5
 
-# CUDA StarPU workers only
+# CUDA StarPU workers + CUDA torch reference
 STARPU_NCPU=0 STARPU_NCUDA=2 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
-    --restrict-cuda --epochs 5 \
+    --restrict-cuda --torch-device cuda --epochs 5 \
     --axis-tiling batch=15000,15000,15000,15000 \
     --axis-tiling features=392,392 \
     --axis-tiling hidden=128,128

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -452,6 +452,8 @@ When CUDA workers are enabled (`STARPU_NCUDA > 0`), use ``--restrict-cuda`` in
 the MNIST example (or call ``restrict_cuda()``) and shut StarPU down at exit.
 The example calls ``torch_nntile.wait()`` and ``torch_nntile.shutdown_context()``
 in a ``finally`` block; ``init_context()`` also registers an ``atexit`` hook.
+With ``--torch-device cuda``, the example finishes the PyTorch CUDA reference
+**before** ``init_context()`` to avoid StarPU/PyTorch CUDA stream conflicts.
 
 ## macOS / PyTorch cpu_fallback ABI
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -347,15 +347,15 @@ expected output.
 ```bash
 export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
 
-# CPU StarPU workers (nntile path); reference PyTorch path defaults to CPU
+# CPU StarPU workers (nntile path); torch reference is always CPU
 STARPU_NCPU=4 STARPU_NCUDA=0 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
     --epochs 5
 
-# CUDA StarPU workers + CUDA torch reference
+# CUDA StarPU workers (nntile); torch reference stays on CPU
 STARPU_NCPU=0 STARPU_NCUDA=2 \
   python torch_nntile/examples/train_deep_relu_mnist.py \
-    --restrict-cuda --torch-device cuda --epochs 5 \
+    --restrict-cuda --epochs 5 \
     --axis-tiling batch=15000,15000,15000,15000 \
     --axis-tiling features=392,392 \
     --axis-tiling hidden=128,128
@@ -455,9 +455,9 @@ When CUDA workers are enabled (`STARPU_NCUDA > 0`), use ``--restrict-cuda`` in
 the MNIST example (or call ``restrict_cuda()``) and shut StarPU down at exit.
 The example calls ``torch_nntile.wait()`` and ``torch_nntile.shutdown_context()``
 in a ``finally`` block; ``init_context()`` also registers an ``atexit`` hook.
-With ``--torch-device cuda``, the example runs the PyTorch CUDA reference in a
-subprocess that never imports ``torch_nntile``, because registering PrivateUse1
-breaks CUDA autograd streams on PyTorch >= 2.8 (pytorch/pytorch#161129).
+The MNIST torch reference is always CPU: a CUDA torch reference is not
+supported because registering PrivateUse1 breaks CUDA autograd on PyTorch
+>= 2.8 (pytorch/pytorch#161129).
 
 ## macOS / PyTorch cpu_fallback ABI
 

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -838,6 +838,13 @@ void sync_param_grad_aliases_locked()
         {
             continue;
         }
+        // Autograd only populates .grad on leaves. Linear/transpose backward
+        // also register activation tensors here; accessing .grad on those
+        // non-leaves triggers TensorBody warnings (pytorch#30531).
+        if (!entry.param.is_leaf())
+        {
+            continue;
+        }
         const at::Tensor grad = entry.param.grad();
         if (!grad.defined())
         {

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -707,13 +707,30 @@ void compile_graph_locked(
     const nntile::TensorGraphTiling tiling =
         nntile::TensorGraphTiling::from_tensor_graph(*g_graph);
 
-    nntile::append_tensor_graph_phase(
-        *g_graph,
-        phase,
-        tiling,
-        *g_exec->tile_graph,
-        g_exec->inc_state,
-        g_exec->tile_map);
+    try
+    {
+        nntile::append_tensor_graph_phase(
+            *g_graph,
+            phase,
+            tiling,
+            *g_exec->tile_graph,
+            g_exec->inc_state,
+            g_exec->tile_map);
+    }
+    catch (const std::runtime_error &err)
+    {
+        const std::string msg = err.what();
+        if (msg.find("layout_fingerprint mismatch") != std::string::npos)
+        {
+            throw std::runtime_error(
+                msg +
+                " Hint: avoid .cpu() / host round-trips on nntile tensors "
+                "before the first compile_graph() that applies "
+                "set_axis_group_tiling(); early host reads seal the untiled "
+                "layout into the TileGraph.");
+        }
+        throw;
+    }
 
     g_exec->pending_exec_op_begin = g_exec->executed_op_end;
     g_exec->runtime->compile();

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -14,9 +14,14 @@ Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
 ``run()`` in graph mode.
 
 The reference PyTorch path defaults to CPU; pass ``--torch-device cuda`` to
-compare against a CUDA torch reference instead. When ``cuda`` is selected, the
-torch path runs **before** ``torch_nntile.init_context()`` so StarPU CUDA
-workers do not break PyTorch autograd streams.
+compare against a CUDA torch reference instead.
+
+**Important (PyTorch >= 2.8):** registering the ``nntile`` PrivateUse1 backend
+makes ``at::getAccelerator()`` prefer it over CUDA, so CUDA ``loss.backward()``
+fails with ``opt_ready_stream && opt_parent_stream`` (pytorch/pytorch#161129).
+When ``--torch-device`` is CUDA, this script runs the torch reference in a
+**subprocess that never imports** ``torch_nntile``, then starts the nntile path
+in the parent process.
 
 Axis-group naming and tiling (optional) are configured in this script:
 
@@ -26,7 +31,7 @@ Axis-group naming and tiling (optional) are configured in this script:
   weight/grad/velocity matrix row or column of that size
 - ``classes`` — output logits dimension (10)
 
-Example with batch and hidden tiling in graph mode::
+Example with batch and hidden tiling::
 
     export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
     STARPU_NCPU=0 STARPU_NCUDA=2 \\
@@ -44,28 +49,20 @@ Run instructions and expected CPU vs CUDA output:
 
 from __future__ import annotations
 
-from typing import Callable
-
 import argparse
+import importlib.util
+import pickle
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
-
 import torch
 from torchvision import datasets
 
-# Allow running from repo root before editable install.
 _REPO = Path(__file__).resolve().parents[2]
-if str(_REPO / "torch_nntile") not in sys.path:
-    sys.path.insert(0, str(_REPO / "torch_nntile"))
-
-import torch_nntile  # noqa: E402
-from torch_nntile import _C  # noqa: E402
-from torch_nntile.models import DeepReLU  # noqa: E402
-from torch_nntile.training import (  # noqa: E402
-    clone_model_weights,
-    max_weight_delta,
-    train_full_batch_step,
-)
+_TORCH_NNTILE_ROOT = _REPO / "torch_nntile"
+if str(_TORCH_NNTILE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_TORCH_NNTILE_ROOT))
 
 
 def load_mnist_full_batch(
@@ -139,8 +136,156 @@ def resolve_torch_device(spec: str) -> torch.device:
     )
 
 
+def _load_deep_relu_class():
+    """Load DeepReLU without importing the torch_nntile package (no PrivateUse1)."""
+    path = _TORCH_NNTILE_ROOT / "torch_nntile" / "models" / "deep_relu.py"
+    spec = importlib.util.spec_from_file_location(
+        "_deep_relu_standalone",
+        path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load DeepReLU from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.DeepReLU
+
+
+def _clone_state_dict_cpu(model: torch.nn.Module) -> dict[str, torch.Tensor]:
+    return {
+        name: tensor.detach().cpu().clone()
+        for name, tensor in model.state_dict().items()
+    }
+
+
+def build_torch_model(
+    seed: int,
+    hidden_dim: int,
+    depth: int,
+    torch_device: torch.device,
+) -> torch.nn.Module:
+    """Build the reference DeepReLU on ``torch_device`` (no torch_nntile import)."""
+    deep_relu = _load_deep_relu_class()
+    torch.manual_seed(seed)
+    model = deep_relu.mnist(hidden_dim=hidden_dim, depth=depth)
+    model.init_kaiming_uniform_(seed=seed)
+    return model.to(torch_device)
+
+
+def train_torch_reference(
+    model: torch.nn.Module,
+    images: torch.Tensor,
+    labels: torch.Tensor,
+    *,
+    device: torch.device,
+    epochs: int,
+    learning_rate: float,
+) -> list[float]:
+    """Pure-PyTorch full-batch SGD (no torch_nntile / PrivateUse1)."""
+    x = images.to(device)
+    y = labels.to(device)
+    losses: list[float] = []
+    for epoch in range(epochs):
+        for param in model.parameters():
+            param.grad = None
+        logits = model(x)
+        loss = torch.nn.functional.cross_entropy(logits, y)
+        loss.backward()
+        with torch.no_grad():
+            for param in model.parameters():
+                if param.grad is not None:
+                    param.add_(param.grad, alpha=-learning_rate)
+        value = float(loss.detach().cpu().item())
+        losses.append(value)
+        print(f"[{device}] epoch {epoch + 1}/{epochs}  loss={value:.6f}")
+    return losses
+
+
+def _run_torch_reference_worker(args: argparse.Namespace) -> None:
+    """Subprocess entry: train torch reference, write pickle, never import nntile."""
+    torch_device = resolve_torch_device(args.torch_device)
+    images, labels = load_mnist_full_batch(args.data_dir)
+    model = build_torch_model(
+        seed=args.seed,
+        hidden_dim=args.hidden_dim,
+        depth=args.depth,
+        torch_device=torch_device,
+    )
+    init_weights = _clone_state_dict_cpu(model)
+    losses = train_torch_reference(
+        model,
+        images,
+        labels,
+        device=torch_device,
+        epochs=args.epochs,
+        learning_rate=args.lr,
+    )
+    final_weights = _clone_state_dict_cpu(model)
+    out_path = Path(args.torch_reference_out)
+    with out_path.open("wb") as handle:
+        pickle.dump(
+            {
+                "losses": losses,
+                "init_weights": init_weights,
+                "final_weights": final_weights,
+            },
+            handle,
+        )
+
+
+def run_torch_reference_subprocess(
+    *,
+    script_path: Path,
+    data_dir: str,
+    torch_device: torch.device,
+    epochs: int,
+    lr: float,
+    seed: int,
+    hidden_dim: int,
+    depth: int,
+) -> tuple[list[float], dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+    """Train CUDA torch reference in a child that never registers PrivateUse1."""
+    with tempfile.TemporaryDirectory(prefix="mnist_torch_ref_") as tmp:
+        out_path = Path(tmp) / "torch_reference.pkl"
+        cmd = [
+            sys.executable,
+            str(script_path),
+            "--torch-reference-worker",
+            "--torch-reference-out",
+            str(out_path),
+            "--data-dir",
+            data_dir,
+            "--torch-device",
+            str(torch_device),
+            "--epochs",
+            str(epochs),
+            "--lr",
+            str(lr),
+            "--seed",
+            str(seed),
+            "--hidden-dim",
+            str(hidden_dim),
+            "--depth",
+            str(depth),
+        ]
+        proc = subprocess.run(cmd, check=False)
+        if proc.returncode != 0:
+            raise SystemExit(
+                f"torch CUDA reference subprocess failed "
+                f"(exit {proc.returncode})"
+            )
+        with out_path.open("rb") as handle:
+            payload = pickle.load(handle)
+    return (
+        payload["losses"],
+        payload["init_weights"],
+        payload["final_weights"],
+    )
+
+
 def _name_hidden_on_matrix(tensor: torch.Tensor, hidden_dim: int) -> None:
     """Tag matrix rows/cols of size ``hidden_dim`` with the ``hidden`` axis group."""
+    import torch_nntile
+
     if tensor.ndim != 2:
         return
     out_features, in_features = tensor.shape
@@ -161,6 +306,8 @@ def name_mnist_axis_groups(
     hidden_dim: int,
 ) -> None:
     """Name axis groups for DeepReLU MNIST training on nntile."""
+    import torch_nntile
+
     torch_nntile.set_axis_group_name(x, {0: "batch", 1: "features"})
     torch_nntile.set_axis_group_name(logits, {1: "classes"})
     for module in model.modules():
@@ -175,63 +322,43 @@ def name_mnist_axis_groups(
             _name_hidden_on_matrix(velocity, hidden_dim)
 
 
-def build_torch_model(
-    seed: int,
-    hidden_dim: int,
-    depth: int,
-    torch_device: torch.device,
-) -> DeepReLU:
-    """Build the reference DeepReLU on ``torch_device`` (no StarPU yet)."""
-    torch.manual_seed(seed)
-    model = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
-    model.init_kaiming_uniform_(seed=seed)
-    return model.to(torch_device)
-
-
 def build_nntile_model(
     hidden_dim: int,
     depth: int,
     state_dict: dict[str, torch.Tensor],
-) -> DeepReLU:
+) -> torch.nn.Module:
     """Clone CPU ``state_dict`` onto ``device='nntile'`` (requires init_context)."""
+    from torch_nntile.models import DeepReLU
+
     model = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
     model.load_state_dict(state_dict)
     return model.to("nntile")
 
 
-def train_on_device(
+def train_on_nntile(
     model: torch.nn.Module,
     images: torch.Tensor,
     labels: torch.Tensor,
     *,
-    device: str | torch.device,
     epochs: int,
     learning_rate: float,
     hidden_dim: int,
     axis_group_tiling: dict[str, list[int]] | None = None,
     print_axis_groups: bool = False,
 ) -> list[float]:
-    device_label = str(device)
-    if device_label == "nntile":
-        x = images.to("nntile")
-        y = labels.to("nntile")
-        if axis_group_tiling is not None:
-            for name, tile_sizes in axis_group_tiling.items():
-                torch_nntile.set_axis_group_tiling(name, tile_sizes)
-    else:
-        torch_device = torch.device(device)
-        x = images.to(torch_device)
-        y = labels.to(torch_device)
+    import torch_nntile
+    from torch_nntile.training import train_full_batch_step
+
+    x = images.to("nntile")
+    y = labels.to("nntile")
+    if axis_group_tiling is not None:
+        for name, tile_sizes in axis_group_tiling.items():
+            torch_nntile.set_axis_group_tiling(name, tile_sizes)
+
+    def name_axis_groups(x: torch.Tensor, logits: torch.Tensor) -> None:
+        name_mnist_axis_groups(model, x, logits, hidden_dim=hidden_dim)
 
     losses: list[float] = []
-    name_axis_groups: (
-        Callable[[torch.Tensor, torch.Tensor], None] | None
-    ) = None
-    if device_label == "nntile":
-
-        def name_axis_groups(x: torch.Tensor, logits: torch.Tensor) -> None:
-            name_mnist_axis_groups(model, x, logits, hidden_dim=hidden_dim)
-
     for epoch in range(epochs):
         loss = train_full_batch_step(
             model,
@@ -239,19 +366,15 @@ def train_on_device(
             y,
             learning_rate,
             name_axis_groups=name_axis_groups,
-            axis_group_tiling=(
-                axis_group_tiling if device_label == "nntile" else None
-            ),
-            print_axis_groups=(
-                print_axis_groups and device_label == "nntile" and epoch == 0
-            ),
+            axis_group_tiling=axis_group_tiling,
+            print_axis_groups=print_axis_groups and epoch == 0,
         )
         losses.append(loss)
-        print(f"[{device_label}] epoch {epoch + 1}/{epochs}  loss={loss:.6f}")
+        print(f"[nntile] epoch {epoch + 1}/{epochs}  loss={loss:.6f}")
     return losses
 
 
-def main() -> None:
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--data-dir", default="/tmp/mnist_torch_nntile")
     parser.add_argument("--epochs", type=int, default=5)
@@ -265,8 +388,8 @@ def main() -> None:
         metavar="DEVICE",
         help=(
             "Device for the reference PyTorch path: cpu (default), cuda, "
-            "or cuda:N. When cuda, the torch path runs before StarPU "
-            "init_context to avoid CUDA stream conflicts."
+            "or cuda:N. CUDA runs in a subprocess that never imports "
+            "torch_nntile (PrivateUse1 breaks CUDA autograd streams)."
         ),
     )
     parser.add_argument(
@@ -282,7 +405,7 @@ def main() -> None:
     parser.add_argument(
         "--print-axis-groups",
         action="store_true",
-        help="Print axis groups after the first nntile training step (graph mode)",
+        help="Print axis groups after the first nntile training step",
     )
     parser.add_argument(
         "--restrict-cuda",
@@ -295,13 +418,27 @@ def main() -> None:
         help="Enable verbose StarPU / NNTile context logging",
     )
     parser.add_argument("--output-dir", default="deep_relu_mnist_runs")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--torch-reference-worker",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--torch-reference-out",
+        default="",
+        help=argparse.SUPPRESS,
+    )
+    return parser
 
-    if not _C.has_libnntile():
-        raise SystemExit(
-            "torch_nntile was built without libnntile. "
-            "Set NNTILE_BUILD_DIR and reinstall."
-        )
+
+def main() -> None:
+    args = _build_parser().parse_args()
+
+    if args.torch_reference_worker:
+        if not args.torch_reference_out:
+            raise SystemExit("--torch-reference-out is required for the worker")
+        _run_torch_reference_worker(args)
+        return
 
     torch_device = resolve_torch_device(args.torch_device)
     axis_group_tiling = build_axis_group_tiling(args.axis_tiling)
@@ -318,31 +455,55 @@ def main() -> None:
     images, labels = load_mnist_full_batch(args.data_dir)
     print(f"  images {tuple(images.shape)}, labels {tuple(labels.shape)}")
 
-    # Run the torch reference before StarPU init_context. StarPU CUDA workers
-    # share the process CUDA context and can break PyTorch autograd streams
-    # (opt_ready_stream INTERNAL ASSERT) if torch CUDA training runs after.
-    model_torch = build_torch_model(
-        seed=args.seed,
-        hidden_dim=args.hidden_dim,
-        depth=args.depth,
-        torch_device=torch_device,
-    )
-    init_weights = clone_model_weights(model_torch)
-
-    print(f"\nTraining on torch ({torch_device})...")
-    torch_losses = train_on_device(
-        model_torch,
-        images,
-        labels,
-        device=torch_device,
-        epochs=args.epochs,
-        learning_rate=args.lr,
-        hidden_dim=args.hidden_dim,
-    )
-    final_torch = clone_model_weights(model_torch)
-    del model_torch
+    # CUDA torch reference must not see PrivateUse1 (nntile) registration
+    # (pytorch/pytorch#161129). CPU torch is fine in-process after import.
     if torch_device.type == "cuda":
-        torch.cuda.synchronize()
+        print(
+            f"\nTraining on torch ({torch_device}) in a subprocess "
+            "(avoids PrivateUse1 / CUDA autograd conflict)..."
+        )
+        torch_losses, init_weights, final_torch = (
+            run_torch_reference_subprocess(
+                script_path=Path(__file__).resolve(),
+                data_dir=args.data_dir,
+                torch_device=torch_device,
+                epochs=args.epochs,
+                lr=args.lr,
+                seed=args.seed,
+                hidden_dim=args.hidden_dim,
+                depth=args.depth,
+            )
+        )
+
+    import torch_nntile
+    from torch_nntile import _C
+    from torch_nntile.training import clone_model_weights, max_weight_delta
+
+    if not _C.has_libnntile():
+        raise SystemExit(
+            "torch_nntile was built without libnntile. "
+            "Set NNTILE_BUILD_DIR and reinstall."
+        )
+
+    if torch_device.type != "cuda":
+        model_torch = build_torch_model(
+            seed=args.seed,
+            hidden_dim=args.hidden_dim,
+            depth=args.depth,
+            torch_device=torch_device,
+        )
+        init_weights = _clone_state_dict_cpu(model_torch)
+        print(f"\nTraining on torch ({torch_device})...")
+        torch_losses = train_torch_reference(
+            model_torch,
+            images,
+            labels,
+            device=torch_device,
+            epochs=args.epochs,
+            learning_rate=args.lr,
+        )
+        final_torch = _clone_state_dict_cpu(model_torch)
+        del model_torch
 
     torch_nntile.init_context(
         ncpu=-1,
@@ -360,18 +521,19 @@ def main() -> None:
             depth=args.depth,
             state_dict=init_weights,
         )
-        init_delta = max_weight_delta(init_weights, clone_model_weights(model_nnt))
+        # Do not .cpu() / clone_model_weights before the first tiled compile:
+        # that seals untiled layouts into the TileGraph and later
+        # --axis-tiling hits layout_fingerprint mismatch.
         print(
-            f"Initial weight max |torch - nntile| = {init_delta:.3e} "
-            "(expect 0)"
+            "Initial weights loaded from torch state_dict onto nntile "
+            "(host round-trip deferred until after training)"
         )
 
         print("\nTraining on nntile...")
-        nnt_losses = train_on_device(
+        nnt_losses = train_on_nntile(
             model_nnt,
             images,
             labels,
-            device="nntile",
             epochs=args.epochs,
             learning_rate=args.lr,
             hidden_dim=args.hidden_dim,

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -26,7 +26,6 @@ Example with batch and hidden tiling in graph mode::
     export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
     STARPU_NCPU=0 STARPU_NCUDA=2 \\
     python torch_nntile/examples/train_deep_relu_mnist.py \\
-        --runtime-mode graph \\
         --restrict-cuda \\
         --epochs 5 \\
         --axis-tiling batch=15000,15000,15000,15000 \\

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -3,9 +3,13 @@
 #                              (Skoltech), Russia. All rights reserved.
 #
 # @file torch_nntile/examples/train_deep_relu_mnist.py
-# Train DeepReLU on the full MNIST training set (60k batch) on torch vs nntile.
+# Train DeepReLU on the full MNIST training set (60k batch) on nntile.
 
-"""Full-batch MNIST training with DeepReLU on torch (CPU) vs device=\"nntile\".
+"""Full-batch MNIST training with DeepReLU on device=\"nntile\".
+
+By default this script trains only on nntile (useful for larger tiled /
+multi-worker runs). Pass ``--compare-torch`` to also train a CPU PyTorch
+reference and print per-epoch loss / final weight parity.
 
 Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
 (same tensor-op chain as ``NNCrossEntropyOp`` in libnntile). Logits are
@@ -13,8 +17,8 @@ Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
 ``device="nntile"``; read it with ``loss.to("cpu")`` after ``compile_graph()`` and
 ``run()`` in graph mode.
 
-The reference PyTorch path is always CPU. StarPU may still use CUDA workers
-for the nntile path via ``STARPU_NCUDA`` and ``--restrict-cuda``.
+StarPU may use CUDA workers for the nntile path via ``STARPU_NCUDA`` and
+``--restrict-cuda``.
 
 Axis-group naming and tiling (optional) are configured in this script:
 
@@ -24,7 +28,7 @@ Axis-group naming and tiling (optional) are configured in this script:
   weight/grad/velocity matrix row or column of that size
 - ``classes`` — output logits dimension (10)
 
-Example with batch and hidden tiling::
+Nntile-only (tiled CUDA workers)::
 
     export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
     STARPU_NCPU=0 STARPU_NCUDA=2 \\
@@ -35,7 +39,13 @@ Example with batch and hidden tiling::
         --axis-tiling features=392,392 \\
         --axis-tiling hidden=128,128
 
-Run instructions and expected CPU vs CUDA-worker output:
+CPU torch parity check::
+
+    STARPU_NCPU=4 STARPU_NCUDA=0 \\
+    python torch_nntile/examples/train_deep_relu_mnist.py \\
+        --compare-torch --epochs 5
+
+Run instructions and expected output:
 ``docs/torch_nntile.md`` (DeepReLU MNIST example section).
 """
 
@@ -102,12 +112,19 @@ def build_axis_group_tiling(
     return tiling
 
 
+def _clone_state_dict_cpu(model: torch.nn.Module) -> dict[str, torch.Tensor]:
+    return {
+        name: tensor.detach().cpu().clone()
+        for name, tensor in model.state_dict().items()
+    }
+
+
 def build_torch_model(
     seed: int,
     hidden_dim: int,
     depth: int,
 ) -> torch.nn.Module:
-    """Build the reference DeepReLU on CPU."""
+    """Build DeepReLU on CPU with Kaiming init."""
     from torch_nntile.models import DeepReLU
 
     torch.manual_seed(seed)
@@ -243,6 +260,14 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--hidden-dim", type=int, default=256)
     parser.add_argument("--depth", type=int, default=5)
     parser.add_argument(
+        "--compare-torch",
+        action="store_true",
+        help=(
+            "Also train a CPU PyTorch reference and print loss/weight "
+            "parity (default: nntile-only)"
+        ),
+    )
+    parser.add_argument(
         "--axis-tiling",
         action="append",
         default=[],
@@ -274,8 +299,12 @@ def _build_parser() -> argparse.ArgumentParser:
 def main() -> None:
     args = _build_parser().parse_args()
     axis_group_tiling = build_axis_group_tiling(args.axis_tiling)
+    compare_torch = bool(args.compare_torch)
 
-    print("Reference torch device: cpu")
+    if compare_torch:
+        print("Mode: nntile + CPU torch parity")
+    else:
+        print("Mode: nntile-only (pass --compare-torch for CPU parity)")
     if axis_group_tiling:
         print(f"Axis-group tiling: {axis_group_tiling}")
     print(f"DeepReLU hidden_dim={args.hidden_dim} depth={args.depth}")
@@ -297,28 +326,26 @@ def main() -> None:
             "Set NNTILE_BUILD_DIR and reinstall."
         )
 
-    model_torch = build_torch_model(
+    model_init = build_torch_model(
         seed=args.seed,
         hidden_dim=args.hidden_dim,
         depth=args.depth,
     )
-    init_weights = {
-        name: tensor.detach().cpu().clone()
-        for name, tensor in model_torch.state_dict().items()
-    }
-    print("\nTraining on torch (cpu)...")
-    torch_losses = train_torch_reference(
-        model_torch,
-        images,
-        labels,
-        epochs=args.epochs,
-        learning_rate=args.lr,
-    )
-    final_torch = {
-        name: tensor.detach().cpu().clone()
-        for name, tensor in model_torch.state_dict().items()
-    }
-    del model_torch
+    init_weights = _clone_state_dict_cpu(model_init)
+
+    torch_losses: list[float] | None = None
+    final_torch: dict[str, torch.Tensor] | None = None
+    if compare_torch:
+        print("\nTraining on torch (cpu)...")
+        torch_losses = train_torch_reference(
+            model_init,
+            images,
+            labels,
+            epochs=args.epochs,
+            learning_rate=args.lr,
+        )
+        final_torch = _clone_state_dict_cpu(model_init)
+    del model_init
 
     torch_nntile.init_context(
         ncpu=-1,
@@ -356,27 +383,36 @@ def main() -> None:
             print_axis_groups=args.print_axis_groups,
         )
 
-        torch_path = output_dir / "deep_relu_mnist_torch_cpu.pt"
         nnt_path = output_dir / "deep_relu_mnist_nntile.pt"
-        torch.save(final_torch, torch_path)
-        torch.save(clone_model_weights(model_nnt), nnt_path)
-
+        # Host gather only after training (safe with --axis-tiling).
         final_nnt = clone_model_weights(model_nnt)
-        weight_delta = max_weight_delta(final_torch, final_nnt)
+        torch.save(final_nnt, nnt_path)
+        print(f"\nSaved nntile model (CPU tensors) to {nnt_path}")
 
-        print("\nLoss comparison (torch/cpu vs nntile):")
-        for epoch, (loss_torch, loss_nnt) in enumerate(
-            zip(torch_losses, nnt_losses), start=1
-        ):
+        if compare_torch:
+            assert torch_losses is not None and final_torch is not None
+            torch_path = output_dir / "deep_relu_mnist_torch_cpu.pt"
+            torch.save(final_torch, torch_path)
+            weight_delta = max_weight_delta(final_torch, final_nnt)
+
+            print("\nLoss comparison (torch/cpu vs nntile):")
+            for epoch, (loss_torch, loss_nnt) in enumerate(
+                zip(torch_losses, nnt_losses), start=1
+            ):
+                print(
+                    f"  epoch {epoch}: torch={loss_torch:.6f}  "
+                    f"nntile={loss_nnt:.6f}  "
+                    f"diff={abs(loss_torch - loss_nnt):.3e}"
+                )
+
             print(
-                f"  epoch {epoch}: torch={loss_torch:.6f}  "
-                f"nntile={loss_nnt:.6f}  "
-                f"diff={abs(loss_torch - loss_nnt):.3e}"
+                f"\nFinal weight max |torch - nntile| = {weight_delta:.3e}"
             )
-
-        print(f"\nFinal weight max |torch - nntile| = {weight_delta:.3e}")
-        print(f"Saved torch model (CPU tensors) to {torch_path}")
-        print(f"Saved nntile model (CPU tensors) to {nnt_path}")
+            print(f"Saved torch model (CPU tensors) to {torch_path}")
+        else:
+            print("\nNntile losses:")
+            for epoch, loss_nnt in enumerate(nnt_losses, start=1):
+                print(f"  epoch {epoch}: nntile={loss_nnt:.6f}")
     finally:
         torch_nntile.wait()
         torch_nntile.shutdown_context()

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -14,7 +14,9 @@ Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
 ``run()`` in graph mode.
 
 The reference PyTorch path defaults to CPU; pass ``--torch-device cuda`` to
-compare against a CUDA torch reference instead.
+compare against a CUDA torch reference instead. When ``cuda`` is selected, the
+torch path runs **before** ``torch_nntile.init_context()`` so StarPU CUDA
+workers do not break PyTorch autograd streams.
 
 Axis-group naming and tiling (optional) are configured in this script:
 
@@ -173,21 +175,28 @@ def name_mnist_axis_groups(
             _name_hidden_on_matrix(velocity, hidden_dim)
 
 
-def build_models(
+def build_torch_model(
     seed: int,
     hidden_dim: int,
     depth: int,
     torch_device: torch.device,
-) -> tuple[DeepReLU, DeepReLU]:
+) -> DeepReLU:
+    """Build the reference DeepReLU on ``torch_device`` (no StarPU yet)."""
     torch.manual_seed(seed)
-    model_torch = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
-    model_torch.init_kaiming_uniform_(seed=seed)
+    model = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
+    model.init_kaiming_uniform_(seed=seed)
+    return model.to(torch_device)
 
-    model_nnt = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
-    model_nnt.load_state_dict(model_torch.state_dict())
-    model_torch = model_torch.to(torch_device)
-    model_nnt = model_nnt.to("nntile")
-    return model_torch, model_nnt
+
+def build_nntile_model(
+    hidden_dim: int,
+    depth: int,
+    state_dict: dict[str, torch.Tensor],
+) -> DeepReLU:
+    """Clone CPU ``state_dict`` onto ``device='nntile'`` (requires init_context)."""
+    model = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
+    model.load_state_dict(state_dict)
+    return model.to("nntile")
 
 
 def train_on_device(
@@ -256,7 +265,8 @@ def main() -> None:
         metavar="DEVICE",
         help=(
             "Device for the reference PyTorch path: cpu (default), cuda, "
-            "or cuda:N"
+            "or cuda:N. When cuda, the torch path runs before StarPU "
+            "init_context to avoid CUDA stream conflicts."
         ),
     )
     parser.add_argument(
@@ -296,6 +306,44 @@ def main() -> None:
     torch_device = resolve_torch_device(args.torch_device)
     axis_group_tiling = build_axis_group_tiling(args.axis_tiling)
 
+    print(f"Reference torch device: {torch_device}")
+    if axis_group_tiling:
+        print(f"Axis-group tiling: {axis_group_tiling}")
+    print(f"DeepReLU hidden_dim={args.hidden_dim} depth={args.depth}")
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print("Loading MNIST training set (60 000 images, single batch)...")
+    images, labels = load_mnist_full_batch(args.data_dir)
+    print(f"  images {tuple(images.shape)}, labels {tuple(labels.shape)}")
+
+    # Run the torch reference before StarPU init_context. StarPU CUDA workers
+    # share the process CUDA context and can break PyTorch autograd streams
+    # (opt_ready_stream INTERNAL ASSERT) if torch CUDA training runs after.
+    model_torch = build_torch_model(
+        seed=args.seed,
+        hidden_dim=args.hidden_dim,
+        depth=args.depth,
+        torch_device=torch_device,
+    )
+    init_weights = clone_model_weights(model_torch)
+
+    print(f"\nTraining on torch ({torch_device})...")
+    torch_losses = train_on_device(
+        model_torch,
+        images,
+        labels,
+        device=torch_device,
+        epochs=args.epochs,
+        learning_rate=args.lr,
+        hidden_dim=args.hidden_dim,
+    )
+    final_torch = clone_model_weights(model_torch)
+    del model_torch
+    if torch_device.type == "cuda":
+        torch.cuda.synchronize()
+
     torch_nntile.init_context(
         ncpu=-1,
         ncuda=-1,
@@ -304,46 +352,18 @@ def main() -> None:
     )
     if args.restrict_cuda:
         torch_nntile.restrict_cuda()
+        print("Worker placement: CUDA only (restrict_cuda)")
 
     try:
-        print(f"Reference torch device: {torch_device}")
-        if args.restrict_cuda:
-            print("Worker placement: CUDA only (restrict_cuda)")
-        if axis_group_tiling:
-            print(f"Axis-group tiling: {axis_group_tiling}")
-        print(f"DeepReLU hidden_dim={args.hidden_dim} depth={args.depth}")
-
-        output_dir = Path(args.output_dir)
-        output_dir.mkdir(parents=True, exist_ok=True)
-
-        print("Loading MNIST training set (60 000 images, single batch)...")
-        images, labels = load_mnist_full_batch(args.data_dir)
-        print(f"  images {tuple(images.shape)}, labels {tuple(labels.shape)}")
-
-        model_torch, model_nnt = build_models(
-            seed=args.seed,
+        model_nnt = build_nntile_model(
             hidden_dim=args.hidden_dim,
             depth=args.depth,
-            torch_device=torch_device,
+            state_dict=init_weights,
         )
-
-        init_torch = clone_model_weights(model_torch)
-        init_nnt = clone_model_weights(model_nnt)
-        init_delta = max_weight_delta(init_torch, init_nnt)
+        init_delta = max_weight_delta(init_weights, clone_model_weights(model_nnt))
         print(
             f"Initial weight max |torch - nntile| = {init_delta:.3e} "
             "(expect 0)"
-        )
-
-        print(f"\nTraining on torch ({torch_device})...")
-        torch_losses = train_on_device(
-            model_torch,
-            images,
-            labels,
-            device=torch_device,
-            epochs=args.epochs,
-            learning_rate=args.lr,
-            hidden_dim=args.hidden_dim,
         )
 
         print("\nTraining on nntile...")
@@ -359,12 +379,13 @@ def main() -> None:
             print_axis_groups=args.print_axis_groups,
         )
 
-        torch_path = output_dir / f"deep_relu_mnist_torch_{torch_device.type}.pt"
+        torch_path = (
+            output_dir / f"deep_relu_mnist_torch_{torch_device.type}.pt"
+        )
         nnt_path = output_dir / "deep_relu_mnist_nntile.pt"
-        torch.save(clone_model_weights(model_torch), torch_path)
+        torch.save(final_torch, torch_path)
         torch.save(clone_model_weights(model_nnt), nnt_path)
 
-        final_torch = clone_model_weights(model_torch)
         final_nnt = clone_model_weights(model_nnt)
         weight_delta = max_weight_delta(final_torch, final_nnt)
 

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -3,15 +3,18 @@
 #                              (Skoltech), Russia. All rights reserved.
 #
 # @file torch_nntile/examples/train_deep_relu_mnist.py
-# Train DeepReLU on the full MNIST training set (60k batch) on CPU vs nntile.
+# Train DeepReLU on the full MNIST training set (60k batch) on torch vs nntile.
 
-"""Full-batch MNIST training with DeepReLU on CPU and device=\"nntile\".
+"""Full-batch MNIST training with DeepReLU on a torch device vs device=\"nntile\".
 
 Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
 (same tensor-op chain as ``NNCrossEntropyOp`` in libnntile). Logits are
 ``[batch, classes]`` (class dim last). The scalar loss lives on
 ``device="nntile"``; read it with ``loss.to("cpu")`` after ``compile_graph()`` and
 ``run()`` in graph mode.
+
+The reference PyTorch path defaults to CPU; pass ``--torch-device cuda`` to
+compare against a CUDA torch reference instead.
 
 Axis-group naming and tiling (optional) are configured in this script:
 
@@ -27,6 +30,7 @@ Example with batch and hidden tiling in graph mode::
     STARPU_NCPU=0 STARPU_NCUDA=2 \\
     python torch_nntile/examples/train_deep_relu_mnist.py \\
         --restrict-cuda \\
+        --torch-device cuda \\
         --epochs 5 \\
         --axis-tiling batch=15000,15000,15000,15000 \\
         --axis-tiling features=392,392 \\
@@ -110,6 +114,29 @@ def build_axis_group_tiling(
     return tiling
 
 
+def resolve_torch_device(spec: str) -> torch.device:
+    """Parse ``cpu`` / ``cuda`` / ``cuda:N`` and check availability."""
+    device = torch.device(spec)
+    if device.type == "cpu":
+        return device
+    if device.type == "cuda":
+        if not torch.cuda.is_available():
+            raise SystemExit(
+                f"--torch-device {spec!r} requested but torch.cuda is "
+                "not available"
+            )
+        index = 0 if device.index is None else device.index
+        if index >= torch.cuda.device_count():
+            raise SystemExit(
+                f"--torch-device {spec!r} is out of range "
+                f"(torch.cuda.device_count()={torch.cuda.device_count()})"
+            )
+        return torch.device("cuda", index)
+    raise SystemExit(
+        f"--torch-device must be cpu or cuda[:N], got {spec!r}"
+    )
+
+
 def _name_hidden_on_matrix(tensor: torch.Tensor, hidden_dim: int) -> None:
     """Tag matrix rows/cols of size ``hidden_dim`` with the ``hidden`` axis group."""
     if tensor.ndim != 2:
@@ -150,15 +177,17 @@ def build_models(
     seed: int,
     hidden_dim: int,
     depth: int,
+    torch_device: torch.device,
 ) -> tuple[DeepReLU, DeepReLU]:
     torch.manual_seed(seed)
-    model_cpu = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
-    model_cpu.init_kaiming_uniform_(seed=seed)
+    model_torch = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
+    model_torch.init_kaiming_uniform_(seed=seed)
 
     model_nnt = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
-    model_nnt.load_state_dict(model_cpu.state_dict())
+    model_nnt.load_state_dict(model_torch.state_dict())
+    model_torch = model_torch.to(torch_device)
     model_nnt = model_nnt.to("nntile")
-    return model_cpu, model_nnt
+    return model_torch, model_nnt
 
 
 def train_on_device(
@@ -166,28 +195,30 @@ def train_on_device(
     images: torch.Tensor,
     labels: torch.Tensor,
     *,
-    device: str,
+    device: str | torch.device,
     epochs: int,
     learning_rate: float,
     hidden_dim: int,
     axis_group_tiling: dict[str, list[int]] | None = None,
     print_axis_groups: bool = False,
 ) -> list[float]:
-    if device == "nntile":
+    device_label = str(device)
+    if device_label == "nntile":
         x = images.to("nntile")
         y = labels.to("nntile")
         if axis_group_tiling is not None:
             for name, tile_sizes in axis_group_tiling.items():
                 torch_nntile.set_axis_group_tiling(name, tile_sizes)
     else:
-        x = images
-        y = labels
+        torch_device = torch.device(device)
+        x = images.to(torch_device)
+        y = labels.to(torch_device)
 
     losses: list[float] = []
     name_axis_groups: (
         Callable[[torch.Tensor, torch.Tensor], None] | None
     ) = None
-    if device == "nntile":
+    if device_label == "nntile":
 
         def name_axis_groups(x: torch.Tensor, logits: torch.Tensor) -> None:
             name_mnist_axis_groups(model, x, logits, hidden_dim=hidden_dim)
@@ -199,11 +230,15 @@ def train_on_device(
             y,
             learning_rate,
             name_axis_groups=name_axis_groups,
-            axis_group_tiling=axis_group_tiling if device == "nntile" else None,
-            print_axis_groups=print_axis_groups and device == "nntile" and epoch == 0,
+            axis_group_tiling=(
+                axis_group_tiling if device_label == "nntile" else None
+            ),
+            print_axis_groups=(
+                print_axis_groups and device_label == "nntile" and epoch == 0
+            ),
         )
         losses.append(loss)
-        print(f"[{device}] epoch {epoch + 1}/{epochs}  loss={loss:.6f}")
+        print(f"[{device_label}] epoch {epoch + 1}/{epochs}  loss={loss:.6f}")
     return losses
 
 
@@ -215,6 +250,15 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--hidden-dim", type=int, default=256)
     parser.add_argument("--depth", type=int, default=5)
+    parser.add_argument(
+        "--torch-device",
+        default="cpu",
+        metavar="DEVICE",
+        help=(
+            "Device for the reference PyTorch path: cpu (default), cuda, "
+            "or cuda:N"
+        ),
+    )
     parser.add_argument(
         "--axis-tiling",
         action="append",
@@ -249,6 +293,7 @@ def main() -> None:
             "Set NNTILE_BUILD_DIR and reinstall."
         )
 
+    torch_device = resolve_torch_device(args.torch_device)
     axis_group_tiling = build_axis_group_tiling(args.axis_tiling)
 
     torch_nntile.init_context(
@@ -261,6 +306,7 @@ def main() -> None:
         torch_nntile.restrict_cuda()
 
     try:
+        print(f"Reference torch device: {torch_device}")
         if args.restrict_cuda:
             print("Worker placement: CUDA only (restrict_cuda)")
         if axis_group_tiling:
@@ -274,23 +320,27 @@ def main() -> None:
         images, labels = load_mnist_full_batch(args.data_dir)
         print(f"  images {tuple(images.shape)}, labels {tuple(labels.shape)}")
 
-        model_cpu, model_nnt = build_models(
+        model_torch, model_nnt = build_models(
             seed=args.seed,
             hidden_dim=args.hidden_dim,
             depth=args.depth,
+            torch_device=torch_device,
         )
 
-        init_cpu = clone_model_weights(model_cpu)
+        init_torch = clone_model_weights(model_torch)
         init_nnt = clone_model_weights(model_nnt)
-        init_delta = max_weight_delta(init_cpu, init_nnt)
-        print(f"Initial weight max |cpu - nntile| = {init_delta:.3e} (expect 0)")
+        init_delta = max_weight_delta(init_torch, init_nnt)
+        print(
+            f"Initial weight max |torch - nntile| = {init_delta:.3e} "
+            "(expect 0)"
+        )
 
-        print("\nTraining on CPU...")
-        cpu_losses = train_on_device(
-            model_cpu,
+        print(f"\nTraining on torch ({torch_device})...")
+        torch_losses = train_on_device(
+            model_torch,
             images,
             labels,
-            device="cpu",
+            device=torch_device,
             epochs=args.epochs,
             learning_rate=args.lr,
             hidden_dim=args.hidden_dim,
@@ -309,26 +359,27 @@ def main() -> None:
             print_axis_groups=args.print_axis_groups,
         )
 
-        cpu_path = output_dir / "deep_relu_mnist_cpu.pt"
+        torch_path = output_dir / f"deep_relu_mnist_torch_{torch_device.type}.pt"
         nnt_path = output_dir / "deep_relu_mnist_nntile.pt"
-        torch.save(model_cpu.state_dict(), cpu_path)
+        torch.save(clone_model_weights(model_torch), torch_path)
         torch.save(clone_model_weights(model_nnt), nnt_path)
 
-        final_cpu = clone_model_weights(model_cpu)
+        final_torch = clone_model_weights(model_torch)
         final_nnt = clone_model_weights(model_nnt)
-        weight_delta = max_weight_delta(final_cpu, final_nnt)
+        weight_delta = max_weight_delta(final_torch, final_nnt)
 
-        print("\nLoss comparison (cpu vs nntile):")
-        for epoch, (loss_cpu, loss_nnt) in enumerate(
-            zip(cpu_losses, nnt_losses), start=1
+        print(f"\nLoss comparison (torch/{torch_device} vs nntile):")
+        for epoch, (loss_torch, loss_nnt) in enumerate(
+            zip(torch_losses, nnt_losses), start=1
         ):
             print(
-                f"  epoch {epoch}: cpu={loss_cpu:.6f}  nntile={loss_nnt:.6f}  "
-                f"diff={abs(loss_cpu - loss_nnt):.3e}"
+                f"  epoch {epoch}: torch={loss_torch:.6f}  "
+                f"nntile={loss_nnt:.6f}  "
+                f"diff={abs(loss_torch - loss_nnt):.3e}"
             )
 
-        print(f"\nFinal weight max |cpu - nntile| = {weight_delta:.3e}")
-        print(f"Saved CPU model to {cpu_path}")
+        print(f"\nFinal weight max |torch - nntile| = {weight_delta:.3e}")
+        print(f"Saved torch model (CPU tensors) to {torch_path}")
         print(f"Saved nntile model (CPU tensors) to {nnt_path}")
     finally:
         torch_nntile.wait()

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -5,7 +5,7 @@
 # @file torch_nntile/examples/train_deep_relu_mnist.py
 # Train DeepReLU on the full MNIST training set (60k batch) on torch vs nntile.
 
-"""Full-batch MNIST training with DeepReLU on a torch device vs device=\"nntile\".
+"""Full-batch MNIST training with DeepReLU on torch (CPU) vs device=\"nntile\".
 
 Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
 (same tensor-op chain as ``NNCrossEntropyOp`` in libnntile). Logits are
@@ -13,15 +13,8 @@ Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
 ``device="nntile"``; read it with ``loss.to("cpu")`` after ``compile_graph()`` and
 ``run()`` in graph mode.
 
-The reference PyTorch path defaults to CPU; pass ``--torch-device cuda`` to
-compare against a CUDA torch reference instead.
-
-**Important (PyTorch >= 2.8):** registering the ``nntile`` PrivateUse1 backend
-makes ``at::getAccelerator()`` prefer it over CUDA, so CUDA ``loss.backward()``
-fails with ``opt_ready_stream && opt_parent_stream`` (pytorch/pytorch#161129).
-When ``--torch-device`` is CUDA, this script runs the torch reference in a
-**subprocess that never imports** ``torch_nntile``, then starts the nntile path
-in the parent process.
+The reference PyTorch path is always CPU. StarPU may still use CUDA workers
+for the nntile path via ``STARPU_NCUDA`` and ``--restrict-cuda``.
 
 Axis-group naming and tiling (optional) are configured in this script:
 
@@ -37,25 +30,21 @@ Example with batch and hidden tiling::
     STARPU_NCPU=0 STARPU_NCUDA=2 \\
     python torch_nntile/examples/train_deep_relu_mnist.py \\
         --restrict-cuda \\
-        --torch-device cuda \\
         --epochs 5 \\
         --axis-tiling batch=15000,15000,15000,15000 \\
         --axis-tiling features=392,392 \\
         --axis-tiling hidden=128,128
 
-Run instructions and expected CPU vs CUDA output:
+Run instructions and expected CPU vs CUDA-worker output:
 ``docs/torch_nntile.md`` (DeepReLU MNIST example section).
 """
 
 from __future__ import annotations
 
 import argparse
-import importlib.util
-import pickle
-import subprocess
 import sys
-import tempfile
 from pathlib import Path
+
 import torch
 from torchvision import datasets
 
@@ -113,62 +102,18 @@ def build_axis_group_tiling(
     return tiling
 
 
-def resolve_torch_device(spec: str) -> torch.device:
-    """Parse ``cpu`` / ``cuda`` / ``cuda:N`` and check availability."""
-    device = torch.device(spec)
-    if device.type == "cpu":
-        return device
-    if device.type == "cuda":
-        if not torch.cuda.is_available():
-            raise SystemExit(
-                f"--torch-device {spec!r} requested but torch.cuda is "
-                "not available"
-            )
-        index = 0 if device.index is None else device.index
-        if index >= torch.cuda.device_count():
-            raise SystemExit(
-                f"--torch-device {spec!r} is out of range "
-                f"(torch.cuda.device_count()={torch.cuda.device_count()})"
-            )
-        return torch.device("cuda", index)
-    raise SystemExit(
-        f"--torch-device must be cpu or cuda[:N], got {spec!r}"
-    )
-
-
-def _load_deep_relu_class():
-    """Load DeepReLU without importing the torch_nntile package (no PrivateUse1)."""
-    path = _TORCH_NNTILE_ROOT / "torch_nntile" / "models" / "deep_relu.py"
-    spec = importlib.util.spec_from_file_location(
-        "_deep_relu_standalone",
-        path,
-    )
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"cannot load DeepReLU from {path}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module.DeepReLU
-
-
-def _clone_state_dict_cpu(model: torch.nn.Module) -> dict[str, torch.Tensor]:
-    return {
-        name: tensor.detach().cpu().clone()
-        for name, tensor in model.state_dict().items()
-    }
-
-
 def build_torch_model(
     seed: int,
     hidden_dim: int,
     depth: int,
-    torch_device: torch.device,
 ) -> torch.nn.Module:
-    """Build the reference DeepReLU on ``torch_device`` (no torch_nntile import)."""
-    deep_relu = _load_deep_relu_class()
+    """Build the reference DeepReLU on CPU."""
+    from torch_nntile.models import DeepReLU
+
     torch.manual_seed(seed)
-    model = deep_relu.mnist(hidden_dim=hidden_dim, depth=depth)
+    model = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
     model.init_kaiming_uniform_(seed=seed)
-    return model.to(torch_device)
+    return model
 
 
 def train_torch_reference(
@@ -176,110 +121,25 @@ def train_torch_reference(
     images: torch.Tensor,
     labels: torch.Tensor,
     *,
-    device: torch.device,
     epochs: int,
     learning_rate: float,
 ) -> list[float]:
-    """Pure-PyTorch full-batch SGD (no torch_nntile / PrivateUse1)."""
-    x = images.to(device)
-    y = labels.to(device)
+    """Pure-PyTorch full-batch SGD on CPU."""
     losses: list[float] = []
     for epoch in range(epochs):
         for param in model.parameters():
             param.grad = None
-        logits = model(x)
-        loss = torch.nn.functional.cross_entropy(logits, y)
+        logits = model(images)
+        loss = torch.nn.functional.cross_entropy(logits, labels)
         loss.backward()
         with torch.no_grad():
             for param in model.parameters():
                 if param.grad is not None:
                     param.add_(param.grad, alpha=-learning_rate)
-        value = float(loss.detach().cpu().item())
+        value = float(loss.detach().item())
         losses.append(value)
-        print(f"[{device}] epoch {epoch + 1}/{epochs}  loss={value:.6f}")
+        print(f"[cpu] epoch {epoch + 1}/{epochs}  loss={value:.6f}")
     return losses
-
-
-def _run_torch_reference_worker(args: argparse.Namespace) -> None:
-    """Subprocess entry: train torch reference, write pickle, never import nntile."""
-    torch_device = resolve_torch_device(args.torch_device)
-    images, labels = load_mnist_full_batch(args.data_dir)
-    model = build_torch_model(
-        seed=args.seed,
-        hidden_dim=args.hidden_dim,
-        depth=args.depth,
-        torch_device=torch_device,
-    )
-    init_weights = _clone_state_dict_cpu(model)
-    losses = train_torch_reference(
-        model,
-        images,
-        labels,
-        device=torch_device,
-        epochs=args.epochs,
-        learning_rate=args.lr,
-    )
-    final_weights = _clone_state_dict_cpu(model)
-    out_path = Path(args.torch_reference_out)
-    with out_path.open("wb") as handle:
-        pickle.dump(
-            {
-                "losses": losses,
-                "init_weights": init_weights,
-                "final_weights": final_weights,
-            },
-            handle,
-        )
-
-
-def run_torch_reference_subprocess(
-    *,
-    script_path: Path,
-    data_dir: str,
-    torch_device: torch.device,
-    epochs: int,
-    lr: float,
-    seed: int,
-    hidden_dim: int,
-    depth: int,
-) -> tuple[list[float], dict[str, torch.Tensor], dict[str, torch.Tensor]]:
-    """Train CUDA torch reference in a child that never registers PrivateUse1."""
-    with tempfile.TemporaryDirectory(prefix="mnist_torch_ref_") as tmp:
-        out_path = Path(tmp) / "torch_reference.pkl"
-        cmd = [
-            sys.executable,
-            str(script_path),
-            "--torch-reference-worker",
-            "--torch-reference-out",
-            str(out_path),
-            "--data-dir",
-            data_dir,
-            "--torch-device",
-            str(torch_device),
-            "--epochs",
-            str(epochs),
-            "--lr",
-            str(lr),
-            "--seed",
-            str(seed),
-            "--hidden-dim",
-            str(hidden_dim),
-            "--depth",
-            str(depth),
-        ]
-        proc = subprocess.run(cmd, check=False)
-        if proc.returncode != 0:
-            raise SystemExit(
-                f"torch CUDA reference subprocess failed "
-                f"(exit {proc.returncode})"
-            )
-        with out_path.open("rb") as handle:
-            payload = pickle.load(handle)
-    return (
-        payload["losses"],
-        payload["init_weights"],
-        payload["final_weights"],
-    )
 
 
 def _name_hidden_on_matrix(tensor: torch.Tensor, hidden_dim: int) -> None:
@@ -383,16 +243,6 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--hidden-dim", type=int, default=256)
     parser.add_argument("--depth", type=int, default=5)
     parser.add_argument(
-        "--torch-device",
-        default="cpu",
-        metavar="DEVICE",
-        help=(
-            "Device for the reference PyTorch path: cpu (default), cuda, "
-            "or cuda:N. CUDA runs in a subprocess that never imports "
-            "torch_nntile (PrivateUse1 breaks CUDA autograd streams)."
-        ),
-    )
-    parser.add_argument(
         "--axis-tiling",
         action="append",
         default=[],
@@ -418,32 +268,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Enable verbose StarPU / NNTile context logging",
     )
     parser.add_argument("--output-dir", default="deep_relu_mnist_runs")
-    parser.add_argument(
-        "--torch-reference-worker",
-        action="store_true",
-        help=argparse.SUPPRESS,
-    )
-    parser.add_argument(
-        "--torch-reference-out",
-        default="",
-        help=argparse.SUPPRESS,
-    )
     return parser
 
 
 def main() -> None:
     args = _build_parser().parse_args()
-
-    if args.torch_reference_worker:
-        if not args.torch_reference_out:
-            raise SystemExit("--torch-reference-out is required for the worker")
-        _run_torch_reference_worker(args)
-        return
-
-    torch_device = resolve_torch_device(args.torch_device)
     axis_group_tiling = build_axis_group_tiling(args.axis_tiling)
 
-    print(f"Reference torch device: {torch_device}")
+    print("Reference torch device: cpu")
     if axis_group_tiling:
         print(f"Axis-group tiling: {axis_group_tiling}")
     print(f"DeepReLU hidden_dim={args.hidden_dim} depth={args.depth}")
@@ -455,26 +287,6 @@ def main() -> None:
     images, labels = load_mnist_full_batch(args.data_dir)
     print(f"  images {tuple(images.shape)}, labels {tuple(labels.shape)}")
 
-    # CUDA torch reference must not see PrivateUse1 (nntile) registration
-    # (pytorch/pytorch#161129). CPU torch is fine in-process after import.
-    if torch_device.type == "cuda":
-        print(
-            f"\nTraining on torch ({torch_device}) in a subprocess "
-            "(avoids PrivateUse1 / CUDA autograd conflict)..."
-        )
-        torch_losses, init_weights, final_torch = (
-            run_torch_reference_subprocess(
-                script_path=Path(__file__).resolve(),
-                data_dir=args.data_dir,
-                torch_device=torch_device,
-                epochs=args.epochs,
-                lr=args.lr,
-                seed=args.seed,
-                hidden_dim=args.hidden_dim,
-                depth=args.depth,
-            )
-        )
-
     import torch_nntile
     from torch_nntile import _C
     from torch_nntile.training import clone_model_weights, max_weight_delta
@@ -485,25 +297,28 @@ def main() -> None:
             "Set NNTILE_BUILD_DIR and reinstall."
         )
 
-    if torch_device.type != "cuda":
-        model_torch = build_torch_model(
-            seed=args.seed,
-            hidden_dim=args.hidden_dim,
-            depth=args.depth,
-            torch_device=torch_device,
-        )
-        init_weights = _clone_state_dict_cpu(model_torch)
-        print(f"\nTraining on torch ({torch_device})...")
-        torch_losses = train_torch_reference(
-            model_torch,
-            images,
-            labels,
-            device=torch_device,
-            epochs=args.epochs,
-            learning_rate=args.lr,
-        )
-        final_torch = _clone_state_dict_cpu(model_torch)
-        del model_torch
+    model_torch = build_torch_model(
+        seed=args.seed,
+        hidden_dim=args.hidden_dim,
+        depth=args.depth,
+    )
+    init_weights = {
+        name: tensor.detach().cpu().clone()
+        for name, tensor in model_torch.state_dict().items()
+    }
+    print("\nTraining on torch (cpu)...")
+    torch_losses = train_torch_reference(
+        model_torch,
+        images,
+        labels,
+        epochs=args.epochs,
+        learning_rate=args.lr,
+    )
+    final_torch = {
+        name: tensor.detach().cpu().clone()
+        for name, tensor in model_torch.state_dict().items()
+    }
+    del model_torch
 
     torch_nntile.init_context(
         ncpu=-1,
@@ -541,9 +356,7 @@ def main() -> None:
             print_axis_groups=args.print_axis_groups,
         )
 
-        torch_path = (
-            output_dir / f"deep_relu_mnist_torch_{torch_device.type}.pt"
-        )
+        torch_path = output_dir / "deep_relu_mnist_torch_cpu.pt"
         nnt_path = output_dir / "deep_relu_mnist_nntile.pt"
         torch.save(final_torch, torch_path)
         torch.save(clone_model_weights(model_nnt), nnt_path)
@@ -551,7 +364,7 @@ def main() -> None:
         final_nnt = clone_model_weights(model_nnt)
         weight_delta = max_weight_delta(final_torch, final_nnt)
 
-        print(f"\nLoss comparison (torch/{torch_device} vs nntile):")
+        print("\nLoss comparison (torch/cpu vs nntile):")
         for epoch, (loss_torch, loss_nnt) in enumerate(
             zip(torch_losses, nnt_losses), start=1
         ):

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -119,6 +119,21 @@ def _clone_state_dict_cpu(model: torch.nn.Module) -> dict[str, torch.Tensor]:
     }
 
 
+def print_tensor_norm(label: str, tensor: torch.Tensor) -> None:
+    """Print ``tensor.norm()`` without recording autograd (norm has no nntile backward)."""
+    with torch.no_grad():
+        print(f"{label}: {tensor.norm().detach().cpu()}")
+
+
+def print_state_dict_norms(
+    prefix: str,
+    state: dict[str, torch.Tensor],
+) -> None:
+    """Print Frobenius norms of state-dict tensors under ``torch.no_grad()``."""
+    for name, tensor in state.items():
+        print_tensor_norm(f"{prefix} {name} norm", tensor)
+
+
 def build_torch_model(
     seed: int,
     hidden_dim: int,
@@ -290,7 +305,10 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--verbose",
         action="store_true",
-        help="Enable verbose StarPU / NNTile context logging",
+        help=(
+            "Verbose StarPU / NNTile context logging, and print weight "
+            "norms under torch.no_grad()"
+        ),
     )
     parser.add_argument("--output-dir", default="deep_relu_mnist_runs")
     return parser
@@ -332,6 +350,8 @@ def main() -> None:
         depth=args.depth,
     )
     init_weights = _clone_state_dict_cpu(model_init)
+    if args.verbose:
+        print_state_dict_norms("init", init_weights)
 
     torch_losses: list[float] | None = None
     final_torch: dict[str, torch.Tensor] | None = None
@@ -345,6 +365,8 @@ def main() -> None:
             learning_rate=args.lr,
         )
         final_torch = _clone_state_dict_cpu(model_init)
+        if args.verbose:
+            print_state_dict_norms("torch/final", final_torch)
     del model_init
 
     torch_nntile.init_context(
@@ -388,6 +410,8 @@ def main() -> None:
         final_nnt = clone_model_weights(model_nnt)
         torch.save(final_nnt, nnt_path)
         print(f"\nSaved nntile model (CPU tensors) to {nnt_path}")
+        if args.verbose:
+            print_state_dict_norms("nntile/final", final_nnt)
 
         if compare_torch:
             assert torch_losses is not None and final_torch is not None

--- a/torch_nntile/tests/test_axis_group_tiling.py
+++ b/torch_nntile/tests/test_axis_group_tiling.py
@@ -176,3 +176,53 @@ def test_int64_label_ingress_with_batch_tiling():
         assert value == value  # finite
         """
     )
+
+
+def test_early_host_roundtrip_before_axis_tiling_raises():
+    """``.cpu()`` before tiling seals untiled layouts; later tiling must fail."""
+    _run_subprocess(
+        """
+        import pytest
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False
+        )
+        torch_nntile.restrict_cpu()
+        x = torch.randn(4, 8).to("nntile")
+        y = torch.randn(4, 8).to("nntile")
+        # Host round-trip compiles ingress scatter under the default
+        # (untiled) layout before axis tiling is registered.
+        _ = x.cpu()
+        torch_nntile.set_axis_group_name(x, {0: "batch"})
+        z = x + y
+        torch_nntile.set_axis_group_tiling("batch", [1, 1, 2])
+        with pytest.raises(RuntimeError, match="layout_fingerprint mismatch"):
+            torch_nntile.execute()
+        """
+    )
+
+
+def test_axis_tiling_without_early_host_roundtrip():
+    """Axis tiling works when no host read seals the graph first."""
+    _run_subprocess(
+        """
+        import torch
+        import torch_nntile
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False
+        )
+        torch_nntile.restrict_cpu()
+        x = torch.randn(4, 8).to("nntile")
+        y = torch.randn(4, 8).to("nntile")
+        torch_nntile.set_axis_group_name(x, {0: "batch"})
+        z = x + y
+        torch_nntile.set_axis_group_tiling("batch", [1, 1, 2])
+        torch_nntile.execute()
+        assert z.shape == (4, 8)
+        out = z.cpu()
+        assert out.shape == (4, 8)
+        """
+    )

--- a/torch_nntile/tests/test_axis_group_tiling.py
+++ b/torch_nntile/tests/test_axis_group_tiling.py
@@ -150,3 +150,29 @@ def test_print_axis_groups_shows_pending_tiling():
         torch_nntile.execute()
         """
     )
+
+
+def test_int64_label_ingress_with_batch_tiling():
+    """INT64 scatter into a tiled logical must work (CE labels + --axis-tiling)."""
+    _run_subprocess(
+        """
+        import torch
+        import torch_nntile
+        from torch_nntile.training import cross_entropy
+
+        torch_nntile.init_context(
+            ncpu=1, ncuda=0, verbose=0, cpu_fallback=False
+        )
+        torch_nntile.restrict_cpu()
+        logits = torch.randn(8, 4).to("nntile")
+        labels = torch.randint(0, 4, (8,), dtype=torch.long).to("nntile")
+        torch_nntile.set_axis_group_name(logits, {0: "batch"})
+        torch_nntile.set_axis_group_name(labels, {0: "batch"})
+        loss = cross_entropy(logits, labels)
+        torch_nntile.set_axis_group_tiling("batch", [4, 4])
+        torch_nntile.compile_graph()
+        torch_nntile.run()
+        value = float(loss.to("cpu").item())
+        assert value == value  # finite
+        """
+    )

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -145,11 +145,18 @@ class SGD:
         key = id(param)
         velocity = self._velocity.get(key)
         if velocity is None:
-            velocity = torch.empty(
-                list(param.shape),
-                dtype=torch.float32,
-                device="nntile",
-            )
+            if param.device.type == "nntile":
+                velocity = torch.empty(
+                    list(param.shape),
+                    dtype=torch.float32,
+                    device="nntile",
+                )
+            else:
+                velocity = torch.zeros(
+                    list(param.shape),
+                    dtype=torch.float32,
+                    device=param.device,
+                )
             self._velocity[key] = velocity
         return velocity
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `--axis-tiling` failures in `torch_nntile` for DeepReLU MNIST training, and makes the CPU torch reference optional.

### INT64 / BOOL `copy_intersection` (batch-tiled CE labels)

With batch tiling, INT64 labels scatter from single-tile staging into a multi-tile logical. TileGraph `copy_intersection` rejected INT64/BOOL even though core `copy_intersection` supports them.

**Fix:** dispatch INT64/BOOL in `nntile/src/tile/ops/copy_intersection.cc` like `copy.cc`.

**Tests:** tile + tensor INT64 (including scatter-into-tiled-logical); tile + tensor BOOL tiled-vs-untiled / core parity.

### `layout_fingerprint mismatch` (early host round-trip)

Calling `clone_model_weights(model_nnt)` / `.cpu()` **before** `--axis-tiling` sealed untiled layouts into the TileGraph.

**Fix:** defer weight gather until after training; document the constraint; clearer recorder hint; regression tests.

**Known limitation:** retile after host seal is still unsupported.

### Optional CPU torch parity

- Default: **nntile-only**; `--compare-torch` for CPU PyTorch loss/weight parity.
- Removed `--torch-device` / CUDA torch reference.

### Non-leaf `.grad` warnings

`sync_param_grad_aliases` walked every registered tensor (including activations from linear backward) and called `.grad`, which warns for non-leaves. Skip non-leaf tensors there.

### Norm diagnostics under `torch.no_grad()`

`--verbose` prints weight norms via helpers that wrap `.norm()` in `torch.no_grad()`.

## Test plan

- [x] `pytest -vv torch_nntile/tests/test_axis_group_tiling.py test_deep_relu_parity.py test_grad_accumulation.py`
- [x] `./build/nntile/tests/tile/test_copy_intersection` (FP32 + INT64 + BOOL)
- [x] `./build/nntile/tests/tensor/test_copy_intersection '*BOOL*'` / `'*INT64*'`
- [x] Repro: `train_full_batch_step` with warnings-as-errors for non-leaf `.grad` — clean
- [x] On CUDA machine (rebuild/reinstall first):

```bash
STARPU_NCPU=0 STARPU_NCUDA=3 python train_deep_relu_mnist.py \
  --restrict-cuda --compare-torch --verbose --epochs 2 \
  --axis-tiling batch=15000,15000,15000,15000 \
  --axis-tiling features=392,392 \
  --axis-tiling hidden=128,128
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7e14d61-b1e1-485b-b20e-a40251df7c72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7e14d61-b1e1-485b-b20e-a40251df7c72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

