### PR TITLE
Fix nntile step-time growth; MNIST example uses Linear bias

### DIFF
--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -97,7 +97,7 @@ run backward (or ingress a real grad tensor via `.to("nntile")`) first.
 
 | # | Topic | Current behavior | Planned follow-up |
 |---|--------|------------------|-------------------|
-| D1 | TensorGraph metadata growth | Each `.cpu()` permanently appends `clear`, `gather`, and a new `io_staging_*` node (op list grows; StarPU payloads for unmarked tensors are reclaimed on compile). | Phase GC / compaction; reuse readout staging per session. |
+| D1 | TensorGraph metadata growth | Each `.cpu()` permanently appends `clear`, `gather`, and a new `io_staging_*` node (op list grows; StarPU payloads for unmarked tensors are reclaimed on compile). `Runtime::compile()` appends only new tile ops and DCE/last-consumer scan the **pending** suffix so ms/step no longer scales with step count; historical TileGraph/TensorGraph nodes still accumulate in memory. | Phase GC / compaction; reuse readout staging per session. |
 | D2 | Incremental tile-map growth | Every ingress/egress lowers a fresh ephemeral `S` into `inc_state.tensor_to_tiles`; entries are never removed. | Reclaim staging descriptors after invalidate; or pool single-tile `S` per `L`. |
 | D3 | Pin bookkeeping | `pin_tensor_for_graph` / ingress may append duplicate `at::Tensor` refs until the next graph clear. | Dedup by `TensorImpl*`; trim on phase seal. |
 | D4 | CE `ignore_index` mean | Mean CE uses `1/numel`; PyTorch uses `1/count_non_ignore`. | Graph-native valid-label count (or document as permanent limitation). |

--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -26,22 +26,22 @@ record into a shared `TensorGraph`; the caller flushes with `compile_graph()`
 
 The session is **one incremental** `TensorGraph` / `TileGraph` (phases append;
 do not reset the session to free memory). StarPU payload reclaim is controlled
-only by marks:
+by marks, with an explicit pending list in torch_nntile:
 
 1. Dropping a Python nntile tensor runs `~NNTileBinding` → `L.mark_output(false)`.
-2. On each `Runtime::compile()`, tile `is_output` is refreshed from the logical
-   `TensorNode` (`is_input` is only set true from logical, never cleared — torch_nntile
-   drives persistence via `mark_output`). Allocated tiles with
-   `mark_output(false)` and `mark_input(false)` get `invalidate_submit` and are
-   removed from the runtime tile map (and not reallocated until re-marked).
-3. Mid-phase, `release_dead_tiles_after_op` still invalidates unmarked tiles
+2. On `compile_graph()`, torch_nntile snapshots logical tensors that are
+   `mark_output(true)` in the sealed phase (`pending_output_reclaim`).
+3. After `run()`, pin holds are cleared (temps drop their NodeRefs). Any
+   snapshot entry that is no longer marked input/output is passed to
+   `Runtime::invalidate_logical_tiles` once — no full tile-map scan.
+4. Mid-phase, `release_dead_tiles_after_op` still invalidates unmarked tiles
    after their last consumer.
 
 Training loops should ``del`` step temporaries (e.g. logits) **after**
-``run()`` / ``wait()`` and any host readout of the loss so the next
-``compile_graph()`` sees ``mark_output(false)`` and can reclaim StarPU
-buffers; keep parameters, optimizer state, and persistent inputs marked via
-live bindings. ``train_full_batch_step`` drops logits after the step runs.
+``run()`` / ``wait()`` and any host readout of the loss so reclaim sees
+``mark_output(false)``; keep parameters, optimizer state, and persistent
+inputs marked via live bindings. ``train_full_batch_step`` drops logits
+after the step runs.
 
 ## I/O
 
@@ -97,7 +97,7 @@ run backward (or ingress a real grad tensor via `.to("nntile")`) first.
 
 | # | Topic | Current behavior | Planned follow-up |
 |---|--------|------------------|-------------------|
-| D1 | TensorGraph metadata growth | Each `.cpu()` permanently appends `clear`, `gather`, and a new `io_staging_*` node (op list grows; StarPU payloads for unmarked tensors are reclaimed on compile). `Runtime::compile()` appends only new tile ops and DCE/last-consumer scan the **pending** suffix so ms/step no longer scales with step count; historical TileGraph/TensorGraph nodes still accumulate in memory. | Phase GC / compaction; reuse readout staging per session. |
+| D1 | TensorGraph metadata growth | Each `.cpu()` permanently appends `clear`, `gather`, and a new `io_staging_*` node (op list grows). Phase outputs cleared after `run()` are reclaimed via `pending_output_reclaim` (O(phase outputs), not a full tile-map scan). Historical TileGraph/TensorGraph nodes still accumulate in memory. | Phase GC / compaction; reuse readout staging per session. |
 | D2 | Incremental tile-map growth | Every ingress/egress lowers a fresh ephemeral `S` into `inc_state.tensor_to_tiles`; entries are never removed. | Reclaim staging descriptors after invalidate; or pool single-tile `S` per `L`. |
 | D3 | Pin bookkeeping | `pin_tensor_for_graph` / ingress may append duplicate `at::Tensor` refs until the next graph clear. | Dedup by `TensorImpl*`; trim on phase seal. |
 | D4 | CE `ignore_index` mean | Mean CE uses `1/numel`; PyTorch uses `1/count_non_ignore`. | Graph-native valid-label count (or document as permanent limitation). |

