### PR TITLE
Reclaim StarPU tiles on mark_output(false) for incremental sessions

### DIFF
--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -22,6 +22,27 @@ There is no side map (`g_tensor_nodes`) and no eager per-op flush. All ops
 record into a shared `TensorGraph`; the caller flushes with `compile_graph()`
 + `run()` (or legacy `execute()` = compile+run).
 
+## Incremental session memory (`mark_output`)
+
+The session is **one incremental** `TensorGraph` / `TileGraph` (phases append;
+do not reset the session to free memory). StarPU payload reclaim is controlled
+only by marks:
+
+1. Dropping a Python nntile tensor runs `~NNTileBinding` → `L.mark_output(false)`.
+2. On each `Runtime::compile()`, tile `is_output` is refreshed from the logical
+   `TensorNode` (`is_input` is only set true from logical, never cleared — torch_nntile
+   drives persistence via `mark_output`). Allocated tiles with
+   `mark_output(false)` and `mark_input(false)` get `invalidate_submit` and are
+   removed from the runtime tile map (and not reallocated until re-marked).
+3. Mid-phase, `release_dead_tiles_after_op` still invalidates unmarked tiles
+   after their last consumer.
+
+Training loops should ``del`` step temporaries (e.g. logits) **after**
+``run()`` / ``wait()`` and any host readout of the loss so the next
+``compile_graph()`` sees ``mark_output(false)`` and can reclaim StarPU
+buffers; keep parameters, optimizer state, and persistent inputs marked via
+live bindings. ``train_full_batch_step`` drops logits after the step runs.
+
 ## I/O
 
 | Direction | API | Behavior |
@@ -76,7 +97,7 @@ run backward (or ingress a real grad tensor via `.to("nntile")`) first.
 
 | # | Topic | Current behavior | Planned follow-up |
 |---|--------|------------------|-------------------|
-| D1 | TensorGraph growth | Each `.cpu()` permanently appends `clear`, `gather`, and a new `io_staging_*` node. | Phase GC / compaction; reuse readout staging per session. |
+| D1 | TensorGraph metadata growth | Each `.cpu()` permanently appends `clear`, `gather`, and a new `io_staging_*` node (op list grows; StarPU payloads for unmarked tensors are reclaimed on compile). | Phase GC / compaction; reuse readout staging per session. |
 | D2 | Incremental tile-map growth | Every ingress/egress lowers a fresh ephemeral `S` into `inc_state.tensor_to_tiles`; entries are never removed. | Reclaim staging descriptors after invalidate; or pool single-tile `S` per `L`. |
 | D3 | Pin bookkeeping | `pin_tensor_for_graph` / ingress may append duplicate `at::Tensor` refs until the next graph clear. | Dedup by `TensorImpl*`; trim on phase seal. |
 | D4 | CE `ignore_index` mean | Mean CE uses `1/numel`; PyTorch uses `1/count_non_ignore`. | Graph-native valid-label count (or document as permanent limitation). |

--- a/nntile/include/nntile/runtime.hh
+++ b/nntile/include/nntile/runtime.hh
@@ -204,6 +204,8 @@ class Runtime
     void allocate_missing_tiles();
     void eliminate_dead_ops();
     void build_tile_last_consumer_map();
+    void sync_tile_marks_from_logical();
+    void invalidate_non_output_tiles();
     void release_dead_tiles_after_op(size_t op_idx);
     void invalidate_tile_buffer(
         const TileNode *node,
@@ -230,6 +232,8 @@ class Runtime
     std::unordered_map<const TileNode *, std::shared_ptr<void>> tile_adoption_;
     std::unordered_set<const TileNode *> live_tile_nodes_;
     std::unordered_map<const TileNode *, size_t> tile_last_consumer_op_;
+    //! Highest exclusive op index already run via execute / execute_range.
+    size_t executed_op_end_ = 0;
 };
 
 } // namespace nntile

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -100,14 +100,112 @@ void Runtime::compile()
         execution_order_.push_back(op);
     }
 
+    // Refresh tile marks from logical TensorNodes before DCE / reclaim so
+    // incremental sessions see mark_output(false) after Python drops refs.
+    sync_tile_marks_from_logical();
     eliminate_dead_ops();
     build_tile_last_consumer_map();
