### PR TITLE
Use torch.no_grad() for norm prints and CPU↔nntile transfers

### DIFF
--- a/torch_nntile/examples/gpt2_hf_out_of_box.py
+++ b/torch_nntile/examples/gpt2_hf_out_of_box.py
@@ -40,7 +40,8 @@ def main() -> None:
     ref = GPT2LMHeadModel(config).eval().float()
     model = GPT2LMHeadModel(config).eval().float()
     model.load_state_dict(ref.state_dict())
-    model = model.to("nntile")
+    with torch.no_grad():
+        model = model.to("nntile")
 
     for param in model.parameters():
         param.requires_grad_(True)
@@ -49,8 +50,9 @@ def main() -> None:
 
     input_ids_cpu = torch.randint(0, config.vocab_size, (2, 8))
     labels_cpu = input_ids_cpu.clone()
-    input_ids = input_ids_cpu.to("nntile")
-    labels = labels_cpu.to("nntile")
+    with torch.no_grad():
+        input_ids = input_ids_cpu.to("nntile")
+        labels = labels_cpu.to("nntile")
 
     with torch.no_grad():
         ref_logits = ref(input_ids_cpu).logits
@@ -68,18 +70,22 @@ def main() -> None:
     optimizer.step()
     torch_nntile.wait()
 
-    print(
-        "forward match:",
-        torch.allclose(logits.cpu(), ref_logits, rtol=1e-4, atol=1e-4),
-    )
-    print(
-        "loss match:",
-        torch.allclose(loss.to("cpu"), ref_loss, rtol=1e-4, atol=1e-4),
-    )
-    print(
-        "wte grad norm:",
-        model.transformer.wte.weight.grad.norm().cpu().item(),
-    )
+    with torch.no_grad():
+        print(
+            "forward match:",
+            torch.allclose(logits.cpu(), ref_logits, rtol=1e-4, atol=1e-4),
+        )
+        print(
+            "loss match:",
+            torch.allclose(loss.to("cpu"), ref_loss, rtol=1e-4, atol=1e-4),
+        )
+        wte_grad = model.transformer.wte.weight.grad
+        grad_norm = (
+            wte_grad.norm().detach().cpu().item()
+            if wte_grad is not None
+            else None
+        )
+        print("wte grad norm:", grad_norm)
 
 
 if __name__ == "__main__":

--- a/torch_nntile/examples/gpt2_minimal_forward.py
+++ b/torch_nntile/examples/gpt2_minimal_forward.py
@@ -37,10 +37,12 @@ def main() -> None:
     hf = GPT2LMHeadModel(config).eval().float()
     model = GPT2LMHead(config).eval().float()
     load_hf_into_gpt2_lm_head(model, hf)
-    model = model.to("nntile")
+    with torch.no_grad():
+        model = model.to("nntile")
 
     input_ids_cpu = torch.randint(0, config.vocab_size, (2, 8))
-    input_ids = input_ids_cpu.to("nntile")
+    with torch.no_grad():
+        input_ids = input_ids_cpu.to("nntile")
     with torch.no_grad():
         ref = hf(input_ids_cpu).logits
         out = model(input_ids).cpu()
@@ -48,15 +50,19 @@ def main() -> None:
 
     for p in model.parameters():
         p.requires_grad_(True)
-    grad_out = torch.randn_like(out).to("nntile")
+    with torch.no_grad():
+        grad_out = torch.randn_like(out).to("nntile")
     model.zero_grad(set_to_none=True)
     logits = model(input_ids)
     logits.backward(grad_out)
     wte_grad = model.transformer.wte.weight.grad
-    print(
-        "backward ok, wte grad norm:",
-        wte_grad.norm().cpu().item() if wte_grad is not None else None,
-    )
+    with torch.no_grad():
+        grad_norm = (
+            wte_grad.norm().detach().cpu().item()
+            if wte_grad is not None
+            else None
+        )
+    print("backward ok, wte grad norm:", grad_norm)
 
 
 if __name__ == "__main__":

--- a/torch_nntile/examples/simple_matmul.py
+++ b/torch_nntile/examples/simple_matmul.py
@@ -199,8 +199,9 @@ def main() -> None:
 
     a = torch.randn(size.m, size.k)
     b = torch.randn(size.k, size.n)