--- a/nntile/include/nntile/runtime.hh
+++ b/nntile/include/nntile/runtime.hh
@@ -234,6 +234,10 @@ class Runtime
     std::unordered_map<const TileNode *, size_t> tile_last_consumer_op_;
     //! Highest exclusive op index already run via execute / execute_range.
     size_t executed_op_end_ = 0;
+    //! How many ``graph_.ops()`` entries have been appended into
+    //! ``execution_order_``. Incremental ``compile()`` only pulls ops beyond
+    //! this watermark so cost stays O(pending) rather than O(history).
+    size_t compiled_graph_op_count_ = 0;
 };
 
 } // namespace nntile

--- a/nntile/include/nntile/runtime.hh
+++ b/nntile/include/nntile/runtime.hh
@@ -128,6 +128,11 @@ class Runtime
 
     void invalidate_initialized(NNGraph::TensorNode const *tensor);
 
+    //! Drop StarPU buffers for a logical tensor that is no longer marked
+    //! input/output. No-op if still marked, unknown, or never allocated.
+    void invalidate_logical_tiles(
+        TensorGraph::TensorNode const *logical);
+
     //! Mark logical tensor tiles as host-populated (after acquire write I/O).
     void mark_initialized(TensorGraph::TensorNode const *tensor);
 
@@ -205,7 +210,6 @@ class Runtime
     void eliminate_dead_ops();
     void build_tile_last_consumer_map();
     void sync_tile_marks_from_logical();
-    void invalidate_non_output_tiles();
     void release_dead_tiles_after_op(size_t op_idx);
     void invalidate_tile_buffer(
         const TileNode *node,

--- a/nntile/include/nntile/runtime.hh
+++ b/nntile/include/nntile/runtime.hh
@@ -238,6 +238,10 @@ class Runtime
     //! ``execution_order_``. Incremental ``compile()`` only pulls ops beyond
     //! this watermark so cost stays O(pending) rather than O(history).
     size_t compiled_graph_op_count_ = 0;
+    //! How many ``graph_.tile_nodes()`` have been considered for allocation.
+    //! Ingress may lower marked staging tiles before any new op is appended;
+    //! those nodes must still be allocated without scanning full history.
+    size_t compiled_tile_node_count_ = 0;
 };
 
 } // namespace nntile

--- a/nntile/include/nntile/tensor/tensor_graph_tiling.hh
+++ b/nntile/include/nntile/tensor/tensor_graph_tiling.hh
@@ -86,6 +86,12 @@ class TensorGraphTiling
 public:
     static TensorGraphTiling from_tensor_graph(const TensorGraph& tg);
 
+    //! Layouts only for tensors touched by ``phase`` (ops + carried). Prefer
+    //! this for incremental compile so cost stays O(phase), not O(history).
+    static TensorGraphTiling from_phase(
+        const TensorGraph& tg,
+        const TensorGraph::PhaseSnapshot& phase);
+
     const TensorAxisLayout* find(const TensorGraph::TensorNode* node) const;
 
     bool contains(const TensorGraph::TensorNode* node) const

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -101,6 +101,7 @@ void Runtime::compile()
     if (compiled_graph_op_count_ > graph_ops.size())
     {
         compiled_graph_op_count_ = 0;
+        compiled_tile_node_count_ = 0;
         execution_order_.clear();
         executed_op_end_ = 0;
     }