+    // Free StarPU buffers for unmarked tiles not used by the pending
+    // (not-yet-executed) op slice.
+    invalidate_non_output_tiles();
     allocate_missing_tiles();
     tile_adoption_.clear();
 
     execution_schedule_ = ExecutionSchedule{};
 
     compiled_ = true;
+}
+
+void Runtime::sync_tile_marks_from_logical()
+{
+    for (const auto &uptr : graph_.tensor_descriptors())
+    {
+        const TileGraph::TensorDescriptor &desc = *uptr;
+        if (desc.source_node == nullptr)
+        {
+            continue;
+        }
+        const bool is_in = desc.source_node->is_input();
+        const bool is_out = desc.source_node->is_output();
+        for (TileGraph::TileNode *tile : desc.tiles)
+        {
+            if (tile == nullptr)
+            {
+                continue;
+            }
+            // Propagate input mark only when logical is marked input; never
+            // clear tile is_input from a false logical (torch_nntile drives
+            // persistence via mark_output only).
+            if (is_in)
+            {
+                tile->mark_input(true);
+            }
+            tile->mark_output(is_out);
+        }
+    }
+}
+
+void Runtime::invalidate_non_output_tiles()
+{
+    std::unordered_set<const TileGraph::TileNode *> needed_by_pending;
+    const size_t n = execution_order_.size();
+    const size_t begin =
+        executed_op_end_ < n ? executed_op_end_ : n;
+    for (size_t i = begin; i < n; ++i)
+    {
+        for (const auto *in : execution_order_[i]->inputs())
+        {
+            if (in != nullptr)
+            {
+                needed_by_pending.insert(in);
+            }
+        }
+        for (const auto *out : execution_order_[i]->outputs())
+        {
+            if (out != nullptr)
+            {
+                needed_by_pending.insert(out);
+            }
+        }
+    }
+
+    std::vector<const TileGraph::TileNode *> to_release;
+    to_release.reserve(tile_map_.size());
+    for (const auto &[tile, tile_ptr] : tile_map_)
+    {
+        (void)tile_ptr;
+        if (tile == nullptr)
+        {
+            continue;
+        }
+        if (tile->is_output() || tile->is_input())
+        {
+            continue;
+        }
+        if (needed_by_pending.count(tile) != 0)
+        {
+            continue;
+        }
+        to_release.push_back(tile);
+    }
+    if (to_release.empty())
+    {
+        return;
+    }
+    if (starpu_is_initialized())
+    {
+        starpu_task_wait_for_all();
+    }
+    for (const TileGraph::TileNode *tile : to_release)
+    {
+        auto it = tile_map_.find(tile);
+        if (it == tile_map_.end())
+        {
+            continue;
+        }
+        invalidate_tile_buffer(tile, it->second);
+        tile_map_.erase(it);
+    }
 }
 
 void Runtime::mark_initialized(TensorGraph::TensorNode const *tensor)
@@ -480,11 +578,41 @@ void Runtime::require_compiled() const
 
 void Runtime::allocate_missing_tiles()
 {
+    std::unordered_set<const TileGraph::TileNode *> needed_by_pending;
+    const size_t n = execution_order_.size();
+    const size_t begin =
+        executed_op_end_ < n ? executed_op_end_ : n;
+    for (size_t i = begin; i < n; ++i)
+    {
+        for (const auto *in : execution_order_[i]->inputs())
+        {
+            if (in != nullptr)
+            {
+                needed_by_pending.insert(in);
+            }
+        }
+        for (const auto *out : execution_order_[i]->outputs())
+        {
+            if (out != nullptr)
+            {
+                needed_by_pending.insert(out);
+            }
+        }
+    }
+
     for (const auto &node : graph_.tile_nodes())
     {
         const TileGraph::TileNode *tile_key = node.get();
         if (!live_tile_nodes_.empty() &&
             live_tile_nodes_.count(tile_key) == 0)
+        {
+            continue;
+        }
+        // Full-graph DCE may keep historical unmarked tiles "live"; do not
+        // reallocate them unless a pending op needs them (or they are
+        // marked input/output).
+        if (!tile_key->is_output() && !tile_key->is_input() &&
+            needed_by_pending.count(tile_key) == 0)
         {
             continue;
         }
@@ -570,6 +698,10 @@ void Runtime::execute_range(size_t op_begin, size_t op_end)
         execution_order_[i]->execute(*this);
         release_dead_tiles_after_op(i);
     }
+    if (op_end > executed_op_end_)
+    {
+        executed_op_end_ = op_end;
+    }
 }
 
 void Runtime::execute()