-    a_nnt = a.to(device="nntile")
-    b_nnt = b.to(device="nntile")
+    with torch.no_grad():
+        a_nnt = a.to(device="nntile")
+        b_nnt = b.to(device="nntile")
 
     c_nnt, t1 = run_matmul_round(
         a_nnt,
@@ -210,7 +211,8 @@ def main() -> None:
         round_idx=1,
         print_groups=args.print_axis_groups,
     )
-    c_round1 = c_nnt.cpu().clone()
+    with torch.no_grad():
+        c_round1 = c_nnt.cpu().clone()
     c_nnt, t2 = run_matmul_round(
         a_nnt,
         b_nnt,
@@ -223,16 +225,17 @@ def main() -> None:
     use_cuda = args.restrict_cuda or (
         args.ncuda != 0 and not args.restrict_cpu
     )
-    if use_cuda and torch.cuda.is_available():
-        c_ref = a.cuda() @ b.cuda()
-        c2 = c_nnt.cpu().cuda()
-        c_round1 = c_round1.cuda()
-    else:
-        c_ref = a @ b
-        c2 = c_nnt.cpu()
+    with torch.no_grad():
+        if use_cuda and torch.cuda.is_available():
+            c_ref = a.cuda() @ b.cuda()
+            c2 = c_nnt.cpu().cuda()
+            c_round1 = c_round1.cuda()
+        else:
+            c_ref = a @ b
+            c2 = c_nnt.cpu()
 
-    rel_err = torch.norm(c_ref - c2) / torch.norm(c_ref)
-    rel_err_r1 = torch.norm(c_ref - c_round1) / torch.norm(c_ref)
+        rel_err = torch.norm(c_ref - c2) / torch.norm(c_ref)
+        rel_err_r1 = torch.norm(c_ref - c_round1) / torch.norm(c_ref)
     total_time = t1 + t2
     flops = 2e-12 * repeat * 2 * size.m * size.k * size.n / total_time
     print(

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -223,8 +223,10 @@ def build_nntile_model(
     from torch_nntile.models import DeepReLU
 
     model = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
-    model.load_state_dict(state_dict)
-    return model.to("nntile")
+    with torch.no_grad():
+        model.load_state_dict(state_dict)
+        model = model.to("nntile")
+    return model
 
 
 def train_on_nntile(
@@ -241,8 +243,9 @@ def train_on_nntile(
     import torch_nntile
     from torch_nntile.training import train_full_batch_step
 
-    x = images.to("nntile")
-    y = labels.to("nntile")
+    with torch.no_grad():
+        x = images.to("nntile")
+        y = labels.to("nntile")
     if axis_group_tiling is not None:
         for name, tile_sizes in axis_group_tiling.items():
             torch_nntile.set_axis_group_tiling(name, tile_sizes)

--- a/torch_nntile/tests/conftest.py
+++ b/torch_nntile/tests/conftest.py
@@ -90,4 +90,5 @@ def nntile_cpu(tensor: torch.Tensor) -> torch.Tensor:
     ):
         torch_nntile.compile_graph()
         torch_nntile.run()
-    return tensor.cpu()
+    with torch.no_grad():
+        return tensor.cpu()

--- a/torch_nntile/tests/test_deep_relu_mnist_train.py
+++ b/torch_nntile/tests/test_deep_relu_mnist_train.py
@@ -56,8 +56,9 @@ def test_mnist_full_batch_training_matches_cpu(mnist_full_batch):
     model_cpu.init_kaiming_uniform_(seed=seed)
 
     model_nnt = DeepReLU.mnist()
-    model_nnt.load_state_dict(model_cpu.state_dict())
-    model_nnt = model_nnt.to("nntile")
+    with torch.no_grad():
+        model_nnt.load_state_dict(model_cpu.state_dict())
+        model_nnt = model_nnt.to("nntile")
 
     assert max_weight_delta(
         clone_model_weights(model_cpu),
@@ -66,8 +67,9 @@ def test_mnist_full_batch_training_matches_cpu(mnist_full_batch):
 
     cpu_losses: list[float] = []
     nnt_losses: list[float] = []
-    x_nnt = images.to("nntile")
-    y_nnt = labels.to("nntile")
+    with torch.no_grad():
+        x_nnt = images.to("nntile")
+        y_nnt = labels.to("nntile")
 
     for _ in range(epochs):
         cpu_losses.append(

--- a/torch_nntile/tests/test_deep_relu_parity.py
+++ b/torch_nntile/tests/test_deep_relu_parity.py
@@ -33,9 +33,10 @@ def test_deep_relu_forward_matches_cpu():
         y_cpu = model_cpu(x_cpu)
 
     model_nnt = DeepReLU.tiny()
-    model_nnt.load_state_dict(model_cpu.state_dict())
-    model_nnt = model_nnt.to("nntile")
-    x_nnt = x_cpu.to("nntile")
+    with torch.no_grad():
+        model_nnt.load_state_dict(model_cpu.state_dict())
+        model_nnt = model_nnt.to("nntile")
+        x_nnt = x_cpu.to("nntile")
 
     with torch.no_grad():
         y_nnt = nntile_cpu(model_nnt(x_nnt))
@@ -50,8 +51,9 @@ def test_linear_relu_layer_matches_cpu():
 
     y_cpu = torch.nn.functional.relu(x_cpu @ weight.t())
 
-    x_nnt = x_cpu.to("nntile")
-    w_nnt = weight.to("nntile")
+    with torch.no_grad():
+        x_nnt = x_cpu.to("nntile")
+        w_nnt = weight.to("nntile")
     y_nnt = nntile_cpu(
         torch.nn.functional.relu(
             torch.nn.functional.linear(x_nnt, w_nnt, None)
@@ -77,10 +79,12 @@ def test_linear_relu_layer_backward_matches_cpu():
     y_nnt = torch.nn.functional.relu(
         torch.nn.functional.linear(x_nnt, w_nnt, None)
     )
+    with torch.no_grad():
+        grad_out_nnt = grad_out.to("nntile")
     gx_nnt, gw_nnt = torch.autograd.grad(
         y_nnt,
         (x_nnt, w_nnt),
-        grad_outputs=grad_out.to("nntile"),
+        grad_outputs=grad_out_nnt,
     )
 
     assert torch.allclose(nntile_cpu(gx_nnt), x_cpu.grad, rtol=1e-4, atol=1e-4)
@@ -103,12 +107,14 @@ def test_deep_relu_backward_matches_cpu():
     grad_out_cpu = torch.ones_like(y_cpu)
 
     model_nnt = DeepReLU.tiny()
-    model_nnt.load_state_dict(model_cpu.state_dict())
-    model_nnt = model_nnt.to("nntile")
+    with torch.no_grad():
+        model_nnt.load_state_dict(model_cpu.state_dict())
+        model_nnt = model_nnt.to("nntile")
 
     x_nnt = x_cpu.detach().to("nntile").requires_grad_(True)
     y_nnt = model_nnt(x_nnt)
-    grad_out = torch.ones(y_nnt.shape, device="cpu").to("nntile")
+    with torch.no_grad():
+        grad_out = torch.ones(y_nnt.shape, device="cpu").to("nntile")
 
     params_nnt = list(model_nnt.parameters())
     gx_nnt, *grads_nnt = torch.autograd.grad(

--- a/torch_nntile/tests/test_hf_gpt2_stock_on_nntile.py
+++ b/torch_nntile/tests/test_hf_gpt2_stock_on_nntile.py
@@ -48,14 +48,16 @@ def _make_stock_models(config: GPT2Config):
     torch.manual_seed(0)
     ref = GPT2LMHeadModel(config).eval().float()
     model = GPT2LMHeadModel(config).eval().float()
-    model.load_state_dict(ref.state_dict())
-    model = model.to("nntile")
+    with torch.no_grad():
+        model.load_state_dict(ref.state_dict())
+        model = model.to("nntile")
     return ref, model
 
 
 def test_hf_gpt2_forward_matches_cpu(tiny_gpt2_config):
     ref, model = _make_stock_models(tiny_gpt2_config)
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
+    with torch.no_grad():
+        input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     with torch.no_grad():
         ref_logits = ref(nntile_cpu(input_ids)).logits
         out = model(input_ids).logits
@@ -69,7 +71,8 @@ def test_hf_gpt2_cross_entropy_backward_matches_cpu(tiny_gpt2_config):
     for param in model.parameters():
         param.requires_grad_(True)
 
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
+    with torch.no_grad():
+        input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     labels = input_ids.clone()
 
     ref.zero_grad(set_to_none=True)
@@ -99,7 +102,8 @@ def test_hf_gpt2_train_full_batch_step_nntile_inputs(tiny_gpt2_config):
     for param in model.parameters():
         param.requires_grad_(True)
 
-    input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
+    with torch.no_grad():
+        input_ids = torch.randint(0, tiny_gpt2_config.vocab_size, (2, 8)).to("nntile")
     labels = input_ids.clone()
     loss = train_full_batch_step(model, input_ids, labels, learning_rate=1e-3)
     assert loss > 0.0

--- a/torch_nntile/tools/smoke_test_wheel.py
+++ b/torch_nntile/tools/smoke_test_wheel.py
@@ -9,12 +9,14 @@ if not _C.has_libnntile():
 torch_nntile.init_context(ncpu=1, ncuda=0, verbose=0, cpu_fallback=False)
 torch_nntile.restrict_cpu()
 
-lhs = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32).to("nntile")
-rhs = torch.tensor([4.0, 5.0, 6.0], dtype=torch.float32).to("nntile")
+with torch.no_grad():
+    lhs = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32).to("nntile")
+    rhs = torch.tensor([4.0, 5.0, 6.0], dtype=torch.float32).to("nntile")
 out = lhs + rhs
 torch_nntile.compile_graph()
 torch_nntile.run()
-result = out.cpu()
+with torch.no_grad():
+    result = out.cpu()
 
 torch.testing.assert_close(
     result,

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -548,7 +548,8 @@ def train_full_batch_step(
         torch_nntile.run()
 
         torch_nntile.wait()
-        loss_cpu = loss.to("cpu")
+        with torch.no_grad():
+            loss_cpu = loss.to("cpu")
         return float(loss_cpu.item())
 
     loss = F.cross_entropy(logits, targets)
@@ -559,10 +560,11 @@ def train_full_batch_step(
 
 def clone_model_weights(model: torch.nn.Module) -> dict[str, torch.Tensor]:
     """Copy weights to CPU tensors for checkpointing."""
-    return {
-        name: tensor.detach().cpu().clone()
-        for name, tensor in model.state_dict().items()
-    }
+    with torch.no_grad():
+        return {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in model.state_dict().items()
+        }
 
 
 def max_weight_delta(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wraps `torch.no_grad()` around tensor norm prints and host/device transfers in the `torch_nntile` extension where autograd tracking is not needed. This avoids runtime errors from calling nntile's forward-only norm on tensors that still have `requires_grad=True`.

## Changes

- **MNIST example** (`train_deep_relu_mnist.py`): already had `print_tensor_norm` under `no_grad`; extended to weight upload and input/label `.to("nntile")` transfers.
- **Other examples** (`gpt2_minimal_forward.py`, `gpt2_hf_out_of_box.py`, `simple_matmul.py`): norm diagnostics, parity checks, and CPU↔nntile copies now run under `no_grad`.
- **Shared helpers** (`training.py`): `clone_model_weights()` and nntile loss `.to("cpu")` are guarded; `conftest.nntile_cpu()` copies to CPU under `no_grad`.
- **Tests**: MNIST training, DeepReLU parity, and HF GPT-2 stock tests updated for the same pattern; smoke wheel helper updated.

## Motivation

`torch.linalg.vector_norm` on `device="nntile"` is forward-only (no nntile backward). Printing norms or moving checkpoint/comparison data without `torch.no_grad()` can trigger autograd errors when tensors still require grad.

Example pattern used throughout:

```python
with torch.no_grad():
    print(f"norm_value: {x.norm().detach().cpu()}")
```

## Testing

- `python3 -m py_compile` on all modified Python files (passes).
- Full `torch_nntile` parity tests require a libnntile build (not run in this CPU-only cloud VM).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-077fa699-e230-4b5c-b4b0-4217a5a0e236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-077fa699-e230-4b5c-b4b0-4217a5a0e236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