@@ -134,10 +135,50 @@ void Runtime::compile()
 
 void Runtime::sync_tile_marks_from_logical()
 {
-    // Prefer descriptors that still own allocated tiles or appear in the
-    // pending op slice. Full-graph scans made incremental compile scale with
-    // session length once TensorDescriptors accumulated.
-    std::unordered_set<const TileGraph::TileNode *> pending_tiles;
+    // Sync only descriptors reachable from allocated tiles or the pending
+    // op slice — do not walk every historical TensorDescriptor.
+    std::unordered_set<const TileGraph::TensorDescriptor *> synced;
+
+    auto sync_tile = [&](const TileGraph::TileNode *tile_key)
+    {
+        if (tile_key == nullptr)
+        {
+            return;
+        }
+        // tensor_descriptor() is non-const on the node API via const TileNode*
+        auto *mutable_tile = const_cast<TileGraph::TileNode *>(tile_key);
+        const TileGraph::TensorDescriptor *desc =
+            mutable_tile->tensor_descriptor();
+        if (desc == nullptr || desc->source_node == nullptr)
+        {
+            return;
+        }
+        if (!synced.insert(desc).second)
+        {
+            return;
+        }
+        const bool is_in = desc->source_node->is_input();
+        const bool is_out = desc->source_node->is_output();
+        for (TileGraph::TileNode *tile : desc->tiles)
+        {
+            if (tile == nullptr)
+            {
+                continue;
+            }
+            if (is_in)
+            {
+                tile->mark_input(true);
+            }
+            tile->mark_output(is_out);
+        }
+    };
+
+    for (const auto &[tile, tile_ptr] : tile_map_)
+    {
+        (void)tile_ptr;
+        sync_tile(tile);
+    }
+
     const size_t n = execution_order_.size();
     const size_t begin =
         executed_op_end_ < n ? executed_op_end_ : n;
@@ -145,61 +186,11 @@ void Runtime::sync_tile_marks_from_logical()
     {
         for (const auto *in : execution_order_[i]->inputs())
         {
-            if (in != nullptr)
-            {
-                pending_tiles.insert(in);
-            }
+            sync_tile(in);
         }
         for (const auto *out : execution_order_[i]->outputs())
         {
-            if (out != nullptr)
-            {
-                pending_tiles.insert(out);
-            }
-        }
-    }
-
-    for (const auto &uptr : graph_.tensor_descriptors())
-    {
-        const TileGraph::TensorDescriptor &desc = *uptr;
-        if (desc.source_node == nullptr)
-        {
-            continue;
-        }
-        bool touch = false;
-        for (TileGraph::TileNode *tile : desc.tiles)
-        {
-            if (tile == nullptr)
-            {
-                continue;
-            }
-            if (tile_map_.count(tile) != 0 ||
-                pending_tiles.count(tile) != 0)
-            {
-                touch = true;
-                break;
-            }
-        }
-        if (!touch)
-        {
-            continue;
-        }
-        const bool is_in = desc.source_node->is_input();
-        const bool is_out = desc.source_node->is_output();
-        for (TileGraph::TileNode *tile : desc.tiles)
-        {
-            if (tile == nullptr)
-            {
-                continue;
-            }
-            // Propagate input mark only when logical is marked input; never
-            // clear tile is_input from a false logical (torch_nntile drives
-            // persistence via mark_output only).
-            if (is_in)
-            {
-                tile->mark_input(true);
-            }
-            tile->mark_output(is_out);
+            sync_tile(out);
         }
     }
 }
@@ -659,13 +650,11 @@ void Runtime::allocate_missing_tiles()
         }
     }
 
-    for (const auto &node : graph_.tile_nodes())
+    auto try_allocate = [&](const TileGraph::TileNode *tile_key)
     {
-        const TileGraph::TileNode *tile_key = node.get();
-        if (!live_tile_nodes_.empty() &&
-            live_tile_nodes_.count(tile_key) == 0)
+        if (tile_key == nullptr)
         {
-            continue;
+            return;
         }
         // Full-graph DCE may keep historical unmarked tiles "live"; do not
         // reallocate them unless a pending op needs them (or they are
@@ -673,64 +662,96 @@ void Runtime::allocate_missing_tiles()
         if (!tile_key->is_output() && !tile_key->is_input() &&
             needed_by_pending.count(tile_key) == 0)
         {
-            continue;
+            return;
         }
         auto adopt_it = tile_adoption_.find(tile_key);
         if (adopt_it != tile_adoption_.end())
         {
             tile_map_[tile_key] = adopt_it->second;
-            continue;
+            return;
         }
         if (tile_map_.count(tile_key) != 0)
         {
-            continue;
+            return;
         }
-        DataType dtype = node->dtype();
-        std::vector<Index> shape = node->shape();
+        // graph_.tile_nodes() owns the unique_ptr; tile_key is non-owning.
+        // Reconstruct mutable node for dtype/shape accessors that are const.
+        DataType dtype = tile_key->dtype();
+        std::vector<Index> shape = tile_key->shape();
+        // allocate_tile_and_register needs non-const TileNode* matching map
+        // keys used elsewhere; const_cast is safe (nodes owned by graph_).
+        auto *node = const_cast<TileGraph::TileNode *>(tile_key);
 
         switch (dtype)
         {
         case DataType::FP32:
             allocate_tile_and_register<nntile::fp32_t>(
-                node.get(), shape, tile_map_);
+                node, shape, tile_map_);
             break;
         case DataType::FP32_FAST_TF32:
             allocate_tile_and_register<nntile::fp32_fast_tf32_t>(
-                node.get(), shape, tile_map_);
+                node, shape, tile_map_);
             break;
         case DataType::FP32_FAST_FP16:
             allocate_tile_and_register<nntile::fp32_fast_fp16_t>(
-                node.get(), shape, tile_map_);
+                node, shape, tile_map_);
             break;
         case DataType::FP32_FAST_BF16:
             allocate_tile_and_register<nntile::fp32_fast_bf16_t>(
-                node.get(), shape, tile_map_);
+                node, shape, tile_map_);
             break;
         case DataType::FP64:
             allocate_tile_and_register<nntile::fp64_t>(
-                node.get(), shape, tile_map_);
+                node, shape, tile_map_);
             break;
         case DataType::FP16:
             allocate_tile_and_register<nntile::fp16_t>(
-                node.get(), shape, tile_map_);
+                node, shape, tile_map_);
             break;
         case DataType::BF16:
             allocate_tile_and_register<nntile::bf16_t>(
-                node.get(), shape, tile_map_);
+                node, shape, tile_map_);
             break;
         case DataType::INT64:
             allocate_tile_and_register<nntile::int64_t>(
-                node.get(), shape, tile_map_);
+                node, shape, tile_map_);
             break;
         case DataType::BOOL:
             allocate_tile_and_register<nntile::bool_t>(
-                node.get(), shape, tile_map_);
+                node, shape, tile_map_);
             break;
         default:
             throw std::runtime_error(
                 "Unsupported data type for tile allocation");
         }