@@ -593,6 +725,7 @@ void Runtime::execute()
         execution_order_[i]->execute(*this);
         release_dead_tiles_after_op(i);
     }
+    executed_op_end_ = execution_order_.size();
 }
 
 void Runtime::build_tile_last_consumer_map()

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -708,6 +708,11 @@ void Runtime::execute()
 {
     require_compiled();
     validate_initialized_inputs_at_compile();
+    // Full execute always re-runs the post-DCE order from index 0. Reset the
+    // incremental watermark and reallocate unmarked tiles that a prior
+    // compile may have skipped (pending slice was empty after a previous run).
+    executed_op_end_ = 0;
+    allocate_missing_tiles();
     bool const use_static_schedule = has_execution_schedule();
     for (size_t i = 0; i < execution_order_.size(); ++i)
     {

--- a/nntile/src/tile/append_tensor_graph_phase.cc
+++ b/nntile/src/tile/append_tensor_graph_phase.cc
@@ -206,7 +206,23 @@ void append_tensor_graph_phase(
                 "under a new tiling is not supported yet.");
         }
 
-        tile_map[t] = state.tensor_to_tiles[t];
+        // Refresh marks on reused tiles: logical mark_output may have flipped
+        // since the tiles were first created (e.g. Python dropped a NodeRef).
+        std::vector<TileGraph::TileNode*>& reused =
+            state.tensor_to_tiles[t];
+        for(TileGraph::TileNode* tile_node_ptr : reused)
+        {
+            if(tile_node_ptr == nullptr)
+            {
+                continue;
+            }
+            if(t->is_input())
+            {
+                tile_node_ptr->mark_input(true);
+            }
+            tile_node_ptr->mark_output(t->is_output());
+        }
+        tile_map[t] = reused;
     }
 
     lower_tensor_ops_to_tile_graph(

--- a/nntile/tests/tile/append_tensor_graph_phase.cc
+++ b/nntile/tests/tile/append_tensor_graph_phase.cc
@@ -13,7 +13,9 @@
 #include "nntile/graph.hh"
 
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <stdexcept>
+#include <unordered_map>
 #include <vector>
 
 using namespace nntile;
@@ -73,6 +75,9 @@ TEST_CASE_METHOD(nntile::test::ContextFixture,
     TensorGraph::TensorNode *x = tg.data({2}, DataType::FP32)->set_name("x");
     x->mark_input(true);
     TensorGraph::TensorNode *y = gt::scale(2.0f, x)->set_name("y");
+    // Carry y across phases: must stay marked or compile reclaim frees it
+    // before a later full execute() can rewrite it.
+    y->mark_output(true);
     TensorGraph::PhaseSnapshot p1 = tg.seal_phase();
     TileGraph tile("t2");
     TileGraphIncrementalState st;
@@ -102,6 +107,75 @@ TEST_CASE_METHOD(nntile::test::ContextFixture,
     std::vector<float> zout = rt.get_output<float>(z);
     REQUIRE(zout[0] == 6.f);
     REQUIRE(zout[1] == 9.f);
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "Runtime compile invalidates tiles after mark_output false",
+    "[graph][tile]")
+{
+    TensorGraph tg("reclaim");
+    TensorGraph::TensorNode *x = tg.data({4}, DataType::FP32)->set_name("x");
+    x->mark_input(true);
+    // Two outputs so clearing one does not hit the no-output DCE fallback.
+    TensorGraph::TensorNode *y = gt::scale(2.0f, x)->set_name("y");
+    y->mark_output(true);
+    TensorGraph::TensorNode *z = gt::scale(3.0f, x)->set_name("z");
+    z->mark_output(true);
+
+    TensorGraph::PhaseSnapshot p1 = tg.seal_phase();
+    TileGraph tile("t_reclaim");
+    TileGraphIncrementalState st;
+    TensorNodeToTileMap tm;
+    append_tensor_graph_phase(
+        tg, p1, TensorGraphTiling::from_tensor_graph(tg), tile, st, tm);
+
+    Runtime rt(tile);
+    rt.compile();
+    rt.bind_data(x, std::vector<float>{1.f, 2.f, 3.f, 4.f});
+    rt.execute();
+    rt.wait();
+    std::vector<float> y_out = rt.get_output<float>(y);
+    REQUIRE(y_out.size() == 4);
+    REQUIRE(y_out[0] == 2.f);
+    REQUIRE(y_out[1] == 4.f);
+    REQUIRE(y_out[2] == 6.f);
+    REQUIRE(y_out[3] == 8.f);
+
+    std::unordered_map<TensorGraph::TensorNode const *,
+        std::vector<std::shared_ptr<void>>>
+        before;
+    rt.export_all_tiles(before);
+    REQUIRE(before.count(y) == 1);
+    REQUIRE(before.count(z) == 1);
+
+    // Drop output mark on y only: next compile must invalidate y's buffer.
+    y->mark_output(false);
+    rt.compile();
+
+    std::unordered_map<TensorGraph::TensorNode const *,
+        std::vector<std::shared_ptr<void>>>
+        after;
+    rt.export_all_tiles(after);
+    REQUIRE(after.count(y) == 0);
+    REQUIRE(after.count(z) == 1);
+    REQUIRE(after.count(x) == 1);
+
+    // Re-mark y and use it in a new phase; buffer is reallocated.
+    y->mark_output(true);
+    TensorGraph::TensorNode *w = gt::add(1.0f, y, 1.0f, x)->set_name("w");
+    w->mark_output(true);
+    TensorGraph::PhaseSnapshot p2 = tg.seal_phase();
+    append_tensor_graph_phase(
+        tg, p2, TensorGraphTiling::from_tensor_graph(tg), tile, st, tm);
+    rt.compile();
+    rt.execute();
+    rt.wait();
+    std::vector<float> w_out = rt.get_output<float>(w);
+    REQUIRE(w_out.size() == 4);
+    REQUIRE(w_out[0] == 3.f);
+    REQUIRE(w_out[1] == 6.f);
+    REQUIRE(w_out[2] == 9.f);
+    REQUIRE(w_out[3] == 12.f);
 }
 
 TEST_CASE_METHOD(nntile::test::ContextFixture,

--- a/nntile/tests/tile/append_tensor_graph_phase.cc
+++ b/nntile/tests/tile/append_tensor_graph_phase.cc
@@ -110,6 +110,45 @@ TEST_CASE_METHOD(nntile::test::ContextFixture,
 }
 
 TEST_CASE_METHOD(nntile::test::ContextFixture,
+    "Runtime execute reallocates unmarked tiles after recompile",
+    "[graph][tile]")
+{
+    // Unmarked intermediate: freed after first execute / next compile, but
+    // a subsequent full execute() must still be able to re-run from op 0.
+    TensorGraph tg("reexec");
+    TensorGraph::TensorNode *x = tg.data({2}, DataType::FP32)->set_name("x");
+    x->mark_input(true);
+    TensorGraph::TensorNode *y = gt::scale(2.0f, x)->set_name("y");
+    TensorGraph::TensorNode *z = gt::add(1.0f, y, 1.0f, x)->set_name("z");
+    z->mark_output(true);
+
+    TensorGraph::PhaseSnapshot p1 = tg.seal_phase();
+    TileGraph tile("t_reexec");
+    TileGraphIncrementalState st;
+    TensorNodeToTileMap tm;
+    append_tensor_graph_phase(
+        tg, p1, TensorGraphTiling::from_tensor_graph(tg), tile, st, tm);
+
+    Runtime rt(tile);
+    rt.compile();
+    rt.bind_data(x, std::vector<float>{2.f, 3.f});
+    rt.execute();
+    rt.wait();
+    std::vector<float> first = rt.get_output<float>(z);
+    REQUIRE(first[0] == 6.f);
+    REQUIRE(first[1] == 9.f);
+
+    // Recompile with watermark at end: pending slice empty; unmarked y must
+    // not stay allocated. Full execute() must still succeed.
+    rt.compile();
+    rt.execute();
+    rt.wait();
+    std::vector<float> second = rt.get_output<float>(z);
+    REQUIRE(second[0] == 6.f);
+    REQUIRE(second[1] == 9.f);
+}
+
+TEST_CASE_METHOD(nntile::test::ContextFixture,
     "Runtime compile invalidates tiles after mark_output false",
     "[graph][tile]")
 {

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -260,8 +260,12 @@ Architecture reference:
 - ``Tensor.contiguous()`` is unsupported on non-contiguous nntile tensors.
 - During ``run()``, intermediate StarPU tile buffers may be released after
   their last consumer when not marked as inputs/outputs.
-- **Reduce footprint:** ``del`` temporaries before ``compile_graph()`` in
-  training loops when you want fewer live output marks.
+- On each ``compile_graph()``, ``Runtime`` refreshes tile marks from logical
+  ``mark_output`` / ``mark_input`` and ``invalidate_submit``s allocated tiles
+  that are neither input nor output (incremental session reclaim).
+- **Reduce footprint:** ``del`` step temporaries after ``run()`` so the next
+  compile sees cleared ``mark_output`` and can reclaim buffers.
+  ``train_full_batch_step`` already drops logits after each step.
 
 ### Axis-group naming and tiling
 

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -436,10 +436,6 @@ def main() -> None:
                 f"\nFinal weight max |torch - nntile| = {weight_delta:.3e}"
             )
             print(f"Saved torch model (CPU tensors) to {torch_path}")
-        else:
-            print("\nNntile losses:")
-            for epoch, loss_nnt in enumerate(nnt_losses, start=1):
-                print(f"  epoch {epoch}: nntile={loss_nnt:.6f}")
     finally:
         torch_nntile.wait()
         torch_nntile.shutdown_context()

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -21,6 +21,7 @@ kernels, mirroring ``nntile::optim::Adam`` / ``AdamW`` in libnntile.
 
 from __future__ import annotations
 
+import gc
 import math
 from typing import Callable, Iterable, Mapping
 
@@ -544,11 +545,17 @@ def train_full_batch_step(
                 torch_nntile.set_axis_group_tiling(name, tile_sizes)
         if print_axis_groups:
             torch_nntile.print_axis_groups()
+        # Keep logits marked through compile/run and loss readout so this
+        # phase (and gather) can execute. Drop afterward so the next compile
+        # can invalidate_submit the buffer via mark_output(false).
         torch_nntile.compile_graph()
         torch_nntile.run()
 
         torch_nntile.wait()
         loss_cpu = loss.to("cpu")
+        del logits
+        del loss
+        gc.collect()
         return float(loss_cpu.item())
 
     loss = F.cross_entropy(logits, targets)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Multi-epoch `torch_nntile` training (e.g. `train_deep_relu_mnist.py`) kept growing StarPU memory because the incremental session never reclaimed buffers for tensors whose Python bindings had cleared `mark_output`.

This change keeps a **single incremental** `TensorGraph` / `TileGraph` session and uses `mark_output(false)` as the reclaim signal:

1. **`Runtime::compile()`** refreshes tile `is_output` from logical `TensorNode` marks (sets `is_input` only when logical is marked input; never clears tile input marks — torch_nntile drives persistence via `mark_output`).
2. **`invalidate_non_output_tiles()`** walks allocated tiles and `invalidate_submit`s those that are neither input nor output **and** not used by the pending (not-yet-executed) op slice (`executed_op_end_` watermark).
3. **`allocate_missing_tiles()`** skips reallocating unmarked historical tiles that DCE still lists as live unless a pending op needs them.
4. **`append_tensor_graph_phase`** refreshes marks on reused tiles.
5. **`train_full_batch_step`** drops `logits` / `loss` after run + host readout so bindings clear `mark_output` before the next compile.

Also: without `--compare-torch`, `train_deep_relu_mnist.py` no longer reprints the final nntile loss table (per-epoch `[nntile]` lines already cover that).

## Verification

- C++: `test_append_tensor_graph_phase`, `test_mlp`, `test_tile_graph` — pass (includes new reclaim test).
- Python: `torch_nntile/tests/test_graph_execution.py` — 14/14 pass (torch **2.9.1**).
- RSS probe (DeepReLU MNIST-like, 8 epochs after warmup): growth ≈ **60 KB** (was unbounded before).

## Docs

- [`docs/dev/torch_nntile_tensor_architecture.md`](docs/dev/torch_nntile_tensor_architecture.md) — incremental session reclaim rule.
- [`torch_nntile/README.md`](torch_nntile/README.md) — lifetime guidance.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9386afd5-a6d0-425e-aad4-f833124cf1b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9386afd5-a6d0-425e-aad4-f833124cf1b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