+    };
+
+    // Only touch pending I/O, DCE-live tiles, and newly lowered tile nodes —
+    // never scan the full historical tile_nodes() list (that made compile
+    // O(session length)). New nodes cover ingress staging lowered before any
+    // scatter op is appended to execution_order_.
+    for (const auto *tile : needed_by_pending)
+    {
+        try_allocate(tile);
     }
+    for (const auto *tile : live_tile_nodes_)
+    {
+        if (needed_by_pending.count(tile) != 0)
+        {
+            continue;
+        }
+        try_allocate(tile);
+    }
+    const auto &all_tiles = graph_.tile_nodes();
+    if (compiled_tile_node_count_ > all_tiles.size())
+    {
+        compiled_tile_node_count_ = 0;
+    }
+    for (size_t i = compiled_tile_node_count_; i < all_tiles.size(); ++i)
+    {
+        try_allocate(all_tiles[i].get());
+    }
+    compiled_tile_node_count_ = all_tiles.size();
 }
 
 void Runtime::execute_range(size_t op_begin, size_t op_end)

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -117,14 +117,13 @@ void Runtime::compile()
         compiled_graph_op_count_ = graph_ops.size();
     }
 
-    // Refresh tile marks from logical TensorNodes before DCE / reclaim so
+    // Refresh tile marks from logical TensorNodes before DCE so
     // incremental sessions see mark_output(false) after Python drops refs.
+    // StarPU reclaim of unmarked phase outputs is deferred to run() via an
+    // explicit pending list (see torch_nntile pending_output_reclaim).
     sync_tile_marks_from_logical();
     eliminate_dead_ops();
     build_tile_last_consumer_map();
-    // Free StarPU buffers for unmarked tiles not used by the pending
-    // (not-yet-executed) op slice.
-    invalidate_non_output_tiles();
     allocate_missing_tiles();
     tile_adoption_.clear();
 
@@ -195,51 +194,49 @@ void Runtime::sync_tile_marks_from_logical()
     }
 }
 
-void Runtime::invalidate_non_output_tiles()
+void Runtime::invalidate_logical_tiles(
+    TensorGraph::TensorNode const *logical)
 {
-    std::unordered_set<const TileGraph::TileNode *> needed_by_pending;
-    const size_t n = execution_order_.size();
-    const size_t begin =
-        executed_op_end_ < n ? executed_op_end_ : n;
-    for (size_t i = begin; i < n; ++i)
+    if (logical == nullptr)
     {
-        for (const auto *in : execution_order_[i]->inputs())
-        {
-            if (in != nullptr)
-            {
-                needed_by_pending.insert(in);
-            }
-        }
-        for (const auto *out : execution_order_[i]->outputs())
-        {
-            if (out != nullptr)
-            {
-                needed_by_pending.insert(out);
-            }
-        }
+        return;
     }
-
-    std::vector<const TileGraph::TileNode *> to_release;
-    to_release.reserve(tile_map_.size());
-    for (const auto &[tile, tile_ptr] : tile_map_)
+    // Persistence is driven by marks: still-marked tensors stay allocated.
+    if (logical->is_output() || logical->is_input())
     {
-        (void)tile_ptr;
+        return;
+    }
+    const TileGraph::TensorDescriptor *desc =
+        graph_.get_tensor_descriptor(logical);
+    if (desc == nullptr)
+    {
+        return;
+    }
+    for (TileGraph::TileNode *tile : desc->tiles)
+    {
         if (tile == nullptr)
         {
             continue;
         }
-        if (tile->is_output() || tile->is_input())
+        tile->mark_output(false);
+    }
+
+    std::vector<const TileGraph::TileNode *> to_release;
+    to_release.reserve(desc->tiles.size());
+    for (TileGraph::TileNode *tile : desc->tiles)
+    {
+        if (tile == nullptr || tile->is_input())
         {
             continue;
         }
-        if (needed_by_pending.count(tile) != 0)
+        if (tile_map_.count(tile) != 0)
         {
-            continue;
+            to_release.push_back(tile);
         }
-        to_release.push_back(tile);
     }
     if (to_release.empty())
     {
+        init_state_.erase(logical);
         return;
     }
     if (starpu_is_initialized())
@@ -256,6 +253,7 @@ void Runtime::invalidate_non_output_tiles()
         invalidate_tile_buffer(tile, it->second);
         tile_map_.erase(it);
     }
+    init_state_.erase(logical);
 }
 
 void Runtime::mark_initialized(TensorGraph::TensorNode const *tensor)

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -93,11 +93,27 @@ DataType Runtime::get_dtype(
 
 void Runtime::compile()
 {
-    execution_order_.clear();
-    execution_order_.reserve(graph_.ops().size());
-    for (const auto &op : graph_.ops())
+    const auto &graph_ops = graph_.ops();
+    // TileGraph is append-only. Rebuilding execution_order_ from the full
+    // op list every compile made each training step pay DCE / last-consumer
+    // cost over all prior phases (ms/step grew with step count). Append only
+    // newly lowered ops; keep already-executed prefix for full execute().
+    if (compiled_graph_op_count_ > graph_ops.size())
     {
-        execution_order_.push_back(op);
+        compiled_graph_op_count_ = 0;
+        execution_order_.clear();
+        executed_op_end_ = 0;
+    }
+    if (compiled_graph_op_count_ < graph_ops.size())
+    {
+        execution_order_.reserve(
+            execution_order_.size() +
+            (graph_ops.size() - compiled_graph_op_count_));
+        for (size_t i = compiled_graph_op_count_; i < graph_ops.size(); ++i)
+        {
+            execution_order_.push_back(graph_ops[i]);
+        }
+        compiled_graph_op_count_ = graph_ops.size();
     }
 
     // Refresh tile marks from logical TensorNodes before DCE / reclaim so
@@ -118,10 +134,53 @@ void Runtime::compile()
 
 void Runtime::sync_tile_marks_from_logical()
 {
+    // Prefer descriptors that still own allocated tiles or appear in the
+    // pending op slice. Full-graph scans made incremental compile scale with
+    // session length once TensorDescriptors accumulated.
+    std::unordered_set<const TileGraph::TileNode *> pending_tiles;
+    const size_t n = execution_order_.size();
+    const size_t begin =
+        executed_op_end_ < n ? executed_op_end_ : n;
+    for (size_t i = begin; i < n; ++i)
+    {
+        for (const auto *in : execution_order_[i]->inputs())
+        {
+            if (in != nullptr)
+            {
+                pending_tiles.insert(in);
+            }
+        }
+        for (const auto *out : execution_order_[i]->outputs())
+        {
+            if (out != nullptr)
+            {
+                pending_tiles.insert(out);
+            }
+        }
+    }
+
     for (const auto &uptr : graph_.tensor_descriptors())
     {
         const TileGraph::TensorDescriptor &desc = *uptr;
         if (desc.source_node == nullptr)
+        {
+            continue;
+        }
+        bool touch = false;
+        for (TileGraph::TileNode *tile : desc.tiles)
+        {
+            if (tile == nullptr)
+            {
+                continue;
+            }
+            if (tile_map_.count(tile) != 0 ||
+                pending_tiles.count(tile) != 0)
+            {
+                touch = true;
+                break;
+            }
+        }
+        if (!touch)
         {
             continue;
         }
@@ -735,8 +794,13 @@ void Runtime::execute()
 
 void Runtime::build_tile_last_consumer_map()
 {
+    // Only pending ops run next; historical last-consumer edges are unused
+    // by release_dead_tiles_after_op during execute_range.
     tile_last_consumer_op_.clear();
-    for (size_t i = 0; i < execution_order_.size(); ++i)
+    const size_t n = execution_order_.size();
+    const size_t begin =
+        executed_op_end_ < n ? executed_op_end_ : n;
+    for (size_t i = begin; i < n; ++i)
     {
         for (const auto *in : execution_order_[i]->inputs())
         {
@@ -839,13 +903,21 @@ void Runtime::eliminate_dead_ops()
     {
         return;
     }
+    // Already-executed prefix is immutable for incremental sessions; DCE only
+    // the pending suffix so compile stays O(new phase), not O(history).
+    const size_t pending_begin =
+        executed_op_end_ < n ? executed_op_end_ : n;
+    if (pending_begin >= n)
+    {
+        return;
+    }
 
     using TNode = const TileGraph::TileNode *;
     std::unordered_map<TNode, std::unordered_set<size_t>> producer;
     std::unordered_map<TNode, std::unordered_set<size_t>> consumer;
     std::unordered_set<TNode> consumed;
 
-    for (size_t i = 0; i < n; ++i)
+    for (size_t i = pending_begin; i < n; ++i)
     {
         const auto &op = execution_order_[i];
         for (const auto *out : op->outputs())
@@ -866,30 +938,30 @@ void Runtime::eliminate_dead_ops()
     }
 
     std::unordered_set<TNode> live_data;
-    for (const auto &node : graph_.tile_nodes())
+    // Seed from marked tiles touched by the pending slice only — scanning
+    // every historical tile_node made compile O(session length).
+    for (size_t i = pending_begin; i < n; ++i)
     {
-        if (node->is_output())
+        const auto &op = execution_order_[i];
+        for (const auto *out : op->outputs())
         {
-            live_data.insert(node.get());
+            if (out != nullptr &&
+                (out->is_output() || out->is_input()))
+            {
+                live_data.insert(out);
+            }
         }
-    }
-    for (const auto &node : graph_.tile_nodes())
-    {
-        if (node->is_input())
+        for (const auto *in : op->inputs())
         {
-            live_data.insert(node.get());
+            if (in != nullptr &&
+                (in->is_output() || in->is_input()))
+            {
+                live_data.insert(in);
+            }
         }
     }
 
-    bool any_marked_output = false;
-    for (const auto &node : graph_.tile_nodes())
-    {
-        if (node->is_output())
-        {
-            any_marked_output = true;
-            break;
-        }
-    }
+    const bool any_marked_output = !live_data.empty();
     if (!any_marked_output)
     {
         for (const auto &p : producer)
@@ -946,8 +1018,12 @@ void Runtime::eliminate_dead_ops()
     }
 
     std::vector<std::shared_ptr<OpNode>> filtered;
-    filtered.reserve(live_ops.size());
-    for (size_t i = 0; i < n; ++i)
+    filtered.reserve(pending_begin + live_ops.size());
+    for (size_t i = 0; i < pending_begin; ++i)
+    {
+        filtered.push_back(execution_order_[i]);
+    }
+    for (size_t i = pending_begin; i < n; ++i)
     {
         if (live_ops.count(i))
         {

--- a/nntile/src/tensor/tensor_graph_tiling.cc
+++ b/nntile/src/tensor/tensor_graph_tiling.cc
@@ -15,6 +15,7 @@
 #include "nntile/tensor/tensor_graph_tiling.hh"
 
 #include <algorithm>
+#include <set>
 #include <sstream>
 
 #include "nntile/tensor/axis_descriptor.hh"
@@ -245,6 +246,48 @@ TensorGraphTiling TensorGraphTiling::from_tensor_graph(const TensorGraph& tg)
     for(const auto& tn : tg.tensor_nodes())
     {
         out.layouts_.emplace(tn.get(), TensorAxisLayout(tn.get()));
+    }
+    return out;
+}
+
+TensorGraphTiling TensorGraphTiling::from_phase(
+    const TensorGraph& tg,
+    const TensorGraph::PhaseSnapshot& phase)
+{
+    TensorGraphTiling out;
+    std::set<const TensorGraph::TensorNode*> touched;
+    for(const TensorGraph::TensorNode* t : phase.carried_tensors)
+    {
+        if(t != nullptr)
+        {
+            touched.insert(t);
+        }
+    }
+    const auto& ops = tg.ops();
+    for(size_t i = phase.op_begin; i < phase.op_end; ++i)
+    {
+        if(i >= ops.size() || ops[i] == nullptr)
+        {
+            continue;
+        }
+        for(TensorGraph::TensorNode* in : ops[i]->inputs())
+        {
+            if(in != nullptr)
+            {
+                touched.insert(in);
+            }
+        }
+        for(TensorGraph::TensorNode* ot : ops[i]->outputs())
+        {
+            if(ot != nullptr)
+            {
+                touched.insert(ot);
+            }
+        }
+    }
+    for(const TensorGraph::TensorNode* t : touched)
+    {
+        out.layouts_.emplace(t, TensorAxisLayout(t));
     }
     return out;
 }

--- a/nntile/tests/tile/append_tensor_graph_phase.cc
+++ b/nntile/tests/tile/append_tensor_graph_phase.cc
@@ -149,7 +149,7 @@ TEST_CASE_METHOD(nntile::test::ContextFixture,
 }
 
 TEST_CASE_METHOD(nntile::test::ContextFixture,
-    "Runtime compile invalidates tiles after mark_output false",
+    "Runtime invalidate_logical_tiles after mark_output false",
     "[graph][tile]")
 {
     TensorGraph tg("reclaim");
@@ -187,9 +187,10 @@ TEST_CASE_METHOD(nntile::test::ContextFixture,
     REQUIRE(before.count(y) == 1);
     REQUIRE(before.count(z) == 1);
 
-    // Drop output mark on y only: next compile must invalidate y's buffer.
+    // Drop output mark on y only: reclaim buffers explicitly (torch_nntile
+    // does this at end of run() via pending_output_reclaim).
     y->mark_output(false);
-    rt.compile();
+    rt.invalidate_logical_tiles(y);
 
     std::unordered_map<TensorGraph::TensorNode const *,
         std::vector<std::shared_ptr<void>>>

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -261,11 +261,12 @@ Architecture reference:
 - During ``run()``, intermediate StarPU tile buffers may be released after
   their last consumer when not marked as inputs/outputs.
 - On each ``compile_graph()``, ``Runtime`` refreshes tile marks from logical
-  ``mark_output`` / ``mark_input`` and ``invalidate_submit``s allocated tiles
-  that are neither input nor output (incremental session reclaim).
-- **Reduce footprint:** ``del`` step temporaries after ``run()`` so the next
-  compile sees cleared ``mark_output`` and can reclaim buffers.
-  ``train_full_batch_step`` already drops logits after each step.
+  ``mark_output`` / ``mark_input`` for the pending slice. torch_nntile snapshots
+  phase outputs and, after ``run()`` (and again at the next compile), calls
+  ``invalidate_logical_tiles`` on snapshot entries that are no longer marked.
+- **Reduce footprint:** ``del`` step temporaries after ``run()`` so reclaim
+  sees cleared ``mark_output``. ``train_full_batch_step`` already drops logits
+  after each step.
 
 ### Axis-group naming and tiling
 

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -271,8 +271,12 @@ void lower_io_staging_locked(nntile::TensorGraph::TensorNode *staging)
         return;
     }
     ensure_recorder_exec_state_locked();
+    nntile::TensorGraph::PhaseSnapshot staging_phase;
+    staging_phase.op_begin = g_graph->num_ops();
+    staging_phase.op_end = staging_phase.op_begin;
+    staging_phase.carried_tensors = {staging};
     const nntile::TensorGraphTiling tiling =
-        nntile::TensorGraphTiling::from_tensor_graph(*g_graph);
+        nntile::TensorGraphTiling::from_phase(*g_graph, staging_phase);
     nntile::lower_staging_tensor_immediate(
         *g_graph,
         staging,
@@ -704,8 +708,10 @@ void compile_graph_locked(
     const nntile::TensorGraph::PhaseSnapshot phase = g_graph->seal_phase();
     std::vector<nntile::TensorGraph::TensorNode *> scatter_stagings;
     collect_scatter_stagings_from_phase_locked(phase, scatter_stagings);
+    // Phase-scoped tiling: full-graph from_tensor_graph rebuilt layouts for
+    // every historical tensor node and made compile O(session length).
     const nntile::TensorGraphTiling tiling =
-        nntile::TensorGraphTiling::from_tensor_graph(*g_graph);
+        nntile::TensorGraphTiling::from_phase(*g_graph, phase);
 
     try
     {

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -86,10 +86,69 @@ struct RecorderExecState
     std::size_t pending_exec_op_end = 0;
     //! Scatter staging tensors in the pending phase (invalidate after run).
     std::vector<nntile::TensorGraph::TensorNode *> pending_scatter_stagings;
+    //! Logical tensors that were mark_output(true) when the pending slice
+    //! was compiled. After run() drops step temps (pin_hold / NodeRef), any
+    //! entry that is no longer marked is invalidated once.
+    std::vector<nntile::TensorGraph::TensorNode *> pending_output_reclaim;
 };
 
 std::unique_ptr<RecorderExecState> g_exec;
 bool g_defer_pending_clear_after_run = false;
+
+void reclaim_pending_outputs_locked()
+{
+    if (g_exec == nullptr || g_exec->runtime == nullptr)
+    {
+        return;
+    }
+    if (g_exec->pending_output_reclaim.empty())
+    {
+        return;
+    }
+    nntile::Runtime &runtime = *g_exec->runtime;
+    // Temps are often del'd after run(); keep still-marked entries so the
+    // next compile/run can invalidate them once NodeRefs drop.
+    std::vector<nntile::TensorGraph::TensorNode *> still_marked;
+    still_marked.reserve(g_exec->pending_output_reclaim.size());
+    for (nntile::TensorGraph::TensorNode *logical :
+        g_exec->pending_output_reclaim)
+    {
+        if (logical == nullptr)
+        {
+            continue;
+        }
+        if (logical->is_output() || logical->is_input())
+        {
+            still_marked.push_back(logical);
+            continue;
+        }
+        runtime.invalidate_logical_tiles(logical);
+    }
+    g_exec->pending_output_reclaim = std::move(still_marked);
+}
+
+void collect_pending_output_reclaim_locked(
+    const nntile::TensorGraph::PhaseSnapshot &phase)
+{
+    if (g_exec == nullptr)
+    {
+        return;
+    }
+    // Drain any unreclaimed candidates from a prior compile that never ran
+    // (or whose temps were dropped early) before replacing the list.
+    reclaim_pending_outputs_locked();
+    g_exec->pending_output_reclaim.clear();
+    g_exec->pending_output_reclaim.reserve(phase.carried_tensors.size());
+    for (nntile::TensorGraph::TensorNode const *t : phase.carried_tensors)
+    {
+        if (t == nullptr || !t->is_output())
+        {
+            continue;
+        }
+        g_exec->pending_output_reclaim.push_back(
+            const_cast<nntile::TensorGraph::TensorNode *>(t));
+    }
+}
 
 void sync_param_grad_aliases_locked();
 
@@ -708,6 +767,7 @@ void compile_graph_locked(
     const nntile::TensorGraph::PhaseSnapshot phase = g_graph->seal_phase();
     std::vector<nntile::TensorGraph::TensorNode *> scatter_stagings;
     collect_scatter_stagings_from_phase_locked(phase, scatter_stagings);
+    collect_pending_output_reclaim_locked(phase);
     // Phase-scoped tiling: full-graph from_tensor_graph rebuilt layouts for
     // every historical tensor node and made compile O(session length).
     const nntile::TensorGraphTiling tiling =
@@ -781,6 +841,10 @@ void run_graph_locked()
         clear_pending_graph_after_compile_locked(pin_drop);
         g_defer_pending_clear_after_run = false;
     }
+    // Drop compile-time pin_hold inside the locked section so mark_output
+    // flips are visible before reclaim.
+    g_exec->pin_hold.clear();
+    reclaim_pending_outputs_locked();
 }
 
 void reset_recorder_locked(
@@ -925,10 +989,6 @@ void run_graph()
 {
     std::lock_guard<std::recursive_mutex> lock(g_recorder_mutex);
     run_graph_locked();
-    if (g_exec != nullptr)
-    {
-        g_exec->pin_hold.clear();
-    }
 }
 
 void reset_graph_session()

--- a/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
+++ b/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
@@ -441,8 +441,8 @@ def train_nntile(
                 f"loss={loss_cpu:.4f} (lr={lr:.6f})"
             )
 
-        # Drop step temporaries so the next compile sees mark_output(false)
-        # and can reclaim StarPU tiles (see torch_nntile tensor architecture).
+        # Drop step temporaries so mark_output(false) is visible to the
+        # pending_output_reclaim pass (end of this run / start of next compile).
         del logits
         del loss
         gc.collect()

--- a/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
+++ b/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
@@ -23,8 +23,7 @@ with this recipe.
 
 Supports ``--device cpu`` / ``cuda`` (PyTorch Adam) and ``--device nntile``
 (``torch_nntile.training.Adam`` + ``cross_entropy``, graph compile/run per
-step). ``nn.Linear`` bias is unsupported on nntile, so layers use
-``F.linear(x, weight, None) + bias``.
+step). Layers use ``nn.Linear`` with bias (nntile ``aten::linear`` bias path).
 
 On ``cpu`` / ``cuda`` / ``nntile``, all train/test batches (images + labels)
 are moved onto the training device **before** training. The script prints
@@ -55,6 +54,7 @@ run is slower on CPU workers than pure torch).
 from __future__ import annotations
 
 import argparse
+import gc
 import math
 import sys
 import time
@@ -76,29 +76,15 @@ if str(_TORCH_NNTILE_ROOT) not in sys.path:
 HIDDEN_WIDTHS = (200, 100, 60, 30)
 
 
-class LinearBias(nn.Module):
-    """Linear + bias via gemm then add (nntile rejects ``nn.Linear`` bias)."""
-
-    def __init__(self, in_features: int, out_features: int) -> None:
-        super().__init__()
-        self.in_features = in_features
-        self.out_features = out_features
-        self.weight = nn.Parameter(torch.empty(out_features, in_features))
-        self.bias = nn.Parameter(torch.empty(out_features))
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return F.linear(x, self.weight, None) + self.bias
-
-
 class FiveLayerReLU(nn.Module):
     """Bias-aware MLP matching the Google five-layer ReLU tutorial."""
 
     def __init__(self) -> None:
         super().__init__()
         widths = (28 * 28, *HIDDEN_WIDTHS, 10)
-        layers: list[LinearBias] = []
+        layers: list[nn.Linear] = []
         for in_features, out_features in zip(widths[:-1], widths[1:]):
-            layers.append(LinearBias(in_features, out_features))
+            layers.append(nn.Linear(in_features, out_features, bias=True))
         self.layers = nn.ModuleList(layers)
         self._init_google_()
 
@@ -223,8 +209,12 @@ def evaluate_nntile(
         torch_nntile.wait()
         compute_s += time.perf_counter() - t0
 
-        logits_cpu = logits.to("cpu")
-        loss_cpu = float(loss.to("cpu").item())
+        with torch.no_grad():
+            logits_cpu = logits.to("cpu")
+            loss_cpu = float(loss.to("cpu").item())
+        del logits
+        del loss
+        gc.collect()
         total_loss += loss_cpu
         total_correct += int(
             (logits_cpu.argmax(dim=1) == labels_cpu).sum().item()
@@ -382,6 +372,7 @@ def train_torch(
         eval_compute_s,
     )
 
+
 def train_nntile(
     model: nn.Module,
     train_batches: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
@@ -449,6 +440,12 @@ def train_nntile(
                 f"{step}: train accuracy={train_acc:.4f} "
                 f"loss={loss_cpu:.4f} (lr={lr:.6f})"
             )
+
+        # Drop step temporaries so the next compile sees mark_output(false)
+        # and can reclaim StarPU tiles (see torch_nntile tensor architecture).
+        del logits
+        del loss
+        gc.collect()
 
         if step % test_every == 0:
             test_loss, test_acc, eval_s = evaluate_nntile(

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -546,8 +546,8 @@ def train_full_batch_step(
         if print_axis_groups:
             torch_nntile.print_axis_groups()
         # Keep logits marked through compile/run and loss readout so this
-        # phase (and gather) can execute. Drop afterward so the next compile
-        # can invalidate_submit the buffer via mark_output(false).
+        # phase (and gather) can execute. Drop afterward so pending_output
+        # reclaim can invalidate_submit via mark_output(false).
         torch_nntile.compile_graph()
         torch_nntile.run()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated why `reproduce_google_five_layer_relu_mnist.py` showed rising ms/step as `--steps` increased (≈50 ms at 100 steps → ≈170 ms at 300).

**Root cause:** each `compile_graph()` rebuilt and scanned the **entire** cumulative `TileGraph` (DCE / last-consumer / mark sync / allocate / tiling), so compile cost grew with session length.

**Fix:**
- Incremental `Runtime::compile()`: append-only ops, pending-only DCE/last-consumer, scoped allocate
- `TensorGraphTiling::from_phase()` for torch_nntile
- **Pending output reclaim:** at compile, snapshot logical tensors that are `mark_output(true)` for the sealed phase (`pending_output_reclaim`). After `run()` (pin holds cleared) — and again at the next compile — loop that list once and `invalidate_logical_tiles` on entries that are no longer marked. Still-marked entries (params / live temps) stay on the list until dropped. No full tile-map scan in `compile()`.

**Example:** `nn.Linear(..., bias=True)` and `del` step temporaries after `run()`.

## Timing (CPU StarPU, after reclaim change)

Windowed MLP microbench ≈ **26.2 / 26.1 / 26.5 ms/step** over `[0,50) / [50,200) / [200,400)` — flat.

## Test plan

- [x] `test_append_tensor_graph_phase` (incl. `invalidate_logical_tiles`)
- [x] pytest linear bias + adam + sgd + graph_execution (40 passed)
- [x] Step-time windows stay flat

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da2fb6c1-2588-4aad-b287-d03e32bb1088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da2fb6c1-2588-4aad-b287-d03e32bb1088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

