### PR TITLE
Speed up torch_nntile incremental graph training (MNIST)

### DIFF
--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -41,8 +41,10 @@ by marks, with an explicit pending list in torch_nntile:
 Training loops should ``del`` step temporaries (e.g. logits) **after**
 ``wait()`` and any host readout of the loss so reclaim sees
 ``mark_output(false)``; keep parameters, optimizer state, and persistent
-inputs marked via live bindings. ``train_full_batch_step`` drops logits
-after the step runs.
+inputs marked via live bindings. Prefer ``gc.collect(0)`` over a full
+``gc.collect()`` — a full collection scans the growing session heap and can
+dominate step time. ``train_full_batch_step`` drops logits after the step
+runs.
 
 ## I/O
 

--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -41,10 +41,10 @@ by marks, with an explicit pending list in torch_nntile:
 Training loops should ``del`` step temporaries (e.g. logits) **after**
 ``wait()`` and any host readout of the loss so reclaim sees
 ``mark_output(false)``; keep parameters, optimizer state, and persistent
-inputs marked via live bindings. Prefer ``gc.collect(0)`` over a full
-``gc.collect()`` — a full collection scans the growing session heap and can
-dominate step time. ``train_full_batch_step`` drops logits after the step
-runs.
+inputs marked via live bindings. Do **not** call ``gc.collect()`` in the
+step loop — refcount drop from ``del`` is enough for bindings, and a full
+collection scans the growing session heap and can dominate step time.
+``train_full_batch_step`` drops logits after the step runs.
 
 ## I/O
 

--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -20,7 +20,8 @@ TensorImpl → NNTileBackendMeta → NodeRef → NNTileBinding { logical L }
 
 There is no side map (`g_tensor_nodes`) and no eager per-op flush. All ops
 record into a shared `TensorGraph`; the caller flushes with `compile_graph()`
-+ `run()` (or legacy `execute()` = compile+run).
++ `run()` (or legacy `execute()` = compile+run+wait). `run()` submits
+StarPU tasks asynchronously; `wait()` synchronizes and runs post-run reclaim.
 
 ## Incremental session memory (`mark_output`)
 
@@ -31,14 +32,14 @@ by marks, with an explicit pending list in torch_nntile:
 1. Dropping a Python nntile tensor runs `~NNTileBinding` → `L.mark_output(false)`.
 2. On `compile_graph()`, torch_nntile snapshots logical tensors that are
    `mark_output(true)` in the sealed phase (`pending_output_reclaim`).
-3. After `run()`, pin holds are cleared (temps drop their NodeRefs). Any
-   snapshot entry that is no longer marked input/output is passed to
-   `Runtime::invalidate_logical_tiles` once — no full tile-map scan.
+3. After `wait()` (following `run()`), pin holds are cleared (temps drop their
+   NodeRefs). Any snapshot entry that is no longer marked input/output is
+   passed to `Runtime::invalidate_logical_tiles` once — no full tile-map scan.
 4. Mid-phase, `release_dead_tiles_after_op` still invalidates unmarked tiles
    after their last consumer.
 
 Training loops should ``del`` step temporaries (e.g. logits) **after**
-``run()`` / ``wait()`` and any host readout of the loss so reclaim sees
+``wait()`` and any host readout of the loss so reclaim sees
 ``mark_output(false)``; keep parameters, optimizer state, and persistent
 inputs marked via live bindings. ``train_full_batch_step`` drops logits
 after the step runs.
@@ -97,7 +98,7 @@ run backward (or ingress a real grad tensor via `.to("nntile")`) first.
 
 | # | Topic | Current behavior | Planned follow-up |
 |---|--------|------------------|-------------------|
-| D1 | TensorGraph metadata growth | Each `.cpu()` permanently appends `clear`, `gather`, and a new `io_staging_*` node (op list grows). Phase outputs cleared after `run()` are reclaimed via `pending_output_reclaim` (O(phase outputs), not a full tile-map scan). Historical TileGraph/TensorGraph nodes still accumulate in memory. | Phase GC / compaction; reuse readout staging per session. |
+| D1 | TensorGraph metadata growth | Each `.cpu()` permanently appends `clear`, `gather`, and a new `io_staging_*` node (op list grows). Phase outputs cleared after `wait()` are reclaimed via `pending_output_reclaim` (O(phase outputs), not a full tile-map scan). Historical TileGraph/TensorGraph nodes still accumulate in memory. | Phase GC / compaction; reuse readout staging per session. |
 | D2 | Incremental tile-map growth | Every ingress/egress lowers a fresh ephemeral `S` into `inc_state.tensor_to_tiles`; entries are never removed. | Reclaim staging descriptors after invalidate; or pool single-tile `S` per `L`. |
 | D3 | Pin bookkeeping | `pin_tensor_for_graph` / ingress may append duplicate `at::Tensor` refs until the next graph clear. | Dedup by `TensorImpl*`; trim on phase seal. |
 | D4 | CE `ignore_index` mean | Mean CE uses `1/numel`; PyTorch uses `1/count_non_ignore`. | Graph-native valid-label count (or document as permanent limitation). |

--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -35,8 +35,10 @@ by marks, with an explicit pending list in torch_nntile:
 3. After `wait()` (following `run()`), pin holds are cleared (temps drop their
    NodeRefs). Any snapshot entry that is no longer marked input/output is
    passed to `Runtime::invalidate_logical_tiles` once — no full tile-map scan.
-4. Mid-phase, `release_dead_tiles_after_op` still invalidates unmarked tiles
-   after their last consumer.
+4. Mid-phase, ``execute_range`` queues unmarked tiles after their last
+   consumer; ``Runtime::wait()`` invalidates them after StarPU drains.
+   Core ``*`` wrappers skip ``starpu_task_wait_for_all`` while submit is
+   deferred so ``run()`` stays asynchronous.
 
 Training loops should ``del`` step temporaries (e.g. logits) **after**
 ``wait()`` and any host readout of the loss so reclaim sees

--- a/nntile/include/nntile/runtime.hh
+++ b/nntile/include/nntile/runtime.hh
@@ -54,7 +54,8 @@ class Runtime
 
     void compile();
 
-    //! Run ops [op_begin, op_end) in the post-dead-code elimination order.
+    //! Submit ops [op_begin, op_end) asynchronously (no StarPU drain).
+    //! Call ``wait()`` before reading outputs or reclaiming tiles.
     void execute_range(size_t op_begin, size_t op_end);
 
     size_t execution_op_count() const { return execution_order_.size(); }
@@ -84,17 +85,18 @@ class Runtime
     template <typename T>
     void bind_data(TileNode const *tile, const std::vector<T> &data);
 
-    //! Submit all compiled ops to StarPU (asynchronous). Call ``wait()`` before
-    //! reading outputs or relying on computed tile values.
+    //! Submit all compiled ops then ``wait()`` (convenience for tests).
+    //! Prefer ``execute_range`` + ``wait()`` for incremental async sessions.
     void execute();
 
     //! StarPU worker for ``STARPU_EXECUTE_ON_WORKER`` during tile op execution,
-    //! or -1 for default StarPU placement. Set by ``execute()`` from the static
-    //! execution schedule when one is installed.
+    //! or -1 for default StarPU placement. Set by ``execute()`` /
+    //! ``execute_range()`` from the static execution schedule when one is
+    //! installed.
     int starpu_worker_hint() const noexcept { return starpu_worker_hint_; }
 
-    //! Block until all tasks submitted by ``execute()`` / ``execute_range()``
-    //! have finished.
+    //! Block until all tasks submitted by ``execute_range()`` have finished,
+    //! then flush queued last-consumer tile reclaim.
     void wait();
 
     //! Read a logical tensor or tile buffer marked for host I/O (input or

--- a/nntile/include/nntile/runtime.hh
+++ b/nntile/include/nntile/runtime.hh
@@ -211,6 +211,8 @@ class Runtime
     void build_tile_last_consumer_map();
     void sync_tile_marks_from_logical();
     void release_dead_tiles_after_op(size_t op_idx);
+    void queue_dead_tiles_after_op(size_t op_idx);
+    void flush_queued_dead_tiles();
     void invalidate_tile_buffer(
         const TileNode *node,
         const std::shared_ptr<void> &tile_ptr);
@@ -236,6 +238,9 @@ class Runtime
     std::unordered_map<const TileNode *, std::shared_ptr<void>> tile_adoption_;
     std::unordered_set<const TileNode *> live_tile_nodes_;
     std::unordered_map<const TileNode *, size_t> tile_last_consumer_op_;
+    //! Tiles whose last consumer ran during async execute_range; flushed in
+    //! ``wait()`` after ``starpu_task_wait_for_all``.
+    std::vector<const TileNode *> queued_dead_tiles_;
     //! Highest exclusive op index already run via execute / execute_range.
     size_t executed_op_end_ = 0;
     //! How many ``graph_.ops()`` entries have been appended into

--- a/nntile/include/nntile/starpu/config.hh
+++ b/nntile/include/nntile/starpu/config.hh
@@ -105,3 +105,5 @@ void unpack_args_ptr(void *cl_args, const Ts *&...args)
 
 } // namespace starpu
 } // namespace nntile
+
+#include <nntile/starpu/sync_defer.hh>

--- a/nntile/include/nntile/starpu/sync_defer.hh
+++ b/nntile/include/nntile/starpu/sync_defer.hh
@@ -1,0 +1,48 @@
+/*! @copyright (c) 2022-present Skolkovo Institute of Science and Technology
+ *                              (Skoltech), Russia. All rights reserved.
+ *                 2023-present Artificial Intelligence Research Institute
+ *                              (AIRI), Russia. All rights reserved.
+ *
+ * @file include/nntile/starpu/sync_defer.hh
+ * Defer ``starpu_task_wait_for_all`` during Runtime::execute_range submit.
+ *
+ * @version 1.1.0
+ * */
+
+#pragma once
+
+#include <starpu.h>
+
+namespace nntile
+{
+
+//! Nesting depth: when > 0, sync wrappers skip ``starpu_task_wait_for_all``.
+inline thread_local int g_starpu_sync_defer_depth = 0;
+
+//! RAII: make blocking core::* wrappers submit-only while in scope.
+struct StarpuSyncDefer
+{
+    StarpuSyncDefer()
+    {
+        ++g_starpu_sync_defer_depth;
+    }
+
+    ~StarpuSyncDefer()
+    {
+        --g_starpu_sync_defer_depth;
+    }
+
+    StarpuSyncDefer(StarpuSyncDefer const &) = delete;
+    StarpuSyncDefer &operator=(StarpuSyncDefer const &) = delete;
+};
+
+//! Wait unless ``StarpuSyncDefer`` is active (incremental async submit).
+inline void starpu_task_wait_for_all_unless_deferred()
+{
+    if(g_starpu_sync_defer_depth == 0)
+    {
+        starpu_task_wait_for_all();
+    }
+}
+
+} // namespace nntile

--- a/nntile/include/nntile/tensor/graph.hh
+++ b/nntile/include/nntile/tensor/graph.hh
@@ -111,16 +111,57 @@ inline void TensorGraph::prepend_ops(
 inline TensorGraph::PhaseSnapshot TensorGraph::seal_phase()
 {
     std::vector<TensorNode const *> carried;
-    carried.reserve(data_.size());
-    for (auto const &node : data_)
+    carried.reserve(marked_io_.size());
+    for (TensorNode const *t : marked_io_)
     {
-        TensorNode const *t = node.get();
-        if (t->is_input() || t->is_output())
+        if (t != nullptr && (t->is_input() || t->is_output()))
         {
             carried.push_back(t);
         }
     }
     return seal_phase(std::move(carried));
+}
+
+inline void TensorGraph::refresh_marked_io_(TensorNode const *node)
+{
+    if (node == nullptr)
+    {
+        return;
+    }
+    if (node->is_input() || node->is_output())
+    {
+        marked_io_.insert(node);
+    }
+    else
+    {
+        marked_io_.erase(node);
+    }
+}
+
+inline void TensorGraph::TensorNode::mark_input(bool v)
+{
+    if (is_input_ == v)
+    {
+        return;
+    }
+    is_input_ = v;
+    if (graph_ != nullptr)
+    {
+        graph_->refresh_marked_io_(this);
+    }
+}
+
+inline void TensorGraph::TensorNode::mark_output(bool v)
+{
+    if (is_output_ == v)
+    {
+        return;
+    }
+    is_output_ = v;
+    if (graph_ != nullptr)
+    {
+        graph_->refresh_marked_io_(this);
+    }
 }
 
 inline TensorGraph::PhaseSnapshot TensorGraph::seal_phase(

--- a/nntile/include/nntile/tensor/graph.hh
+++ b/nntile/include/nntile/tensor/graph.hh
@@ -25,6 +25,8 @@
 #include <nntile/tensor/graph_data_node.hh>
 #include <nntile/tensor/graph_op_node.hh>
 
+#include <algorithm>
+
 namespace nntile
 {
 
@@ -119,6 +121,15 @@ inline TensorGraph::PhaseSnapshot TensorGraph::seal_phase()
             carried.push_back(t);
         }
     }
+    // Stable order by node id (insertion order) so pending-compile equality
+    // checks compare carried lists by index deterministically.
+    std::sort(
+        carried.begin(),
+        carried.end(),
+        [](TensorNode const *a, TensorNode const *b)
+        {
+            return a->id() < b->id();
+        });
     return seal_phase(std::move(carried));
 }
 

--- a/nntile/include/nntile/tensor/graph_data_node.hh
+++ b/nntile/include/nntile/tensor/graph_data_node.hh
@@ -80,8 +80,8 @@ class TensorGraph::TensorNode
     // Graph structure
     bool is_input() const { return is_input_; }
     bool is_output() const { return is_output_; }
-    void mark_input(bool v = true) { is_input_ = v; }
-    void mark_output(bool v = true) { is_output_ = v; }
+    void mark_input(bool v = true);
+    void mark_output(bool v = true);
 
     // Host-side parameter bytes (checkpoint I/O); not applied until bind_data.
     void set_bind_hint(std::vector<std::uint8_t> data);

--- a/nntile/include/nntile/tensor/graph_decl.hh
+++ b/nntile/include/nntile/tensor/graph_decl.hh
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 // NNTile headers
@@ -111,10 +112,15 @@ class TensorGraph
 
     size_t phase_seal_cursor() const { return phase_seal_cursor_; }
 
+    //! Keep ``marked_io_`` in sync with ``mark_input`` / ``mark_output``.
+    void refresh_marked_io_(TensorNode const *node);
+
   private:
     std::string name_;
     std::vector<std::unique_ptr<TensorNode>> data_;
     std::vector<std::shared_ptr<TensorGraph::OpNode>> ops_;
+    //! Nodes with ``is_input || is_output`` for O(1) ``seal_phase`` carry.
+    std::unordered_set<TensorNode const *> marked_io_;
 
     NodeId next_data_id_ = 0;
     NodeId next_op_id_ = 0;

--- a/nntile/include/nntile/tensor/tensor_graph_tiling.hh
+++ b/nntile/include/nntile/tensor/tensor_graph_tiling.hh
@@ -67,8 +67,8 @@ public:
     Index tile_index_containing(Index dim, Index global_index) const;
 
     //! Stable string for comparing tiling of the same logical tensor across
-    //! phases (grid shape + segment lengths per axis).
-    std::string layout_fingerprint() const;
+    //! phases (grid shape + segment lengths per axis). Cached after first call.
+    std::string const &layout_fingerprint() const;
 
 private:
     std::vector<Index> shape_;
@@ -78,6 +78,7 @@ private:
     std::vector<std::vector<Index>> axis_origin_;
     std::vector<Index> grid_shape_;
     Index grid_volume_ = 1;
+    mutable std::string fingerprint_;
 };
 
 //! Maps each tensor data node to its axis layout (from merged AxisDescriptors).
@@ -91,6 +92,18 @@ public:
     static TensorGraphTiling from_phase(
         const TensorGraph& tg,
         const TensorGraph::PhaseSnapshot& phase);
+
+    //! Insert layouts for tensors touched by ``phase`` that are not already
+    //! present. Use with a session-scoped tiling shared_ptr so incremental
+    //! compile does not rebuild/copy layouts for stable carried tensors.
+    void ensure_phase_layouts(
+        const TensorGraph& tg,
+        const TensorGraph::PhaseSnapshot& phase);
+
+    void clear()
+    {
+        layouts_.clear();
+    }
 
     const TensorAxisLayout* find(const TensorGraph::TensorNode* node) const;
 

--- a/nntile/include/nntile/tile/append_tensor_graph_phase.hh
+++ b/nntile/include/nntile/tile/append_tensor_graph_phase.hh
@@ -61,13 +61,31 @@ struct TileGraphIncrementalState
 //! Append one sealed phase: ensure tile nodes for touched tensors (reuse when
 //! layout matches), then lower tensor ops in ``[phase.op_begin, phase.op_end)``.
 //! Updates \p state and \p tile_map in sync.
+//! Prefer the shared_ptr overload so the tiling map is not deep-copied.
 void append_tensor_graph_phase(
+    TensorGraph const& tg,
+    TensorGraph::PhaseSnapshot const& phase,
+    std::shared_ptr<TensorGraphTiling const> tiling,
+    TileGraph& tile_graph,
+    TileGraphIncrementalState& state,
+    TensorNodeToTileMap& tile_map);
+
+inline void append_tensor_graph_phase(
     TensorGraph const& tg,
     TensorGraph::PhaseSnapshot const& phase,
     TensorGraphTiling const& tiling,
     TileGraph& tile_graph,
     TileGraphIncrementalState& state,
-    TensorNodeToTileMap& tile_map);
+    TensorNodeToTileMap& tile_map)
+{
+    append_tensor_graph_phase(
+        tg,
+        phase,
+        std::make_shared<TensorGraphTiling>(tiling),
+        tile_graph,
+        state,
+        tile_map);
+}
 
 //! Lower \p exec_phase into ``tile_graph``, ``compile()`` \p runtime, optionally
 //! ``push_tensor_phase_archive`` on ``nn_graph_for_suffix``, then bump auto

--- a/nntile/include/nntile/tile/lower_staging_tensor.hh
+++ b/nntile/include/nntile/tile/lower_staging_tensor.hh
@@ -24,9 +24,26 @@ namespace nntile
 void lower_staging_tensor_immediate(
     TensorGraph const &tg,
     TensorGraph::TensorNode const *staging,
-    TensorGraphTiling const &tiling,
+    std::shared_ptr<TensorGraphTiling const> tiling,
     TileGraph &tile_graph,
     TileGraphIncrementalState &state,
     TensorNodeToTileMap &tile_map);
+
+inline void lower_staging_tensor_immediate(
+    TensorGraph const &tg,
+    TensorGraph::TensorNode const *staging,
+    TensorGraphTiling const &tiling,
+    TileGraph &tile_graph,
+    TileGraphIncrementalState &state,
+    TensorNodeToTileMap &tile_map)
+{
+    lower_staging_tensor_immediate(
+        tg,
+        staging,
+        std::make_shared<TensorGraphTiling>(tiling),
+        tile_graph,
+        state,
+        tile_map);
+}
 
 } // namespace nntile

--- a/nntile/src/core/adam_step.cc
+++ b/nntile/src/core/adam_step.cc
@@ -79,7 +79,7 @@ void adam_step(int starpu_worker_hint, Index num_iter, Scalar beta_1, Scalar bet
                const Tile<T> &p)
 {
     adam_step_async<T>(starpu_worker_hint, num_iter, beta_1, beta_2, eps, lr, weight_decay, grad, first_moment, second_moment, p);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/adamw_step.cc
+++ b/nntile/src/core/adamw_step.cc
@@ -79,7 +79,7 @@ void adamw_step(int starpu_worker_hint, Index num_iter, Scalar beta_1, Scalar be
                const Tile<T> &p)
 {
     adamw_step_async<T>(starpu_worker_hint, num_iter, beta_1, beta_2, eps, lr, weight_decay, grad, first_moment, second_moment, p);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/add.cc
+++ b/nntile/src/core/add.cc
@@ -71,7 +71,7 @@ void add(int starpu_worker_hint, Scalar alpha, const Tile<T> &src1, Scalar beta,
         const Tile<T> &dst)
 {
     add_async<T>(starpu_worker_hint, alpha, src1, beta, src2, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/add_fiber.cc
+++ b/nntile/src/core/add_fiber.cc
@@ -106,7 +106,7 @@ void add_fiber(int starpu_worker_hint, Scalar alpha, const Tile<T> &src1, Scalar
  * */
 {
     add_fiber_async<T>(starpu_worker_hint, alpha, src1, beta, src2, dst, axis, batch_ndim);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/add_fiber_inplace.cc
+++ b/nntile/src/core/add_fiber_inplace.cc
@@ -101,7 +101,7 @@ void add_fiber_inplace(int starpu_worker_hint, Scalar alpha, const Tile<T> &src,
  * */
 {
     add_fiber_inplace_async<T>(starpu_worker_hint, alpha, src, beta, dst, axis, batch_ndim);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/add_inplace.cc
+++ b/nntile/src/core/add_inplace.cc
@@ -58,7 +58,7 @@ void add_inplace(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, Scala
         const Tile<T> &dst)
 {
     add_inplace_async<T>(starpu_worker_hint, alpha, src, beta, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/add_slice.cc
+++ b/nntile/src/core/add_slice.cc
@@ -105,7 +105,7 @@ void add_slice(int starpu_worker_hint, Scalar alpha, const Tile<T> &src1, Scalar
  * */
 {
     add_slice_async<T>(starpu_worker_hint, alpha, src1, beta, src2, dst, axis);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/add_slice_inplace.cc
+++ b/nntile/src/core/add_slice_inplace.cc
@@ -94,7 +94,7 @@ void add_slice_inplace(int starpu_worker_hint, Scalar alpha, const Tile<T> &src,
  * */
 {
     add_slice_inplace_async<T>(starpu_worker_hint, alpha, src, beta, dst, axis);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/clear.cc
+++ b/nntile/src/core/clear.cc
@@ -36,7 +36,7 @@ template<typename T>
 void clear(int starpu_worker_hint, const Tile<T> &tile)
 {
     clear_async<T>(starpu_worker_hint, tile);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/conv2d_bwd_input_inplace.cc
+++ b/nntile/src/core/conv2d_bwd_input_inplace.cc
@@ -52,7 +52,7 @@ void conv2d_bwd_input_inplace(int starpu_worker_hint, Index src1_m, Index src1_n
             src1_channels, batch, src2_m, src2_n, dilation_m, dilation_n,
             dst_channels, offset_m, offset_n, alpha, src1, src2, dst_m, dst_n,
             beta, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/conv2d_bwd_weight_inplace.cc
+++ b/nntile/src/core/conv2d_bwd_weight_inplace.cc
@@ -52,7 +52,7 @@ void conv2d_bwd_weight_inplace(int starpu_worker_hint, Index src1_m, Index src1_
             src2_m, src2_n, stride_m, stride_n, src2_channels, offset_m,
             offset_n, alpha, src1, src2, dst_m, dst_n, dilation_m, dilation_n,
             beta, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/conv2d_inplace.cc
+++ b/nntile/src/core/conv2d_inplace.cc
@@ -51,7 +51,7 @@ void conv2d_inplace(int starpu_worker_hint, Index src1_m, Index src1_n, Index sr
     conv2d_inplace_async<T>(starpu_worker_hint, src1_m, src1_n, src1_channels, batch, src2_m,
             src2_n, dilation_m, dilation_n, dst_channels, offset_m, offset_n,
             alpha, src1, src2, dst_m, dst_n, stride_m, stride_n, beta, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/copy.cc
+++ b/nntile/src/core/copy.cc
@@ -52,7 +52,7 @@ template<typename T>
 void copy(int starpu_worker_hint, const Tile<T> &src, const Tile<T> &dst)
 {
     copy_async<T>(starpu_worker_hint, src, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/copy_intersection.cc
+++ b/nntile/src/core/copy_intersection.cc
@@ -161,7 +161,7 @@ void copy_intersection(int starpu_worker_hint, const Tile<T> &src,
         const std::vector<Index> &dst_offset, const Tile<int64_t> &scratch)
 {
     copy_intersection_async<T>(starpu_worker_hint, src, src_offset, dst, dst_offset, scratch);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/embedding.cc
+++ b/nntile/src/core/embedding.cc
@@ -41,7 +41,7 @@ void embedding(int starpu_worker_hint, Index m, Index n, Index k, Index k_start,
         const Tile<T> &embed)
 {
     embedding_async<T>(starpu_worker_hint, m, n, k, k_start, k_size, index, vocab, embed);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/embedding_backward.cc
+++ b/nntile/src/core/embedding_backward.cc
@@ -42,7 +42,7 @@ void embedding_backward(int starpu_worker_hint, Index m, Index n, Index k, Index
 {
     embedding_backward_async<T>(starpu_worker_hint, m, n, k, k_start, k_size, index, embed, vocab,
             redux);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/fill.cc
+++ b/nntile/src/core/fill.cc
@@ -41,7 +41,7 @@ template<typename T>
 void fill(int starpu_worker_hint, Scalar val, const Tile<T> &A)
 {
     fill_async<T>(starpu_worker_hint, val, A);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/flash_sdpa_bwd_cudnn.cc
+++ b/nntile/src/core/flash_sdpa_bwd_cudnn.cc
@@ -150,7 +150,7 @@ void flash_sdpa_bwd_cudnn(int starpu_worker_hint,
 {
     flash_sdpa_bwd_cudnn_async<T>(starpu_worker_hint, 
         K, Q, V, A, dA, mask, logsumexp, dK, dQ, dV);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 template

--- a/nntile/src/core/flash_sdpa_fwd_cudnn.cc
+++ b/nntile/src/core/flash_sdpa_fwd_cudnn.cc
@@ -209,7 +209,7 @@ void flash_sdpa_fwd_cudnn(int starpu_worker_hint, const Tile<T> &K, const Tile<T
         const Tile<T> &A)
 {
     flash_sdpa_fwd_cudnn_async<T>(starpu_worker_hint, K, Q, mask, logsumexp, V, A);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/gelu.cc
+++ b/nntile/src/core/gelu.cc
@@ -44,7 +44,7 @@ template<typename T>
 void gelu(int starpu_worker_hint, const Tile<T> &src, const Tile<T> &dst)
 {
     gelu_async<T>(starpu_worker_hint, src, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/gelu_backward.cc
+++ b/nntile/src/core/gelu_backward.cc
@@ -53,7 +53,7 @@ template<typename T>
 void gelu_backward(int starpu_worker_hint, const Tile<T> &x, const Tile<T> &dy, const Tile<T> &dx)
 {
     gelu_backward_async<T>(starpu_worker_hint, x, dy, dx);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/gelu_inplace.cc
+++ b/nntile/src/core/gelu_inplace.cc
@@ -41,7 +41,7 @@ template<typename T>
 void gelu_inplace(int starpu_worker_hint, const Tile<T> &A)
 {
     gelu_inplace_async<T>(starpu_worker_hint, A);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/gelutanh.cc
+++ b/nntile/src/core/gelutanh.cc
@@ -42,7 +42,7 @@ template<typename T>
 void gelutanh(int starpu_worker_hint, const Tile<T> &src, const Tile<T> &dst)
 {
     gelutanh_async<T>(starpu_worker_hint, src, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/gelutanh_backward.cc
+++ b/nntile/src/core/gelutanh_backward.cc
@@ -53,7 +53,7 @@ template<typename T>
 void gelutanh_backward(int starpu_worker_hint, const Tile<T> &x, const Tile<T> &dy, const Tile<T> &dx)
 {
     gelutanh_backward_async<T>(starpu_worker_hint, x, dy, dx);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/gelutanh_inplace.cc
+++ b/nntile/src/core/gelutanh_inplace.cc
@@ -41,7 +41,7 @@ template<typename T>
 void gelutanh_inplace(int starpu_worker_hint, const Tile<T> &A)
 {
     gelutanh_inplace_async<T>(starpu_worker_hint, A);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/gemm.cc
+++ b/nntile/src/core/gemm.cc
@@ -417,7 +417,7 @@ void gemm(int starpu_worker_hint, Scalar alpha, const TransOp &transA, const Til
 {
     gemm_async<T>(starpu_worker_hint, alpha, transA, A, transB, B, beta, C, ndim, batch_ndim,
             redux);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/hypot.cc
+++ b/nntile/src/core/hypot.cc
@@ -53,7 +53,7 @@ template<typename T>
 void hypot(int starpu_worker_hint, Scalar alpha, const Tile<T> &src1, Scalar beta, const Tile<T> &src2, const Tile<T> &dst)
 {
     hypot_async<T>(starpu_worker_hint, alpha, src1, beta, src2, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/hypot_inplace.cc
+++ b/nntile/src/core/hypot_inplace.cc
@@ -57,7 +57,7 @@ template<typename T>
 void hypot_inplace(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, Scalar beta, const Tile<T> &dst)
 {
     hypot_inplace_async<T>(starpu_worker_hint, alpha, src, beta, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/hypot_scalar_inverse.cc
+++ b/nntile/src/core/hypot_scalar_inverse.cc
@@ -35,7 +35,7 @@ template<typename T>
 void hypot_scalar_inverse(int starpu_worker_hint, Scalar eps, Scalar alpha, const Tile<T> &dst)
 {
     hypot_scalar_inverse_async<T>(starpu_worker_hint, eps, alpha, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/isfinite.cc
+++ b/nntile/src/core/isfinite.cc
@@ -43,7 +43,7 @@ template<typename T>
 void isfinite(int starpu_worker_hint, const Tile<T> &A, const Tile<bool_t> &flag)
 {
     isfinite_async<T>(starpu_worker_hint, A, flag);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/log_scalar.cc
+++ b/nntile/src/core/log_scalar.cc
@@ -39,7 +39,7 @@ template<typename T>
 void log_scalar(int starpu_worker_hint, const std::string &name, const Tile<T> &value)
 {
     log_scalar_async<T>(starpu_worker_hint, name, value);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/logsumexp.cc
+++ b/nntile/src/core/logsumexp.cc
@@ -60,7 +60,7 @@ template<typename T>
 void logsumexp(int starpu_worker_hint, const Tile<T> &src, const Tile<T> &dst)
 {
     logsumexp_async<T>(starpu_worker_hint, src, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/mask_scalar.cc
+++ b/nntile/src/core/mask_scalar.cc
@@ -77,7 +77,7 @@ void mask_scalar(int starpu_worker_hint, const Tile<bool_t> &mask, Scalar val, c
         Index batch_ndim)
 {
     mask_scalar_async<T>(starpu_worker_hint, mask, val, A, batch_ndim);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/maxsumexp.cc
+++ b/nntile/src/core/maxsumexp.cc
@@ -83,7 +83,7 @@ template<typename T>
 void maxsumexp(int starpu_worker_hint, const Tile<T> &src, const Tile<T> &dst, Index axis, int redux)
 {
     maxsumexp_async<T>(starpu_worker_hint, src, dst, axis, redux);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/multiply.cc
+++ b/nntile/src/core/multiply.cc
@@ -50,7 +50,7 @@ void multiply(int starpu_worker_hint, Scalar alpha, const Tile<T> &src1, const T
         const Tile<T> &dst)
 {
     multiply_async<T>(starpu_worker_hint, alpha, src1, src2, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/multiply_fiber.cc
+++ b/nntile/src/core/multiply_fiber.cc
@@ -91,7 +91,7 @@ void multiply_fiber(int starpu_worker_hint, Scalar alpha, const Tile<T> &src1, c
  * */
 {
     multiply_fiber_async<T>(starpu_worker_hint, alpha, src1, src2, dst, axis);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/multiply_fiber_inplace.cc
+++ b/nntile/src/core/multiply_fiber_inplace.cc
@@ -81,7 +81,7 @@ void multiply_fiber_inplace(int starpu_worker_hint, Scalar alpha, const Tile<T> 
  * */
 {
     multiply_fiber_inplace_async<T>(starpu_worker_hint, alpha, src, dst, axis);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/multiply_inplace.cc
+++ b/nntile/src/core/multiply_inplace.cc
@@ -52,7 +52,7 @@ template<typename T>
 void multiply_inplace(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, const Tile<T> &dst)
 {
     multiply_inplace_async<T>(starpu_worker_hint, alpha, src, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/multiply_slice.cc
+++ b/nntile/src/core/multiply_slice.cc
@@ -90,7 +90,7 @@ void multiply_slice(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, co
  * */
 {
     multiply_slice_async<T>(starpu_worker_hint, alpha, src, dst, axis);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/norm.cc
+++ b/nntile/src/core/norm.cc
@@ -45,7 +45,7 @@ template<typename T>
 void norm(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, Scalar beta, const Tile<T> &dst)
 {
     norm_async<T>(starpu_worker_hint, alpha, src, beta, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/norm_fiber.cc
+++ b/nntile/src/core/norm_fiber.cc
@@ -83,7 +83,7 @@ void norm_fiber(int starpu_worker_hint, Scalar alpha, const Tile<T> &src1, Scala
         Index axis, Index batch_ndim, int redux)
 {
     norm_fiber_async<T>(starpu_worker_hint, alpha, src1, beta, src2, dst, axis, batch_ndim, redux);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/norm_fiber_inplace.cc
+++ b/nntile/src/core/norm_fiber_inplace.cc
@@ -81,7 +81,7 @@ void norm_fiber_inplace(int starpu_worker_hint, Scalar alpha, const Tile<T> &src
         Index axis, Index batch_ndim, int redux)
 {
     norm_fiber_inplace_async<T>(starpu_worker_hint, alpha, src, beta, dst, axis, batch_ndim, redux);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/norm_slice.cc
+++ b/nntile/src/core/norm_slice.cc
@@ -92,7 +92,7 @@ void norm_slice(int starpu_worker_hint, Scalar alpha, const Tile<T> &src1, Scala
         const Tile<T> &dst, Index axis, int redux)
 {
     norm_slice_async<T>(starpu_worker_hint, alpha, src1, beta, src2, dst, axis, redux);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/norm_slice_inplace.cc
+++ b/nntile/src/core/norm_slice_inplace.cc
@@ -79,7 +79,7 @@ void norm_slice_inplace(int starpu_worker_hint, Scalar alpha, const Tile<T> &src
         Index axis, int redux)
 {
     norm_slice_inplace_async<T>(starpu_worker_hint, alpha, src, beta, dst, axis, redux);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/pow.cc
+++ b/nntile/src/core/pow.cc
@@ -41,7 +41,7 @@ template<typename T>
 void pow(int starpu_worker_hint, Scalar alpha, Scalar exp, const Tile<T> &A)
 {
     pow_async<T>(starpu_worker_hint, alpha, exp, A);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/randn.cc
+++ b/nntile/src/core/randn.cc
@@ -106,7 +106,7 @@ void randn(int starpu_worker_hint, const Tile<T> &dst, const std::vector<Index> 
         Scalar mean, Scalar stddev)
 {
     randn_async<T>(starpu_worker_hint, dst, start, underlying_shape, seed, mean, stddev);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/relu.cc
+++ b/nntile/src/core/relu.cc
@@ -41,7 +41,7 @@ template<typename T>
 void relu(int starpu_worker_hint, const Tile<T> &src, const Tile<T> &dst)
 {
     relu_async<T>(starpu_worker_hint, src, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/relu_backward.cc
+++ b/nntile/src/core/relu_backward.cc
@@ -53,7 +53,7 @@ template<typename T>
 void relu_backward(int starpu_worker_hint, const Tile<T> &x, const Tile<T> &dy, const Tile<T> &dx)
 {
     relu_backward_async<T>(starpu_worker_hint, x, dy, dx);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/relu_inplace.cc
+++ b/nntile/src/core/relu_inplace.cc
@@ -41,7 +41,7 @@ template<typename T>
 void relu_inplace(int starpu_worker_hint, const Tile<T> &A)
 {
     relu_inplace_async<T>(starpu_worker_hint, A);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/rope.cc
+++ b/nntile/src/core/rope.cc
@@ -115,7 +115,7 @@ void rope(int starpu_worker_hint, const Tile<T> &sin, const Tile<T> &cos, const 
  * */
 {
     rope_async<T>(starpu_worker_hint, sin, cos, src, dst, sin_pair0);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/rope_backward.cc
+++ b/nntile/src/core/rope_backward.cc
@@ -95,7 +95,7 @@ void rope_backward(int starpu_worker_hint, const Tile<T> &sin, const Tile<T> &co
         const Tile<T> &dx, Index sin_pair0)
 {
     rope_backward_async<T>(starpu_worker_hint, sin, cos, dy, dx, sin_pair0);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/scale.cc
+++ b/nntile/src/core/scale.cc
@@ -51,7 +51,7 @@ template<typename T>
 void scale(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, const Tile<T> &dst)
 {
     scale_async<T>(starpu_worker_hint, alpha, src, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/scale_fiber.cc
+++ b/nntile/src/core/scale_fiber.cc
@@ -101,7 +101,7 @@ void scale_fiber(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, const
  * */
 {
     scale_fiber_async<T>(starpu_worker_hint, alpha, src, dst, axis, batch_ndim);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/core/scale_inplace.cc
+++ b/nntile/src/core/scale_inplace.cc
@@ -37,7 +37,7 @@ template<typename T>
 void scale_inplace(int starpu_worker_hint, Scalar alpha, const Tile<T> &data)
 {
     scale_inplace_async<T>(starpu_worker_hint, alpha, data);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/scale_slice.cc
+++ b/nntile/src/core/scale_slice.cc
@@ -102,7 +102,7 @@ void scale_slice(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, const
  * */
 {
     scale_slice_async<T>(starpu_worker_hint, alpha, src, dst, axis);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/sgd_step.cc
+++ b/nntile/src/core/sgd_step.cc
@@ -71,7 +71,7 @@ void sgd_step(int starpu_worker_hint, Index num_iter, Scalar momentum, Scalar lr
                const Tile<T> &p)
 {
     sgd_step_async<T>(starpu_worker_hint, num_iter, momentum, lr, weight_decay, dampening, nesterov, grad, velocity, p);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/silu.cc
+++ b/nntile/src/core/silu.cc
@@ -41,7 +41,7 @@ template<typename T>
 void silu(int starpu_worker_hint, const Tile<T> &src, const Tile<T> &dst)
 {
     silu_async<T>(starpu_worker_hint, src, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/silu_backward.cc
+++ b/nntile/src/core/silu_backward.cc
@@ -53,7 +53,7 @@ template<typename T>
 void silu_backward(int starpu_worker_hint, const Tile<T> &x, const Tile<T> &dy, const Tile<T> &dx)
 {
     silu_backward_async<T>(starpu_worker_hint, x, dy, dx);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/silu_inplace.cc
+++ b/nntile/src/core/silu_inplace.cc
@@ -41,7 +41,7 @@ template<typename T>
 void silu_inplace(int starpu_worker_hint, const Tile<T> &A)
 {
     silu_inplace_async<T>(starpu_worker_hint, A);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/softmax.cc
+++ b/nntile/src/core/softmax.cc
@@ -93,7 +93,7 @@ void softmax(int starpu_worker_hint, const Tile<T> &maxsumexp, const Tile<T> &sr
         const Tile<T> &dst, Index axis)
 {
     softmax_async<T>(starpu_worker_hint, maxsumexp, src, alpha, dst, axis);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/softmax_inplace.cc
+++ b/nntile/src/core/softmax_inplace.cc
@@ -84,7 +84,7 @@ void softmax_inplace(int starpu_worker_hint, const Tile<T> &maxsumexp, Scalar al
         Index axis)
 {
     softmax_inplace_async<T>(starpu_worker_hint, maxsumexp, alpha, dst, axis);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/sqrt.cc
+++ b/nntile/src/core/sqrt.cc
@@ -42,7 +42,7 @@ template<typename T>
 void sqrt(int starpu_worker_hint, const Tile<T> &src, const Tile<T> &dst)
 {
     sqrt_async<T>(starpu_worker_hint, src, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/sqrt_inplace.cc
+++ b/nntile/src/core/sqrt_inplace.cc
@@ -41,7 +41,7 @@ template<typename T>
 void sqrt_inplace(int starpu_worker_hint, const Tile<T> &A)
 {
     sqrt_inplace_async<T>(starpu_worker_hint, A);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/subtract_indexed_outputs.cc
+++ b/nntile/src/core/subtract_indexed_outputs.cc
@@ -50,7 +50,7 @@ void subtract_indexed_outputs(int starpu_worker_hint, Scalar val, const Tile<int
         const Tile<T> &dst, Index ignore_index)
 {
     subtract_indexed_outputs_async<T>(starpu_worker_hint, val, labels, dst, ignore_index);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/sum.cc
+++ b/nntile/src/core/sum.cc
@@ -45,7 +45,7 @@ template<typename T>
 void sum(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, Scalar beta, const Tile<T> &dst)
 {
     sum_async<T>(starpu_worker_hint, alpha, src, beta, dst);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/sum_fiber.cc
+++ b/nntile/src/core/sum_fiber.cc
@@ -81,7 +81,7 @@ void sum_fiber(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, Scalar 
         Index axis, Index batch_ndim, int redux)
 {
     sum_fiber_async<T>(starpu_worker_hint, alpha, src, beta, dst, axis, batch_ndim, redux);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/sum_slice.cc
+++ b/nntile/src/core/sum_slice.cc
@@ -86,7 +86,7 @@ void sum_slice(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, Scalar 
         Index axis, int redux)
 {
     sum_slice_async<T>(starpu_worker_hint, alpha, src, beta, dst, axis, redux);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/sumprod_fiber.cc
+++ b/nntile/src/core/sumprod_fiber.cc
@@ -76,7 +76,7 @@ void sumprod_fiber(int starpu_worker_hint, Scalar alpha, const Tile<T> &src1, co
         const Tile<T> &dst, Index axis, int redux)
 {
     sumprod_fiber_async<T>(starpu_worker_hint, alpha, src1, src2, beta, dst, axis, redux);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/sumprod_slice.cc
+++ b/nntile/src/core/sumprod_slice.cc
@@ -85,7 +85,7 @@ void sumprod_slice(int starpu_worker_hint, Scalar alpha, const Tile<T> &src1, co
         const Tile<T> &dst, Index axis, int redux)
 {
     sumprod_slice_async<T>(starpu_worker_hint, alpha, src1, src2, beta, dst, axis, redux);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/swap_two_axes.cc
+++ b/nntile/src/core/swap_two_axes.cc
@@ -69,7 +69,7 @@ void swap_two_axes(
     Index dim1)
 {
     swap_two_axes_async<T>(starpu_worker_hint, src, dst, dim0, dim1);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 template

--- a/nntile/src/core/total_sum_accum.cc
+++ b/nntile/src/core/total_sum_accum.cc
@@ -73,7 +73,7 @@ void total_sum_accum(int starpu_worker_hint, Scalar alpha, const Tile<T> &logsum
 {
     total_sum_accum_async<T>(starpu_worker_hint, alpha, logsumexp, src, class_labels, val,
                              ignore_index);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation

--- a/nntile/src/core/transpose.cc
+++ b/nntile/src/core/transpose.cc
@@ -59,7 +59,7 @@ void transpose(int starpu_worker_hint, Scalar alpha, const Tile<T> &src, const T
         Index ndim)
 {
     transpose_async<T>(starpu_worker_hint, alpha, src, dst, ndim);
-    starpu_task_wait_for_all();
+    nntile::starpu_task_wait_for_all_unless_deferred();
 }
 
 // Explicit instantiation of template

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -134,8 +134,10 @@ void Runtime::compile()
 
 void Runtime::sync_tile_marks_from_logical()
 {
-    // Sync only descriptors reachable from allocated tiles or the pending
-    // op slice — do not walk every historical TensorDescriptor.
+    // Sync only descriptors touched by the pending op slice. Walking
+    // tile_map_ every compile was O(allocated history) and duplicated mark
+    // refresh already done in append_tensor_graph_phase for carried tensors.
+    // Unmarked phase outputs are reclaimed via pending_output_reclaim.
     std::unordered_set<const TileGraph::TensorDescriptor *> synced;
 
     auto sync_tile = [&](const TileGraph::TileNode *tile_key)
@@ -171,12 +173,6 @@ void Runtime::sync_tile_marks_from_logical()
             tile->mark_output(is_out);
         }
     };
-
-    for (const auto &[tile, tile_ptr] : tile_map_)
-    {
-        (void)tile_ptr;
-        sync_tile(tile);
-    }
 
     const size_t n = execution_order_.size();
     const size_t begin =
@@ -1036,20 +1032,27 @@ void Runtime::eliminate_dead_ops()
         }
     }
 
-    std::vector<std::shared_ptr<OpNode>> filtered;
-    filtered.reserve(pending_begin + live_ops.size());
-    for (size_t i = 0; i < pending_begin; ++i)
+    // Keep the executed prefix in place. Rebuilding the full vector every
+    // compile recopied O(history) shared_ptrs and made step time grow.
+    if (live_ops.size() == n - pending_begin)
     {
-        filtered.push_back(execution_order_[i]);
+        live_tile_nodes_ = std::move(live_data);
+        return;
     }
+    size_t write = pending_begin;
     for (size_t i = pending_begin; i < n; ++i)
     {
-        if (live_ops.count(i))
+        if (live_ops.count(i) == 0)
         {
-            filtered.push_back(execution_order_[i]);
+            continue;
         }
+        if (write != i)
+        {
+            execution_order_[write] = std::move(execution_order_[i]);
+        }
+        ++write;
     }
-    execution_order_ = std::move(filtered);
+    execution_order_.resize(write);
     live_tile_nodes_ = std::move(live_data);
 }
 

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -17,6 +17,7 @@
 
 #include "nntile/core/execution_schedule.hh"
 #include "nntile/core/execution_worker.hh"
+#include "nntile/starpu/sync_defer.hh"
 
 // TileGraph::get_tensor_descriptor is inline in graph.hh; this TU must see
 // the definition when calling it on const TileGraph&.
@@ -755,6 +756,9 @@ void Runtime::execute_range(size_t op_begin, size_t op_end)
     {
         throw std::out_of_range("Runtime::execute_range: bad range");
     }
+    // Submit only: core sync wrappers skip wait_for_all while deferred so
+    // torch_nntile run() can return before StarPU finishes the phase.
+    StarpuSyncDefer defer_waits;
     bool const use_static_schedule = has_execution_schedule();
     for (size_t i = op_begin; i < op_end; ++i)
     {
@@ -770,7 +774,7 @@ void Runtime::execute_range(size_t op_begin, size_t op_end)
             starpu_worker_hint_ = -1;
         }
         execution_order_[i]->execute(*this);
-        release_dead_tiles_after_op(i);
+        queue_dead_tiles_after_op(i);
     }
     if (op_end > executed_op_end_)
     {
@@ -787,24 +791,8 @@ void Runtime::execute()
     // compile may have skipped (pending slice was empty after a previous run).
     executed_op_end_ = 0;
     allocate_missing_tiles();
-    bool const use_static_schedule = has_execution_schedule();
-    for (size_t i = 0; i < execution_order_.size(); ++i)
-    {
-        if (use_static_schedule)
-        {
-            starpu_worker_hint_ = sched::starpu_worker_id_for_scheduled_op(
-                execution_schedule_.worker_for_op(i),
-                execution_schedule_.use_cuda_workers,
-                execution_order_[i]->op_name());
-        }
-        else
-        {
-            starpu_worker_hint_ = -1;
-        }
-        execution_order_[i]->execute(*this);
-        release_dead_tiles_after_op(i);
-    }
-    executed_op_end_ = execution_order_.size();
+    execute_range(0, execution_order_.size());
+    wait();
 }
 
 void Runtime::build_tile_last_consumer_map()
@@ -883,9 +871,16 @@ void Runtime::invalidate_tile_buffer(
 
 void Runtime::release_dead_tiles_after_op(size_t op_idx)
 {
-    starpu_task_wait_for_all();
-    std::vector<const TileGraph::TileNode *> to_release;
-    to_release.reserve(tile_last_consumer_op_.size());
+    queue_dead_tiles_after_op(op_idx);
+    if (g_starpu_sync_defer_depth == 0)
+    {
+        starpu_task_wait_for_all();
+        flush_queued_dead_tiles();
+    }
+}
+
+void Runtime::queue_dead_tiles_after_op(size_t op_idx)
+{
     for (const auto &[tile, last_op] : tile_last_consumer_op_)
     {
         if (last_op != op_idx)
@@ -896,9 +891,17 @@ void Runtime::release_dead_tiles_after_op(size_t op_idx)
         {
             continue;
         }
-        to_release.push_back(tile);
+        queued_dead_tiles_.push_back(tile);
     }
-    for (const TileGraph::TileNode *tile : to_release)
+}
+
+void Runtime::flush_queued_dead_tiles()
+{
+    if (queued_dead_tiles_.empty())
+    {
+        return;
+    }
+    for (const TileGraph::TileNode *tile : queued_dead_tiles_)
     {
         auto it = tile_map_.find(tile);
         if (it == tile_map_.end())
@@ -908,6 +911,7 @@ void Runtime::release_dead_tiles_after_op(size_t op_idx)
         invalidate_tile_buffer(tile, it->second);
         tile_map_.erase(it);
     }
+    queued_dead_tiles_.clear();
 }
 
 void Runtime::eliminate_dead_ops()
@@ -1056,6 +1060,10 @@ void Runtime::eliminate_dead_ops()
     live_tile_nodes_ = std::move(live_data);
 }
 
-void Runtime::wait() { starpu_task_wait_for_all(); }
+void Runtime::wait()
+{
+    starpu_task_wait_for_all();
+    flush_queued_dead_tiles();
+}
 
 } // namespace nntile

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -135,10 +135,10 @@ void Runtime::compile()
 
 void Runtime::sync_tile_marks_from_logical()
 {
-    // Sync only descriptors touched by the pending op slice. Walking
-    // tile_map_ every compile was O(allocated history) and duplicated mark
-    // refresh already done in append_tensor_graph_phase for carried tensors.
-    // Unmarked phase outputs are reclaimed via pending_output_reclaim.
+    // Sync descriptors for the pending op slice and for any allocated tile
+    // whose logical mark flipped to unmarked (held-across-compile outputs
+    // that NodeRefs later dropped). Avoid a full historical TensorDescriptor
+    // walk; tile_map_ is bounded by live allocations.
     std::unordered_set<const TileGraph::TensorDescriptor *> synced;
 
     auto sync_tile = [&](const TileGraph::TileNode *tile_key)
@@ -188,6 +188,35 @@ void Runtime::sync_tile_marks_from_logical()
         {
             sync_tile(out);
         }
+    }
+
+    // Refresh marks on allocated tiles not touched by the pending slice so
+    // last-consumer reclaim sees mark_output(false) after Python drops refs.
+    for (const auto &[tile, tile_ptr] : tile_map_)
+    {
+        (void)tile_ptr;
+        if (tile == nullptr)
+        {
+            continue;
+        }
+        auto *mutable_tile = const_cast<TileGraph::TileNode *>(tile);
+        const TileGraph::TensorDescriptor *desc =
+            mutable_tile->tensor_descriptor();
+        if (desc == nullptr || desc->source_node == nullptr)
+        {
+            continue;
+        }
+        if (synced.count(desc) != 0)
+        {
+            continue;
+        }
+        // Only sync when the logical is unmarked — carried/live marks were
+        // refreshed by append_tensor_graph_phase for the current phase.
+        if (desc->source_node->is_input() || desc->source_node->is_output())
+        {
+            continue;
+        }
+        sync_tile(tile);
     }
 }
 

--- a/nntile/src/tensor/tensor_graph_tiling.cc
+++ b/nntile/src/tensor/tensor_graph_tiling.cc
@@ -15,8 +15,8 @@
 #include "nntile/tensor/tensor_graph_tiling.hh"
 
 #include <algorithm>
-#include <set>
 #include <sstream>
+#include <unordered_set>
 
 #include "nntile/tensor/axis_descriptor.hh"
 #include "nntile/tensor/graph.hh"
@@ -204,8 +204,12 @@ Index TensorAxisLayout::tile_index_containing(
     return static_cast<Index>((it - origin.begin()) - 1);
 }
 
-std::string TensorAxisLayout::layout_fingerprint() const
+std::string const &TensorAxisLayout::layout_fingerprint() const
 {
+    if(!fingerprint_.empty())
+    {
+        return fingerprint_;
+    }
     std::ostringstream o;
     for(Index g : grid_shape_)
     {
@@ -220,7 +224,8 @@ std::string TensorAxisLayout::layout_fingerprint() const
         }
         o << ';';
     }
-    return o.str();
+    fingerprint_ = o.str();
+    return fingerprint_;
 }
 
 void TensorAxisLayout::tile_axis_global_range(
@@ -250,12 +255,14 @@ TensorGraphTiling TensorGraphTiling::from_tensor_graph(const TensorGraph& tg)
     return out;
 }
 
-TensorGraphTiling TensorGraphTiling::from_phase(
-    const TensorGraph& tg,
-    const TensorGraph::PhaseSnapshot& phase)
+namespace
 {
-    TensorGraphTiling out;
-    std::set<const TensorGraph::TensorNode*> touched;
+
+void collect_phase_touched(
+    const TensorGraph& tg,
+    const TensorGraph::PhaseSnapshot& phase,
+    std::unordered_set<const TensorGraph::TensorNode*>& touched)
+{
     for(const TensorGraph::TensorNode* t : phase.carried_tensors)
     {
         if(t != nullptr)
@@ -285,11 +292,33 @@ TensorGraphTiling TensorGraphTiling::from_phase(
             }
         }
     }
+}
+
+} // namespace
+
+TensorGraphTiling TensorGraphTiling::from_phase(
+    const TensorGraph& tg,
+    const TensorGraph::PhaseSnapshot& phase)
+{
+    TensorGraphTiling out;
+    out.ensure_phase_layouts(tg, phase);
+    return out;
+}
+
+void TensorGraphTiling::ensure_phase_layouts(
+    const TensorGraph& tg,
+    const TensorGraph::PhaseSnapshot& phase)
+{
+    std::unordered_set<const TensorGraph::TensorNode*> touched;
+    collect_phase_touched(tg, phase, touched);
     for(const TensorGraph::TensorNode* t : touched)
     {
-        out.layouts_.emplace(t, TensorAxisLayout(t));
+        if(layouts_.count(t) != 0)
+        {
+            continue;
+        }
+        layouts_.emplace(t, TensorAxisLayout(t));
     }
-    return out;
 }
 
 const TensorAxisLayout* TensorGraphTiling::find(

--- a/nntile/src/tile/append_tensor_graph_phase.cc
+++ b/nntile/src/tile/append_tensor_graph_phase.cc
@@ -149,7 +149,7 @@ std::vector<TileGraph::TileNode*> build_tile_nodes(
 void append_tensor_graph_phase(
     TensorGraph const& tg,
     TensorGraph::PhaseSnapshot const& phase,
-    TensorGraphTiling const& tiling,
+    std::shared_ptr<TensorGraphTiling const> tiling,
     TileGraph& tile_graph,
     TileGraphIncrementalState& state,
     TensorNodeToTileMap& tile_map)
@@ -164,23 +164,27 @@ void append_tensor_graph_phase(
         throw std::out_of_range(
             "append_tensor_graph_phase: phase.op_end > num_ops");
     }
+    if(tiling == nullptr)
+    {
+        throw std::invalid_argument(
+            "append_tensor_graph_phase: tiling must be non-null");
+    }
 
-    tile_graph.set_tiling_scheme(
-        std::make_shared<TensorGraphTiling>(tiling));
+    tile_graph.set_tiling_scheme(tiling);
 
     std::set<TensorGraph::TensorNode const*> touched;
     collect_phase_tensors(tg, phase, touched);
 
     for(TensorGraph::TensorNode const* t : touched)
     {
-        const TensorAxisLayout* lay = tiling.find(t);
+        const TensorAxisLayout* lay = tiling->find(t);
         if(lay == nullptr)
         {
             throw std::runtime_error(
                 "append_tensor_graph_phase: missing tiling for tensor '" +
                 t->name() + "'");
         }
-        const std::string fp = lay->layout_fingerprint();
+        std::string const& fp = lay->layout_fingerprint();
         auto fp_it = state.tensor_layout_fp.find(t);
         const bool have_tiles =
             state.tensor_to_tiles.count(t) != 0 &&

--- a/nntile/src/tile/lower_staging_tensor.cc
+++ b/nntile/src/tile/lower_staging_tensor.cc
@@ -95,7 +95,7 @@ std::vector<TileGraph::TileNode *> build_tile_nodes(
 void lower_staging_tensor_immediate(
     TensorGraph const &tg,
     TensorGraph::TensorNode const *staging,
-    TensorGraphTiling const &tiling,
+    std::shared_ptr<TensorGraphTiling const> tiling,
     TileGraph &tile_graph,
     TileGraphIncrementalState &state,
     TensorNodeToTileMap &tile_map)
@@ -106,7 +106,12 @@ void lower_staging_tensor_immediate(
         throw std::invalid_argument(
             "lower_staging_tensor_immediate: staging must be non-null");
     }
-    const TensorAxisLayout *lay = tiling.find(staging);
+    if (tiling == nullptr)
+    {
+        throw std::invalid_argument(
+            "lower_staging_tensor_immediate: tiling must be non-null");
+    }
+    const TensorAxisLayout *lay = tiling->find(staging);
     if (lay == nullptr)
     {
         throw std::runtime_error(
@@ -119,10 +124,9 @@ void lower_staging_tensor_immediate(
             "lower_staging_tensor_immediate: staging must be single-tile");
     }
 
-    tile_graph.set_tiling_scheme(
-        std::make_shared<TensorGraphTiling>(tiling));
+    tile_graph.set_tiling_scheme(tiling);
 
-    const std::string fp = lay->layout_fingerprint();
+    std::string const &fp = lay->layout_fingerprint();
     auto fp_it = state.tensor_layout_fp.find(staging);
     const bool have_tiles =
         state.tensor_to_tiles.count(staging) != 0 &&

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -285,6 +285,7 @@ then set tile sizes by group name before ``compile_graph()``.
 | `set_axis_group_tiling(name, tile_sizes)` | Uniform `int` or heterogeneous `list` |
 | `format_axis_groups()` | String summary of pending axis groups |
 | `print_axis_groups()` | Print summary (includes `pending_tile=` before compile) |
+| `print_info()` | Print cumulative `compile_graph` / `run` / `wait` / host-readout timing |
 
 ```python
 torch_nntile.init_context(

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -268,9 +268,9 @@ Architecture reference:
   phase outputs and, after ``wait()`` (and again at the next compile), calls
   ``invalidate_logical_tiles`` on snapshot entries that are no longer marked.
 - **Reduce footprint:** ``del`` step temporaries after ``wait()`` so reclaim
-  sees cleared ``mark_output``. Prefer ``gc.collect(0)`` over a full
-  ``gc.collect()`` (full collections scale with session size and can dominate
-  step time). ``train_full_batch_step`` already drops logits after each step.
+  sees cleared ``mark_output``. Do not call ``gc.collect()`` in the training
+  step loop (it scales with session size and can dominate step time).
+  ``train_full_batch_step`` already drops logits after each step.
 
 ### Axis-group naming and tiling
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -268,8 +268,9 @@ Architecture reference:
   phase outputs and, after ``wait()`` (and again at the next compile), calls
   ``invalidate_logical_tiles`` on snapshot entries that are no longer marked.
 - **Reduce footprint:** ``del`` step temporaries after ``wait()`` so reclaim
-  sees cleared ``mark_output``. ``train_full_batch_step`` already drops logits
-  after each step.
+  sees cleared ``mark_output``. Prefer ``gc.collect(0)`` over a full
+  ``gc.collect()`` (full collections scale with session size and can dominate
+  step time). ``train_full_batch_step`` already drops logits after each step.
 
 ### Axis-group naming and tiling
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -217,28 +217,31 @@ Use this to verify that a model forward uses only nntile kernels.
 
 All ops record into a shared ``TensorGraph``. Flush with ``compile_graph()`` and
 ``run()`` (or the legacy one-shot ``execute()``) before relying on tile side
-effects other than host readout.
+effects other than host readout. ``run()`` **submits asynchronously** and does
+not wait; call ``wait()`` before host readout or the next dependent phase
+(``.to("cpu")`` also waits).
 
 ```python
 torch_nntile.init_context(ncpu=1, ncuda=0, cpu_fallback=False)
 y = model(x)              # recorded, not executed yet
 loss.backward()           # backward ops recorded too
 torch_nntile.compile_graph()
-torch_nntile.run()
+torch_nntile.run()        # async submit
+torch_nntile.wait()       # sync + post-run reclaim
 z = y.to("cpu")           # host readout (also auto-flushes if still pending)
 ```
 
 Forward and backward stay in one pending graph (StarPU resolves dependencies).
 Call ``torch_nntile.compile_graph()`` then ``torch_nntile.run()`` each step when
 you want an explicit compile boundary. Training helpers such as
-``train_full_batch_step`` call ``compile_graph()`` + ``run()`` and return
-``loss.to("cpu").item()``.
+``train_full_batch_step`` call ``compile_graph()`` + ``run()`` + ``wait()`` and
+return ``loss.to("cpu").item()``.
 
 **`.cpu()` / `.to("cpu")` auto-flush (by design):** host readout of a nntile
-tensor compiles and runs any still-pending ops, then records and runs
-`gather(L→S)` into an ephemeral staging node. You do not need a prior
-``compile_graph()``/``run()`` for correctness, but each readout permanently
-appends gather nodes to the session graph (see debt D1 in
+tensor waits for any in-flight ``run()``, compiles and runs any still-pending
+ops, then records and runs `gather(L→S)` into an ephemeral staging node. You do
+not need a prior ``compile_graph()``/``run()`` for correctness, but each
+readout permanently appends gather nodes to the session graph (see debt D1 in
 [torch_nntile_tensor_architecture.md](../docs/dev/torch_nntile_tensor_architecture.md)).
 
 Tests: `pytest -vv torch_nntile/tests/test_graph_execution.py`
@@ -262,9 +265,9 @@ Architecture reference:
   their last consumer when not marked as inputs/outputs.
 - On each ``compile_graph()``, ``Runtime`` refreshes tile marks from logical
   ``mark_output`` / ``mark_input`` for the pending slice. torch_nntile snapshots
-  phase outputs and, after ``run()`` (and again at the next compile), calls
+  phase outputs and, after ``wait()`` (and again at the next compile), calls
   ``invalidate_logical_tiles`` on snapshot entries that are no longer marked.
-- **Reduce footprint:** ``del`` step temporaries after ``run()`` so reclaim
+- **Reduce footprint:** ``del`` step temporaries after ``wait()`` so reclaim
   sees cleared ``mark_output``. ``train_full_batch_step`` already drops logits
   after each step.
 

--- a/torch_nntile/csrc/nntile_context.cpp
+++ b/torch_nntile/csrc/nntile_context.cpp
@@ -137,12 +137,8 @@ void restore_where()
 
 void wait_for_all()
 {
-    std::lock_guard<std::mutex> lock(g_context_mutex);
-    if (g_context == nullptr || !starpu_is_initialized())
-    {
-        return;
-    }
-    starpu_task_wait_for_all();
+    // Finish async run() post-work (pin_hold / reclaim) then drain StarPU.
+    wait_graph_session();
 }
 
 void shutdown_context()

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -105,6 +105,10 @@ struct GraphApiTimingStats
     std::uint64_t compile_calls = 0;
     double compile_s = 0.0;
     std::uint64_t compile_ops = 0;
+    double compile_seal_s = 0.0;
+    double compile_tiling_s = 0.0;
+    double compile_append_s = 0.0;
+    double compile_runtime_s = 0.0;
     std::uint64_t run_calls = 0;
     double run_s = 0.0;
     std::uint64_t run_ops = 0;
@@ -802,15 +806,21 @@ void compile_graph_locked(
     sync_param_grad_aliases_locked();
     apply_pending_axis_tiling_locked();
 
+    SteadyClock::time_point t_part = SteadyClock::now();
     const nntile::TensorGraph::PhaseSnapshot phase = g_graph->seal_phase();
     std::vector<nntile::TensorGraph::TensorNode *> scatter_stagings;
     collect_scatter_stagings_from_phase_locked(phase, scatter_stagings);
     collect_pending_output_reclaim_locked(phase);
+    g_timing.compile_seal_s += seconds_since(t_part);
+
     // Phase-scoped tiling: full-graph from_tensor_graph rebuilt layouts for
     // every historical tensor node and made compile O(session length).
+    t_part = SteadyClock::now();
     const nntile::TensorGraphTiling tiling =
         nntile::TensorGraphTiling::from_phase(*g_graph, phase);
+    g_timing.compile_tiling_s += seconds_since(t_part);
 
+    t_part = SteadyClock::now();
     try
     {
         nntile::append_tensor_graph_phase(
@@ -835,9 +845,12 @@ void compile_graph_locked(
         }
         throw;
     }
+    g_timing.compile_append_s += seconds_since(t_part);
 
     g_exec->pending_exec_op_begin = g_exec->executed_op_end;
+    t_part = SteadyClock::now();
     g_exec->runtime->compile();
+    g_timing.compile_runtime_s += seconds_since(t_part);
     g_exec->pending_exec_op_end =
         g_exec->runtime->execution_op_count();
     g_exec->pending_scatter_stagings = std::move(scatter_stagings);
@@ -1623,6 +1636,25 @@ std::string format_info_locked()
        << g_timing.compile_s << "s"
        << " (avg " << avg_ms(g_timing.compile_s, g_timing.compile_calls)
        << " ms), tile-ops lowered=" << g_timing.compile_ops << '\n';
+    if (g_timing.compile_calls > 0)
+    {
+        ss << "    seal+reclaim: " << g_timing.compile_seal_s << "s"
+           << " (avg "
+           << avg_ms(g_timing.compile_seal_s, g_timing.compile_calls)
+           << " ms)\n";
+        ss << "    from_phase:   " << g_timing.compile_tiling_s << "s"
+           << " (avg "
+           << avg_ms(g_timing.compile_tiling_s, g_timing.compile_calls)
+           << " ms)\n";
+        ss << "    append_phase: " << g_timing.compile_append_s << "s"
+           << " (avg "
+           << avg_ms(g_timing.compile_append_s, g_timing.compile_calls)
+           << " ms)\n";
+        ss << "    runtime.compile: " << g_timing.compile_runtime_s << "s"
+           << " (avg "
+           << avg_ms(g_timing.compile_runtime_s, g_timing.compile_calls)
+           << " ms)\n";
+    }
     ss << "  run (submit):  " << g_timing.run_calls << " calls, "
        << g_timing.run_s << "s"
        << " (avg " << avg_ms(g_timing.run_s, g_timing.run_calls)

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -887,14 +887,14 @@ void finish_run_locked()
         g_run_cleanup_pending = false;
         return;
     }
-    SteadyClock::time_point const t0 = SteadyClock::now();
-    g_exec->runtime->wait();
+    // run() is asynchronous: only wait when a submit is still unfinished.
+    // Idle calls (e.g. redundant wait_for_all before .to("cpu")) are no-ops.
     if (!g_run_cleanup_pending)
     {
-        g_timing.wait_s += seconds_since(t0);
-        ++g_timing.wait_calls;
         return;
     }
+    SteadyClock::time_point const t0 = SteadyClock::now();
+    g_exec->runtime->wait();
     for (nntile::TensorGraph::TensorNode *staging :
         g_exec->pending_scatter_stagings)
     {
@@ -1630,7 +1630,7 @@ std::string format_info_locked()
     ss << "  wait:          " << g_timing.wait_calls << " calls, "
        << g_timing.wait_s << "s"
        << " (avg " << avg_ms(g_timing.wait_s, g_timing.wait_calls)
-       << " ms)\n";
+       << " ms; finishes a pending run() only)\n";
     ss << "  host_readout:  " << g_timing.host_readout_calls << " calls, "
        << g_timing.host_readout_s << "s"
        << " (avg "
@@ -1639,6 +1639,11 @@ std::string format_info_locked()
        << "compile/run/wait)\n";
     ss << "  sum compile+run+wait: "
        << (g_timing.compile_s + g_timing.run_s + g_timing.wait_s) << "s\n";
+    if (g_timing.run_calls > 0)
+    {
+        ss << "  note: wait_calls should be ≈ run_calls when callers avoid "
+           << "redundant wait(); idle wait() is a no-op\n";
+    }
 
     if (g_graph != nullptr)
     {

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -168,19 +168,33 @@ void collect_pending_output_reclaim_locked(
     {
         return;
     }
-    // Drain any unreclaimed candidates from a prior compile that never ran
-    // (or whose temps were dropped early) before replacing the list.
+    // Invalidate unmarked leftovers from a prior phase, but keep entries that
+    // are still marked (held across compile) so a later wait() can reclaim.
     reclaim_pending_outputs_locked();
-    g_exec->pending_output_reclaim.clear();
-    g_exec->pending_output_reclaim.reserve(phase.carried_tensors.size());
+    auto &reclaim = g_exec->pending_output_reclaim;
+    auto already = [&](nntile::TensorGraph::TensorNode *node) -> bool
+    {
+        for (nntile::TensorGraph::TensorNode *existing : reclaim)
+        {
+            if (existing == node)
+            {
+                return true;
+            }
+        }
+        return false;
+    };
+    reclaim.reserve(reclaim.size() + phase.carried_tensors.size());
     for (nntile::TensorGraph::TensorNode const *t : phase.carried_tensors)
     {
         if (t == nullptr || !t->is_output())
         {
             continue;
         }
-        g_exec->pending_output_reclaim.push_back(
-            const_cast<nntile::TensorGraph::TensorNode *>(t));
+        auto *mutable_t = const_cast<nntile::TensorGraph::TensorNode *>(t);
+        if (!already(mutable_t))
+        {
+            reclaim.push_back(mutable_t);
+        }
     }
 }
 
@@ -917,8 +931,11 @@ void run_graph_locked()
         g_timing.run_ops += phase_ops;
         g_exec->executed_op_end = g_exec->pending_exec_op_end;
         g_exec->pending_exec_op_begin = g_exec->pending_exec_op_end;
-        g_run_cleanup_pending = true;
     }
+    // Always require wait() for compile-side cleanup (pin_hold, reclaim,
+    // scatter stagings, deferred pending clear) — including empty post-DCE
+    // phases that submit no StarPU tasks.
+    g_run_cleanup_pending = true;
 }
 
 void finish_run_locked()

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -77,23 +77,25 @@ struct RecorderExecState
     std::unique_ptr<nntile::Runtime> runtime;
     nntile::TileGraphIncrementalState inc_state;
     nntile::TensorNodeToTileMap tile_map;
-    //! Pins transferred at compile; kept alive until run_graph() finishes.
+    //! Pins transferred at compile; kept alive until wait_graph_session().
     std::vector<at::Tensor> pin_hold;
     //! Post-DCE execution_order index already submitted via execute_range.
     std::size_t executed_op_end = 0;
     //! Slice scheduled by the latest compile_graph_locked call.
     std::size_t pending_exec_op_begin = 0;
     std::size_t pending_exec_op_end = 0;
-    //! Scatter staging tensors in the pending phase (invalidate after run).
+    //! Scatter staging tensors in the pending phase (invalidate after wait).
     std::vector<nntile::TensorGraph::TensorNode *> pending_scatter_stagings;
     //! Logical tensors that were mark_output(true) when the pending slice
-    //! was compiled. After run() drops step temps (pin_hold / NodeRef), any
+    //! was compiled. After wait() drops step temps (pin_hold / NodeRef), any
     //! entry that is no longer marked is invalidated once.
     std::vector<nntile::TensorGraph::TensorNode *> pending_output_reclaim;
 };
 
 std::unique_ptr<RecorderExecState> g_exec;
 bool g_defer_pending_clear_after_run = false;
+//! True after run_graph() until wait_graph_session() finishes post-run work.
+bool g_run_cleanup_pending = false;
 
 void reclaim_pending_outputs_locked()
 {
@@ -106,7 +108,7 @@ void reclaim_pending_outputs_locked()
         return;
     }
     nntile::Runtime &runtime = *g_exec->runtime;
-    // Temps are often del'd after run(); keep still-marked entries so the
+    // Temps are often del'd after wait(); keep still-marked entries so the
     // next compile/run can invalidate them once NodeRefs drop.
     std::vector<nntile::TensorGraph::TensorNode *> still_marked;
     still_marked.reserve(g_exec->pending_output_reclaim.size());
@@ -157,6 +159,8 @@ void compile_graph_locked(
     std::vector<at::Tensor> &pin_drop);
 
 void run_graph_locked();
+
+void finish_run_locked();
 
 void register_grad_alias_for_host_copy_locked(
     at::Tensor &grad,
@@ -752,6 +756,12 @@ void compile_graph_locked(
     bool clear_pending_after,
     std::vector<at::Tensor> &pin_drop)
 {
+    // A prior async run() must finish before sealing the next phase.
+    if (g_run_cleanup_pending)
+    {
+        finish_run_locked();
+    }
+
     if (g_graph == nullptr ||
         g_graph->num_ops() <= g_graph->phase_seal_cursor())
     {
@@ -817,24 +827,37 @@ void run_graph_locked()
     {
         return;
     }
+    // Submit only. Never wait here — callers use wait_graph_session() /
+    // torch_nntile.wait() for synchronization and post-run reclaim.
     if (g_exec->pending_exec_op_end > g_exec->pending_exec_op_begin)
     {
         g_exec->runtime->execute_range(
             g_exec->pending_exec_op_begin,
             g_exec->pending_exec_op_end);
-        g_exec->runtime->wait();
-        for (nntile::TensorGraph::TensorNode *staging :
-            g_exec->pending_scatter_stagings)
-        {
-            invalidate_staging_tile_submit_locked(staging);
-        }
-        g_exec->pending_scatter_stagings.clear();
         g_exec->executed_op_end = g_exec->pending_exec_op_end;
+        g_exec->pending_exec_op_begin = g_exec->pending_exec_op_end;
+        g_run_cleanup_pending = true;
     }
-    else
+}
+
+void finish_run_locked()
+{
+    if (g_exec == nullptr || g_exec->runtime == nullptr)
     {
-        g_exec->runtime->wait();
+        g_run_cleanup_pending = false;
+        return;
     }
+    g_exec->runtime->wait();
+    if (!g_run_cleanup_pending)
+    {
+        return;
+    }
+    for (nntile::TensorGraph::TensorNode *staging :
+        g_exec->pending_scatter_stagings)
+    {
+        invalidate_staging_tile_submit_locked(staging);
+    }
+    g_exec->pending_scatter_stagings.clear();
     if (g_defer_pending_clear_after_run)
     {
         std::vector<at::Tensor> pin_drop;
@@ -845,6 +868,7 @@ void run_graph_locked()
     // flips are visible before reclaim.
     g_exec->pin_hold.clear();
     reclaim_pending_outputs_locked();
+    g_run_cleanup_pending = false;
 }
 
 void reset_recorder_locked(
@@ -857,6 +881,7 @@ void reset_recorder_locked(
     {
         g_exec->runtime->wait();
     }
+    g_run_cleanup_pending = false;
     if (g_exec != nullptr)
     {
         g_exec->pin_hold.clear();
@@ -931,6 +956,9 @@ void execute_pending_graph_locked(std::vector<at::Tensor> &pin_drop)
 {
     compile_graph_locked(false, pin_drop);
     run_graph_locked();
+    // Legacy execute() flushes then clears recorder pins; wait first so
+    // scatter staging is done before host buffers are released.
+    finish_run_locked();
     clear_pending_graph_after_compile_locked(pin_drop);
 }
 
@@ -989,6 +1017,16 @@ void run_graph()
 {
     std::lock_guard<std::recursive_mutex> lock(g_recorder_mutex);
     run_graph_locked();
+}
+
+void wait_graph_session()
+{
+    std::lock_guard<std::recursive_mutex> lock(g_recorder_mutex);
+    finish_run_locked();
+    if (starpu_is_initialized())
+    {
+        starpu_task_wait_for_all();
+    }
 }
 
 void reset_graph_session()
@@ -1062,6 +1100,7 @@ void gather_logical_to_staging_and_read_locked(
     std::vector<at::Tensor> pin_drop;
     compile_graph_locked(false, pin_drop);
     run_graph_locked();
+    finish_run_locked();
 
     read_staging_to_host_locked(staging, host_ptr, dtype, count);
     invalidate_staging_tile_submit_locked(staging);
@@ -1090,6 +1129,7 @@ void copy_nntile_tensor_to_cpu(const at::Tensor &src, at::Tensor &dst)
         std::vector<at::Tensor> pin_drop;
         compile_graph_locked(false, pin_drop);
         run_graph_locked();
+        finish_run_locked();
     }
 
     if (g_exec == nullptr || g_exec->runtime == nullptr ||
@@ -1561,6 +1601,10 @@ void compile_graph()
 void run_graph()
 {
     require_libnntile();
+}
+
+void wait_graph_session()
+{
 }
 
 void reset_graph_session()

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -43,6 +43,9 @@ std::vector<Index> tile_sizes_for_axis_extent(
     Index extent);
 } // namespace nntile
 
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -96,6 +99,29 @@ std::unique_ptr<RecorderExecState> g_exec;
 bool g_defer_pending_clear_after_run = false;
 //! True after run_graph() until wait_graph_session() finishes post-run work.
 bool g_run_cleanup_pending = false;
+
+struct GraphApiTimingStats
+{
+    std::uint64_t compile_calls = 0;
+    double compile_s = 0.0;
+    std::uint64_t compile_ops = 0;
+    std::uint64_t run_calls = 0;
+    double run_s = 0.0;
+    std::uint64_t run_ops = 0;
+    std::uint64_t wait_calls = 0;
+    double wait_s = 0.0;
+    std::uint64_t host_readout_calls = 0;
+    double host_readout_s = 0.0;
+};
+
+GraphApiTimingStats g_timing;
+
+using SteadyClock = std::chrono::steady_clock;
+
+double seconds_since(SteadyClock::time_point const start)
+{
+    return std::chrono::duration<double>(SteadyClock::now() - start).count();
+}
 
 void reclaim_pending_outputs_locked()
 {
@@ -768,6 +794,8 @@ void compile_graph_locked(
         return;
     }
 
+    SteadyClock::time_point const t0 = SteadyClock::now();
+
     ensure_nntile_context();
     ensure_recorder_exec_state_locked();
 
@@ -819,6 +847,12 @@ void compile_graph_locked(
         transfer_pinned_tensors_locked(pin_drop);
         g_defer_pending_clear_after_run = true;
     }
+
+    std::uint64_t const phase_ops = static_cast<std::uint64_t>(
+        g_exec->pending_exec_op_end - g_exec->pending_exec_op_begin);
+    g_timing.compile_s += seconds_since(t0);
+    ++g_timing.compile_calls;
+    g_timing.compile_ops += phase_ops;
 }
 
 void run_graph_locked()
@@ -831,9 +865,15 @@ void run_graph_locked()
     // torch_nntile.wait() for synchronization and post-run reclaim.
     if (g_exec->pending_exec_op_end > g_exec->pending_exec_op_begin)
     {
+        std::uint64_t const phase_ops = static_cast<std::uint64_t>(
+            g_exec->pending_exec_op_end - g_exec->pending_exec_op_begin);
+        SteadyClock::time_point const t0 = SteadyClock::now();
         g_exec->runtime->execute_range(
             g_exec->pending_exec_op_begin,
             g_exec->pending_exec_op_end);
+        g_timing.run_s += seconds_since(t0);
+        ++g_timing.run_calls;
+        g_timing.run_ops += phase_ops;
         g_exec->executed_op_end = g_exec->pending_exec_op_end;
         g_exec->pending_exec_op_begin = g_exec->pending_exec_op_end;
         g_run_cleanup_pending = true;
@@ -847,9 +887,12 @@ void finish_run_locked()
         g_run_cleanup_pending = false;
         return;
     }
+    SteadyClock::time_point const t0 = SteadyClock::now();
     g_exec->runtime->wait();
     if (!g_run_cleanup_pending)
     {
+        g_timing.wait_s += seconds_since(t0);
+        ++g_timing.wait_calls;
         return;
     }
     for (nntile::TensorGraph::TensorNode *staging :
@@ -869,6 +912,8 @@ void finish_run_locked()
     g_exec->pin_hold.clear();
     reclaim_pending_outputs_locked();
     g_run_cleanup_pending = false;
+    g_timing.wait_s += seconds_since(t0);
+    ++g_timing.wait_calls;
 }
 
 void reset_recorder_locked(
@@ -1085,6 +1130,7 @@ void gather_logical_to_staging_and_read_locked(
         throw std::runtime_error(
             "torch_nntile: gather readout requires an active TensorGraph");
     }
+    SteadyClock::time_point const t0 = SteadyClock::now();
     nntile::TensorGraph::TensorNode *staging =
         new_ephemeral_staging_node_locked(logical, "readout");
     if (staging == nullptr)
@@ -1105,6 +1151,8 @@ void gather_logical_to_staging_and_read_locked(
     read_staging_to_host_locked(staging, host_ptr, dtype, count);
     invalidate_staging_tile_submit_locked(staging);
     staging->mark_output(false);
+    g_timing.host_readout_s += seconds_since(t0);
+    ++g_timing.host_readout_calls;
 }
 
 void copy_nntile_tensor_to_cpu(const at::Tensor &src, at::Tensor &dst)
@@ -1558,6 +1606,64 @@ void print_axis_groups()
     }
 }
 
+std::string format_info_locked()
+{
+    auto avg_ms = [](double seconds, std::uint64_t calls) -> double
+    {
+        if (calls == 0)
+        {
+            return 0.0;
+        }
+        return 1.0e3 * seconds / static_cast<double>(calls);
+    };
+
+    std::ostringstream ss;
+    ss << "torch_nntile graph API timing (cumulative):\n";
+    ss << "  compile_graph: " << g_timing.compile_calls << " calls, "
+       << g_timing.compile_s << "s"
+       << " (avg " << avg_ms(g_timing.compile_s, g_timing.compile_calls)
+       << " ms), tile-ops lowered=" << g_timing.compile_ops << '\n';
+    ss << "  run (submit):  " << g_timing.run_calls << " calls, "
+       << g_timing.run_s << "s"
+       << " (avg " << avg_ms(g_timing.run_s, g_timing.run_calls)
+       << " ms), tile-ops submitted=" << g_timing.run_ops << '\n';
+    ss << "  wait:          " << g_timing.wait_calls << " calls, "
+       << g_timing.wait_s << "s"
+       << " (avg " << avg_ms(g_timing.wait_s, g_timing.wait_calls)
+       << " ms)\n";
+    ss << "  host_readout:  " << g_timing.host_readout_calls << " calls, "
+       << g_timing.host_readout_s << "s"
+       << " (avg "
+       << avg_ms(g_timing.host_readout_s, g_timing.host_readout_calls)
+       << " ms; .to(\"cpu\") gather wall, includes nested "
+       << "compile/run/wait)\n";
+    ss << "  sum compile+run+wait: "
+       << (g_timing.compile_s + g_timing.run_s + g_timing.wait_s) << "s\n";
+
+    if (g_graph != nullptr)
+    {
+        ss << "  session tensor_graph_ops: " << g_graph->num_ops()
+           << " (seal_cursor=" << g_graph->phase_seal_cursor() << ")\n";
+    }
+    if (g_exec != nullptr && g_exec->runtime != nullptr)
+    {
+        ss << "  session executed_tile_ops: " << g_exec->executed_op_end
+           << " / " << g_exec->runtime->execution_op_count() << '\n';
+    }
+    return ss.str();
+}
+
+void print_info()
+{
+    std::string text;
+    {
+        std::lock_guard<std::recursive_mutex> lock(g_recorder_mutex);
+        text = format_info_locked();
+    }
+    std::fputs(text.c_str(), stdout);
+    std::fflush(stdout);
+}
+
 } // namespace torch_nntile
 
 #else
@@ -1696,6 +1802,10 @@ std::string format_axis_groups()
 void print_axis_groups()
 {
     require_libnntile();
+}
+
+void print_info()
+{
 }
 
 void shutdown_recorder()

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -637,6 +637,14 @@ bool should_pin_tensor_for_graph_locked(const at::Tensor &tensor)
 void pin_tensor_for_graph(const at::Tensor &tensor)
 {
     std::lock_guard<std::recursive_mutex> lock(g_recorder_mutex);
+    TensorImplKey const key = tensor_impl_key(tensor);
+    for (at::Tensor const &pinned : g_pinned_tensors)
+    {
+        if (tensor_impl_key(pinned) == key)
+        {
+            return;
+        }
+    }
     g_pinned_tensors.push_back(tensor);
 }
 

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -80,6 +80,8 @@ struct RecorderExecState
     std::unique_ptr<nntile::Runtime> runtime;
     nntile::TileGraphIncrementalState inc_state;
     nntile::TensorNodeToTileMap tile_map;
+    //! Session-scoped layouts; ensure_phase_layouts only adds new tensors.
+    std::shared_ptr<nntile::TensorGraphTiling> session_tiling;
     //! Pins transferred at compile; kept alive until wait_graph_session().
     std::vector<at::Tensor> pin_hold;
     //! Post-DCE execution_order index already submitted via execute_range.
@@ -276,6 +278,7 @@ void apply_pending_axis_tiling_locked()
         return;
     }
 
+    bool applied_any = false;
     for (const auto &[name, pattern] : g_axis_tiling_by_name)
     {
         bool found_any = false;
@@ -286,6 +289,7 @@ void apply_pending_axis_tiling_locked()
                 continue;
             }
             found_any = true;
+            applied_any = true;
             const std::vector<nntile::Index> resolved =
                 nntile::tile_sizes_for_axis_extent(pattern, axis->extent);
             nntile::apply_tiling_to_axis(axis, resolved);
@@ -296,6 +300,12 @@ void apply_pending_axis_tiling_locked()
                 "torch_nntile set_axis_group_tiling: unknown axis group '" +
                 name + "'");
         }
+    }
+    // Axis tile_sizes changed: drop cached layouts so the next ensure rebuilds
+    // from the updated AxisDescriptors.
+    if (applied_any && g_exec != nullptr && g_exec->session_tiling != nullptr)
+    {
+        g_exec->session_tiling->clear();
     }
 }
 
@@ -368,12 +378,16 @@ void lower_io_staging_locked(nntile::TensorGraph::TensorNode *staging)
     staging_phase.op_begin = g_graph->num_ops();
     staging_phase.op_end = staging_phase.op_begin;
     staging_phase.carried_tensors = {staging};
-    const nntile::TensorGraphTiling tiling =
-        nntile::TensorGraphTiling::from_phase(*g_graph, staging_phase);
+    if (g_exec->session_tiling == nullptr)
+    {
+        g_exec->session_tiling =
+            std::make_shared<nntile::TensorGraphTiling>();
+    }
+    g_exec->session_tiling->ensure_phase_layouts(*g_graph, staging_phase);
     nntile::lower_staging_tensor_immediate(
         *g_graph,
         staging,
-        tiling,
+        g_exec->session_tiling,
         *g_exec->tile_graph,
         g_exec->inc_state,
         g_exec->tile_map);
@@ -815,9 +829,15 @@ void compile_graph_locked(
 
     // Phase-scoped tiling: full-graph from_tensor_graph rebuilt layouts for
     // every historical tensor node and made compile O(session length).
+    // Session-scoped tiling only constructs layouts for newly touched tensors
+    // and is shared into TileGraph (no per-compile deep copy).
     t_part = SteadyClock::now();
-    const nntile::TensorGraphTiling tiling =
-        nntile::TensorGraphTiling::from_phase(*g_graph, phase);
+    if (g_exec->session_tiling == nullptr)
+    {
+        g_exec->session_tiling =
+            std::make_shared<nntile::TensorGraphTiling>();
+    }
+    g_exec->session_tiling->ensure_phase_layouts(*g_graph, phase);
     g_timing.compile_tiling_s += seconds_since(t_part);
 
     t_part = SteadyClock::now();
@@ -826,7 +846,7 @@ void compile_graph_locked(
         nntile::append_tensor_graph_phase(
             *g_graph,
             phase,
-            tiling,
+            g_exec->session_tiling,
             *g_exec->tile_graph,
             g_exec->inc_state,
             g_exec->tile_map);

--- a/torch_nntile/csrc/nntile_graph_recorder.h
+++ b/torch_nntile/csrc/nntile_graph_recorder.h
@@ -57,6 +57,8 @@ std::string format_axis_groups();
 
 void print_axis_groups();
 
+void print_info();
+
 void copy_nntile_tensor_to_cpu(const at::Tensor &src, at::Tensor &dst);
 
 } // namespace torch_nntile

--- a/torch_nntile/csrc/nntile_graph_recorder.h
+++ b/torch_nntile/csrc/nntile_graph_recorder.h
@@ -31,6 +31,10 @@ void compile_graph();
 
 void run_graph();
 
+//! Block until submitted run() tasks finish; then reclaim / release pin holds.
+//! Prefer ``torch_nntile.wait()`` / ``wait_for_all()`` which call this.
+void wait_graph_session();
+
 void reset_graph_session();
 
 void shutdown_recorder();

--- a/torch_nntile/csrc/nntile_kernels.cpp
+++ b/torch_nntile/csrc/nntile_kernels.cpp
@@ -410,7 +410,8 @@ at::Tensor copy_from(
 #ifdef TORCH_NNTILE_USE_LIBNNTILE
         if (has_graph_session())
         {
-            wait_for_all();
+            // run() is async; do not wait_for_all here. copy_nntile_tensor_to_cpu
+            // / gather compile finishes any pending run before readout.
             copy_nntile_tensor_to_cpu(self, mutable_dst);
             return dst;
         }

--- a/torch_nntile/csrc/nntile_module.cpp
+++ b/torch_nntile/csrc/nntile_module.cpp
@@ -222,7 +222,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def(
         "run",
         &torch_nntile::run_graph,
-        "Execute the compiled graph session (no data transfer)");
+        "Submit the compiled graph to StarPU (asynchronous; does not wait)");
     m.def(
         "reset_graph_session",
         &torch_nntile::reset_graph_session,
@@ -251,6 +251,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         "print_axis_groups",
         &torch_nntile::print_axis_groups,
         "Print pending TensorGraph axis groups to stdout");
+    m.def(
+        "print_info",
+        &torch_nntile::print_info,
+        "Print cumulative compile/run/wait/host-readout timing stats");
     m.def(
         "gemm_forward",
         &torch_nntile::gemm_forward,

--- a/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
+++ b/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
@@ -218,7 +218,10 @@ def evaluate_nntile(
             loss_cpu = float(loss.to("cpu").item())
         del logits
         del loss
-        gc.collect()
+        # Full gc.collect() scans the whole heap and dominates step time as the
+        # session graph grows; generation-0 is enough to drop young cycles so
+        # ~NNTileBinding can mark_output(false) for reclaim.
+        gc.collect(0)
         total_loss += loss_cpu
         total_correct += int(
             (logits_cpu.argmax(dim=1) == labels_cpu).sum().item()
@@ -434,6 +437,12 @@ def train_nntile(
     last_test_acc = float("nan")
     train_step_s = 0.0
     eval_wall_s = 0.0
+    record_s = 0.0
+    compile_s = 0.0
+    run_s = 0.0
+    wait_s = 0.0
+    readout_s = 0.0
+    gc_s = 0.0
     # Host-side previous log: (step, accuracy, loss, lr). Printed only after
     # the next step has been ordered. Do not keep nntile logits/loss across
     # the next compile_graph() — that blocks pending_output_reclaim.
@@ -450,13 +459,22 @@ def train_nntile(
         images, labels, labels_cpu = next(batches)
 
         t_step0 = time.perf_counter()
+        t0 = time.perf_counter()
         optimizer.zero_grad(set_to_none=True)
         logits = model(images)
         loss_current = cross_entropy(logits, labels)
         loss_current.backward()
         optimizer.step()
+        record_s += time.perf_counter() - t0
+
+        t0 = time.perf_counter()
         torch_nntile.compile_graph()
+        compile_s += time.perf_counter() - t0
+
+        t0 = time.perf_counter()
         torch_nntile.run()
+        run_s += time.perf_counter() - t0
+
         # Current step is submitted asynchronously. Print the previous host
         # log here so it overlaps with StarPU compute; wait() syncs below.
         if pending_log is not None:
@@ -466,10 +484,14 @@ def train_nntile(
                 f"loss={prev_loss:.4f} (lr={prev_lr:.6f})"
             )
             pending_log = None
+
+        t0 = time.perf_counter()
         torch_nntile.wait()
+        wait_s += time.perf_counter() - t0
 
         is_last = step == steps
         if step % train_log_every == 0 or is_last:
+            t0 = time.perf_counter()
             with torch.no_grad():
                 logits_cpu = logits.to("cpu")
                 loss_val = float(loss_current.to("cpu").item())
@@ -479,6 +501,7 @@ def train_nntile(
                     .mean()
                     .item()
                 )
+            readout_s += time.perf_counter() - t0
             snapshot = (step, train_acc, loss_val, lr)
             if is_last:
                 final_log = snapshot
@@ -489,7 +512,11 @@ def train_nntile(
         # pending_output_reclaim pass (end of this run / start of next compile).
         del logits
         del loss_current
-        gc.collect()
+        t0 = time.perf_counter()
+        # Full gc.collect() dominates step time on long sessions; gen0 is enough
+        # for young autograd cycles so bindings can mark_output(false).
+        gc.collect(0)
+        gc_s += time.perf_counter() - t0
         train_step_s += time.perf_counter() - t_step0
 
         if step % test_every == 0:
@@ -515,14 +542,20 @@ def train_nntile(
         f"loss={final_loss:.4f} (lr={final_lr:.6f})"
     )
 
+    n_steps = steps + 1
     print(
         f"timing nntile train wall: {wall_s:.3f}s "
-        f"(steps+eval+logging over {steps + 1} steps)"
+        f"(steps+eval+logging over {n_steps} steps)"
     )
     print(
         f"timing nntile train steps: {train_step_s:.3f}s "
-        f"({train_step_s / (steps + 1) * 1e3:.2f} ms/step, "
-        f"includes compile/run/wait, host readout, gc; excludes eval)"
+        f"({train_step_s / n_steps * 1e3:.2f} ms/step, excludes eval)"
+    )
+    print(
+        f"timing nntile step breakdown: "
+        f"record={record_s:.3f}s compile={compile_s:.3f}s "
+        f"run={run_s:.3f}s wait={wait_s:.3f}s "
+        f"readout={readout_s:.3f}s gc={gc_s:.3f}s"
     )
     print(f"timing nntile eval wall: {eval_wall_s:.3f}s")
     torch_nntile.print_info()

--- a/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
+++ b/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
@@ -175,23 +175,22 @@ def evaluate_torch(
     batches: list[tuple[torch.Tensor, torch.Tensor]],
     device: torch.device,
 ) -> tuple[float, float, float]:
-    """Evaluate on preloaded device batches; return loss, acc, compute seconds."""
+    """Evaluate on preloaded device batches; return loss, acc, wall seconds."""
     model.eval()
     total_loss = 0.0
     total_correct = 0
     total = 0
-    compute_s = 0.0
+    t0 = time.perf_counter()
     for images, labels in batches:
-        t0 = time.perf_counter()
         logits = model(images)
         loss = F.cross_entropy(logits, labels, reduction="sum")
         synchronize_device(device)
-        compute_s += time.perf_counter() - t0
         total_loss += float(loss.item())
         total_correct += int((logits.argmax(dim=1) == labels).sum().item())
         total += labels.numel()
+    wall_s = time.perf_counter() - t0
     model.train()
-    return total_loss / total, total_correct / total, compute_s
+    return total_loss / total, total_correct / total, wall_s
 
 
 @torch.no_grad()
@@ -199,7 +198,7 @@ def evaluate_nntile(
     model: nn.Module,
     nntile_batches: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
 ) -> tuple[float, float, float]:
-    """Evaluate on preloaded nntile batches; return loss, acc, compute seconds."""
+    """Evaluate on preloaded nntile batches; return loss, acc, wall seconds."""
     import torch_nntile
     from torch_nntile.training import cross_entropy
 
@@ -207,16 +206,13 @@ def evaluate_nntile(
     total_loss = 0.0
     total_correct = 0
     total = 0
-    compute_s = 0.0
+    t0 = time.perf_counter()
     for images, labels, labels_cpu in nntile_batches:
-        t0 = time.perf_counter()
         logits = model(images)
         loss = cross_entropy(logits, labels, reduction="sum")
         torch_nntile.compile_graph()
         torch_nntile.run()
         torch_nntile.wait()
-        compute_s += time.perf_counter() - t0
-
         with torch.no_grad():
             logits_cpu = logits.to("cpu")
             loss_cpu = float(loss.to("cpu").item())
@@ -228,8 +224,9 @@ def evaluate_nntile(
             (logits_cpu.argmax(dim=1) == labels_cpu).sum().item()
         )
         total += labels_cpu.numel()
+    wall_s = time.perf_counter() - t0
     model.train()
-    return total_loss / total, total_correct / total, compute_s
+    return total_loss / total, total_correct / total, wall_s
 
 
 def parse_args() -> argparse.Namespace:
@@ -311,21 +308,22 @@ def train_torch(
 
     Returns
     -------
-    max_test_acc, last_test_acc, last_test_loss, train_compute_s, eval_compute_s
+    max_test_acc, last_test_acc, last_test_loss, train_wall_s, eval_wall_s
     """
     optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate(0))
     batches = cycle_batches(train_batches)
     max_test_acc = 0.0
     last_test_loss = float("nan")
     last_test_acc = float("nan")
-    train_compute_s = 0.0
-    eval_compute_s = 0.0
+    train_step_s = 0.0
+    eval_wall_s = 0.0
     # Host-side previous log: (step, accuracy, loss, lr). Printed only after
     # the next step has been ordered.
     pending_log: tuple[int, float, float, float] | None = None
     final_log: tuple[int, float, float, float] | None = None
     model.train()
 
+    t_wall0 = time.perf_counter()
     for step in range(steps + 1):
         lr = learning_rate(step)
         for group in optimizer.param_groups:
@@ -333,14 +331,13 @@ def train_torch(
 
         images, labels = next(batches)
 
-        t0 = time.perf_counter()
+        t_step0 = time.perf_counter()
         optimizer.zero_grad(set_to_none=True)
         logits = model(images)
         loss_current = F.cross_entropy(logits, labels)
         loss_current.backward()
         optimizer.step()
         synchronize_device(device)
-        train_compute_s += time.perf_counter() - t0
 
         # Current step ordered: emit previous train log if any.
         if pending_log is not None:
@@ -363,12 +360,13 @@ def train_torch(
                 final_log = snapshot
             else:
                 pending_log = snapshot
+        train_step_s += time.perf_counter() - t_step0
 
         if step % test_every == 0:
             test_loss, test_acc, eval_s = evaluate_torch(
                 model, test_batches, device
             )
-            eval_compute_s += eval_s
+            eval_wall_s += eval_s
             last_test_loss = test_loss
             last_test_acc = test_acc
             max_test_acc = max(max_test_acc, test_acc)
@@ -378,6 +376,8 @@ def train_torch(
                 f"test accuracy={test_acc:.4f} test loss={test_loss:.4f}"
             )
 
+    wall_s = time.perf_counter() - t_wall0
+
     assert final_log is not None
     _, final_acc, final_loss, final_lr = final_log
     print(
@@ -386,21 +386,21 @@ def train_torch(
     )
 
     print(
-        f"timing torch train compute: {train_compute_s:.3f}s "
-        f"({steps + 1} steps, {train_compute_s / (steps + 1) * 1e3:.2f} "
-        f"ms/step)"
+        f"timing torch train wall: {wall_s:.3f}s "
+        f"(steps+eval+logging over {steps + 1} steps)"
     )
-    print(f"timing torch eval compute: {eval_compute_s:.3f}s")
     print(
-        f"timing torch compute total "
-        f"(train+eval): {train_compute_s + eval_compute_s:.3f}s"
+        f"timing torch train steps: {train_step_s:.3f}s "
+        f"({train_step_s / (steps + 1) * 1e3:.2f} ms/step, "
+        f"excludes eval)"
     )
+    print(f"timing torch eval wall: {eval_wall_s:.3f}s")
     return (
         max_test_acc,
         last_test_acc,
         last_test_loss,
-        train_compute_s,
-        eval_compute_s,
+        wall_s,
+        eval_wall_s,
     )
 
 
@@ -432,9 +432,8 @@ def train_nntile(
     max_test_acc = 0.0
     last_test_loss = float("nan")
     last_test_acc = float("nan")
-    train_compute_s = 0.0
-    eval_compute_s = 0.0
-    host_readout_s = 0.0
+    train_step_s = 0.0
+    eval_wall_s = 0.0
     # Host-side previous log: (step, accuracy, loss, lr). Printed only after
     # the next step has been ordered. Do not keep nntile logits/loss across
     # the next compile_graph() — that blocks pending_output_reclaim.
@@ -442,6 +441,7 @@ def train_nntile(
     final_log: tuple[int, float, float, float] | None = None
     model.train()
 
+    t_wall0 = time.perf_counter()
     for step in range(steps + 1):
         lr = learning_rate(step)
         for group in optimizer.param_groups:
@@ -449,7 +449,7 @@ def train_nntile(
 
         images, labels, labels_cpu = next(batches)
 
-        t0 = time.perf_counter()
+        t_step0 = time.perf_counter()
         optimizer.zero_grad(set_to_none=True)
         logits = model(images)
         loss_current = cross_entropy(logits, labels)
@@ -467,11 +467,9 @@ def train_nntile(
             )
             pending_log = None
         torch_nntile.wait()
-        train_compute_s += time.perf_counter() - t0
 
         is_last = step == steps
         if step % train_log_every == 0 or is_last:
-            t1 = time.perf_counter()
             with torch.no_grad():
                 logits_cpu = logits.to("cpu")
                 loss_val = float(loss_current.to("cpu").item())
@@ -481,7 +479,6 @@ def train_nntile(
                     .mean()
                     .item()
                 )
-            host_readout_s += time.perf_counter() - t1
             snapshot = (step, train_acc, loss_val, lr)
             if is_last:
                 final_log = snapshot
@@ -493,12 +490,13 @@ def train_nntile(
         del logits
         del loss_current
         gc.collect()
+        train_step_s += time.perf_counter() - t_step0
 
         if step % test_every == 0:
             test_loss, test_acc, eval_s = evaluate_nntile(
                 model, test_batches
             )
-            eval_compute_s += eval_s
+            eval_wall_s += eval_s
             last_test_loss = test_loss
             last_test_acc = test_acc
             max_test_acc = max(max_test_acc, test_acc)
@@ -508,6 +506,8 @@ def train_nntile(
                 f"test accuracy={test_acc:.4f} test loss={test_loss:.4f}"
             )
 
+    wall_s = time.perf_counter() - t_wall0
+
     assert final_log is not None
     _, final_acc, final_loss, final_lr = final_log
     print(
@@ -516,22 +516,21 @@ def train_nntile(
     )
 
     print(
-        f"timing nntile train compute: {train_compute_s:.3f}s "
-        f"({steps + 1} steps, {train_compute_s / (steps + 1) * 1e3:.2f} "
-        f"ms/step)"
+        f"timing nntile train wall: {wall_s:.3f}s "
+        f"(steps+eval+logging over {steps + 1} steps)"
     )
-    print(f"timing nntile eval compute: {eval_compute_s:.3f}s")
-    print(f"timing nntile host readout (logs): {host_readout_s:.3f}s")
     print(
-        f"timing nntile compute total "
-        f"(train+eval): {train_compute_s + eval_compute_s:.3f}s"
+        f"timing nntile train steps: {train_step_s:.3f}s "
+        f"({train_step_s / (steps + 1) * 1e3:.2f} ms/step, "
+        f"includes compile/run/wait, host readout, gc; excludes eval)"
     )
+    print(f"timing nntile eval wall: {eval_wall_s:.3f}s")
     return (
         max_test_acc,
         last_test_acc,
         last_test_loss,
-        train_compute_s,
-        eval_compute_s,
+        wall_s,
+        eval_wall_s,
     )
 
 

--- a/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
+++ b/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
@@ -419,7 +419,7 @@ def train_nntile(
 
     Returns
     -------
-    max_test_acc, last_test_acc, last_test_loss, train_compute_s, eval_compute_s
+    max_test_acc, last_test_acc, last_test_loss, train_wall_s, eval_wall_s
     """
     import torch_nntile
     from torch_nntile.training import Adam, cross_entropy
@@ -525,6 +525,7 @@ def train_nntile(
         f"includes compile/run/wait, host readout, gc; excludes eval)"
     )
     print(f"timing nntile eval wall: {eval_wall_s:.3f}s")
+    torch_nntile.print_info()
     return (
         max_test_acc,
         last_test_acc,

--- a/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
+++ b/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
@@ -25,11 +25,13 @@ Supports ``--device cpu`` / ``cuda`` (PyTorch Adam) and ``--device nntile``
 (``torch_nntile.training.Adam`` + ``cross_entropy``, graph compile/run per
 step). Layers use ``nn.Linear`` with bias (nntile ``aten::linear`` bias path).
 
-Train loss logging is **double-buffered**: each step keeps ``loss_previous``
-and only prints it after the next step has ordered ``loss_current`` (forward +
-backward). The final ``loss_current`` is printed separately after the loop.
-Under nntile this defers host readout so a compiled graph can keep computing
-while previous loss data is consumed.
+Train loss logging is **double-buffered on the host**: after each step is
+ordered, the script prints the previous step's train metrics (when that step
+was a log step), then snapshots the current metrics to host scalars if needed.
+The final current loss is printed separately after the loop. Nntile step
+tensors (``logits`` / ``loss``) are still ``del``'d every iteration so
+``pending_output_reclaim`` can run — holding them across the next
+``compile_graph()`` would stall tile reclaim and inflate step time.
 
 On ``cpu`` / ``cuda`` / ``nntile``, all train/test batches (images + labels)
 are moved onto the training device **before** training. The script prints
@@ -318,11 +320,10 @@ def train_torch(
     last_test_acc = float("nan")
     train_compute_s = 0.0
     eval_compute_s = 0.0
-    loss_previous: torch.Tensor | None = None
-    logits_previous: torch.Tensor | None = None
-    labels_previous: torch.Tensor | None = None
-    prev_step: int | None = None
-    prev_lr: float | None = None
+    # Host-side previous log: (step, accuracy, loss, lr). Printed only after
+    # the next step has been ordered.
+    pending_log: tuple[int, float, float, float] | None = None
+    final_log: tuple[int, float, float, float] | None = None
     model.train()
 
     for step in range(steps + 1):
@@ -341,33 +342,27 @@ def train_torch(
         synchronize_device(device)
         train_compute_s += time.perf_counter() - t0
 
-        # Print previous only after current forward/backward is ordered.
-        if (
-            loss_previous is not None
-            and logits_previous is not None
-            and labels_previous is not None
-            and prev_step is not None
-            and prev_lr is not None
-            and prev_step % train_log_every == 0
-        ):
+        # Current step ordered: emit previous train log if any.
+        if pending_log is not None:
+            prev_step, prev_acc, prev_loss, prev_lr = pending_log
+            print(
+                f"{prev_step}: train accuracy={prev_acc:.4f} "
+                f"loss={prev_loss:.4f} (lr={prev_lr:.6f})"
+            )
+            pending_log = None
+
+        is_last = step == steps
+        if step % train_log_every == 0 or is_last:
             with torch.no_grad():
                 train_acc = float(
-                    (logits_previous.argmax(dim=1) == labels_previous)
-                    .float()
-                    .mean()
-                    .item()
+                    (logits.argmax(dim=1) == labels).float().mean().item()
                 )
-            print(
-                f"{prev_step}: train accuracy={train_acc:.4f} "
-                f"loss={float(loss_previous.detach()):.4f} "
-                f"(lr={prev_lr:.6f})"
-            )
-
-        loss_previous = loss_current
-        logits_previous = logits
-        labels_previous = labels
-        prev_step = step
-        prev_lr = lr
+                loss_val = float(loss_current.detach())
+            snapshot = (step, train_acc, loss_val, lr)
+            if is_last:
+                final_log = snapshot
+            else:
+                pending_log = snapshot
 
         if step % test_every == 0:
             test_loss, test_acc, eval_s = evaluate_torch(
@@ -383,22 +378,11 @@ def train_torch(
                 f"test accuracy={test_acc:.4f} test loss={test_loss:.4f}"
             )
 
-    # Final current loss (held in the previous buffer after the last shift).
-    assert loss_previous is not None
-    assert logits_previous is not None
-    assert labels_previous is not None
-    assert prev_lr is not None
-    with torch.no_grad():
-        final_train_acc = float(
-            (logits_previous.argmax(dim=1) == labels_previous)
-            .float()
-            .mean()
-            .item()
-        )
+    assert final_log is not None
+    _, final_acc, final_loss, final_lr = final_log
     print(
-        f"final: train accuracy={final_train_acc:.4f} "
-        f"loss={float(loss_previous.detach()):.4f} "
-        f"(lr={prev_lr:.6f})"
+        f"final: train accuracy={final_acc:.4f} "
+        f"loss={final_loss:.4f} (lr={final_lr:.6f})"
     )
 
     print(
@@ -451,11 +435,11 @@ def train_nntile(
     train_compute_s = 0.0
     eval_compute_s = 0.0
     host_readout_s = 0.0
-    loss_previous: torch.Tensor | None = None
-    logits_previous: torch.Tensor | None = None
-    labels_cpu_previous: torch.Tensor | None = None
-    prev_step: int | None = None
-    prev_lr: float | None = None
+    # Host-side previous log: (step, accuracy, loss, lr). Printed only after
+    # the next step has been ordered. Do not keep nntile logits/loss across
+    # the next compile_graph() — that blocks pending_output_reclaim.
+    pending_log: tuple[int, float, float, float] | None = None
+    final_log: tuple[int, float, float, float] | None = None
     model.train()
 
     for step in range(steps + 1):
@@ -473,49 +457,42 @@ def train_nntile(
         optimizer.step()
         torch_nntile.compile_graph()
         torch_nntile.run()
-        # Current step is ordered; read previous while the graph can run.
-        order_s = time.perf_counter() - t0
+        torch_nntile.wait()
+        train_compute_s += time.perf_counter() - t0
 
-        if (
-            loss_previous is not None
-            and logits_previous is not None
-            and prev_step is not None
-            and prev_lr is not None
-            and labels_cpu_previous is not None
-            and prev_step % train_log_every == 0
-        ):
+        # Current step ordered: emit previous train log if any.
+        if pending_log is not None:
+            prev_step, prev_acc, prev_loss, prev_lr = pending_log
+            print(
+                f"{prev_step}: train accuracy={prev_acc:.4f} "
+                f"loss={prev_loss:.4f} (lr={prev_lr:.6f})"
+            )
+            pending_log = None
+
+        is_last = step == steps
+        if step % train_log_every == 0 or is_last:
             t1 = time.perf_counter()
             with torch.no_grad():
-                logits_cpu = logits_previous.to("cpu")
-                loss_cpu = float(loss_previous.to("cpu").item())
+                logits_cpu = logits.to("cpu")
+                loss_val = float(loss_current.to("cpu").item())
                 train_acc = float(
-                    (logits_cpu.argmax(dim=1) == labels_cpu_previous)
+                    (logits_cpu.argmax(dim=1) == labels_cpu)
                     .float()
                     .mean()
                     .item()
                 )
             host_readout_s += time.perf_counter() - t1
-            print(
-                f"{prev_step}: train accuracy={train_acc:.4f} "
-                f"loss={loss_cpu:.4f} (lr={prev_lr:.6f})"
-            )
+            snapshot = (step, train_acc, loss_val, lr)
+            if is_last:
+                final_log = snapshot
+            else:
+                pending_log = snapshot
 
-        t_wait0 = time.perf_counter()
-        torch_nntile.wait()
-        train_compute_s += order_s + (time.perf_counter() - t_wait0)
-
-        # Drop previous-step temporaries so mark_output(false) is visible to
-        # pending_output_reclaim (end of this run / start of next compile).
-        if loss_previous is not None:
-            del loss_previous
-            del logits_previous
-            gc.collect()
-
-        loss_previous = loss_current
-        logits_previous = logits
-        labels_cpu_previous = labels_cpu
-        prev_step = step
-        prev_lr = lr
+        # Drop step temporaries so mark_output(false) is visible to the
+        # pending_output_reclaim pass (end of this run / start of next compile).
+        del logits
+        del loss_current
+        gc.collect()
 
         if step % test_every == 0:
             test_loss, test_acc, eval_s = evaluate_nntile(
@@ -531,29 +508,12 @@ def train_nntile(
                 f"test accuracy={test_acc:.4f} test loss={test_loss:.4f}"
             )
 
-    # Final current loss (held in the previous buffer after the last shift).
-    assert loss_previous is not None
-    assert logits_previous is not None
-    assert labels_cpu_previous is not None
-    assert prev_lr is not None
-    t1 = time.perf_counter()
-    with torch.no_grad():
-        logits_cpu = logits_previous.to("cpu")
-        loss_cpu = float(loss_previous.to("cpu").item())
-        final_train_acc = float(
-            (logits_cpu.argmax(dim=1) == labels_cpu_previous)
-            .float()
-            .mean()
-            .item()
-        )
-    host_readout_s += time.perf_counter() - t1
+    assert final_log is not None
+    _, final_acc, final_loss, final_lr = final_log
     print(
-        f"final: train accuracy={final_train_acc:.4f} "
-        f"loss={loss_cpu:.4f} (lr={prev_lr:.6f})"
+        f"final: train accuracy={final_acc:.4f} "
+        f"loss={final_loss:.4f} (lr={final_lr:.6f})"
     )
-    del logits_previous
-    del loss_previous
-    gc.collect()
 
     print(
         f"timing nntile train compute: {train_compute_s:.3f}s "

--- a/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
+++ b/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
@@ -25,13 +25,13 @@ Supports ``--device cpu`` / ``cuda`` (PyTorch Adam) and ``--device nntile``
 (``torch_nntile.training.Adam`` + ``cross_entropy``, graph compile/run per
 step). Layers use ``nn.Linear`` with bias (nntile ``aten::linear`` bias path).
 
-Train loss logging is **double-buffered on the host**: after each step is
-ordered, the script prints the previous step's train metrics (when that step
-was a log step), then snapshots the current metrics to host scalars if needed.
-The final current loss is printed separately after the loop. Nntile step
-tensors (``logits`` / ``loss``) are still ``del``'d every iteration so
-``pending_output_reclaim`` can run — holding them across the next
-``compile_graph()`` would stall tile reclaim and inflate step time.
+Train loss logging is **double-buffered on the host**: after ``run()``
+submits the current step (asynchronous), the script prints the previous
+step's train metrics so host I/O can overlap StarPU compute, then
+``wait()`` synchronizes. Current metrics are snapshotted to host scalars
+when needed; the final current loss is printed after the loop. Nntile
+step tensors (``logits`` / ``loss``) are ``del``'d every iteration so
+``pending_output_reclaim`` can run.
 
 On ``cpu`` / ``cuda`` / ``nntile``, all train/test batches (images + labels)
 are moved onto the training device **before** training. The script prints
@@ -457,10 +457,8 @@ def train_nntile(
         optimizer.step()
         torch_nntile.compile_graph()
         torch_nntile.run()
-        torch_nntile.wait()
-        train_compute_s += time.perf_counter() - t0
-
-        # Current step ordered: emit previous train log if any.
+        # Current step is submitted asynchronously. Print the previous host
+        # log here so it overlaps with StarPU compute; wait() syncs below.
         if pending_log is not None:
             prev_step, prev_acc, prev_loss, prev_lr = pending_log
             print(
@@ -468,6 +466,8 @@ def train_nntile(
                 f"loss={prev_loss:.4f} (lr={prev_lr:.6f})"
             )
             pending_log = None
+        torch_nntile.wait()
+        train_compute_s += time.perf_counter() - t0
 
         is_last = step == steps
         if step % train_log_every == 0 or is_last:

--- a/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
+++ b/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
@@ -25,6 +25,12 @@ Supports ``--device cpu`` / ``cuda`` (PyTorch Adam) and ``--device nntile``
 (``torch_nntile.training.Adam`` + ``cross_entropy``, graph compile/run per
 step). Layers use ``nn.Linear`` with bias (nntile ``aten::linear`` bias path).
 
+Train loss logging is **double-buffered**: each step keeps ``loss_previous``
+and only prints it after the next step has ordered ``loss_current`` (forward +
+backward). The final ``loss_current`` is printed separately after the loop.
+Under nntile this defers host readout so a compiled graph can keep computing
+while previous loss data is consumed.
+
 On ``cpu`` / ``cuda`` / ``nntile``, all train/test batches (images + labels)
 are moved onto the training device **before** training. The script prints
 data-preparation time separately from train/eval compute time.
@@ -312,6 +318,11 @@ def train_torch(
     last_test_acc = float("nan")
     train_compute_s = 0.0
     eval_compute_s = 0.0
+    loss_previous: torch.Tensor | None = None
+    logits_previous: torch.Tensor | None = None
+    labels_previous: torch.Tensor | None = None
+    prev_step: int | None = None
+    prev_lr: float | None = None
     model.train()
 
     for step in range(steps + 1):
@@ -324,21 +335,39 @@ def train_torch(
         t0 = time.perf_counter()
         optimizer.zero_grad(set_to_none=True)
         logits = model(images)
-        loss = F.cross_entropy(logits, labels)
-        loss.backward()
+        loss_current = F.cross_entropy(logits, labels)
+        loss_current.backward()
         optimizer.step()
         synchronize_device(device)
         train_compute_s += time.perf_counter() - t0
 
-        if step % train_log_every == 0:
+        # Print previous only after current forward/backward is ordered.
+        if (
+            loss_previous is not None
+            and logits_previous is not None
+            and labels_previous is not None
+            and prev_step is not None
+            and prev_lr is not None
+            and prev_step % train_log_every == 0
+        ):
             with torch.no_grad():
                 train_acc = float(
-                    (logits.argmax(dim=1) == labels).float().mean().item()
+                    (logits_previous.argmax(dim=1) == labels_previous)
+                    .float()
+                    .mean()
+                    .item()
                 )
             print(
-                f"{step}: train accuracy={train_acc:.4f} "
-                f"loss={float(loss.detach()):.4f} (lr={lr:.6f})"
+                f"{prev_step}: train accuracy={train_acc:.4f} "
+                f"loss={float(loss_previous.detach()):.4f} "
+                f"(lr={prev_lr:.6f})"
             )
+
+        loss_previous = loss_current
+        logits_previous = logits
+        labels_previous = labels
+        prev_step = step
+        prev_lr = lr
 
         if step % test_every == 0:
             test_loss, test_acc, eval_s = evaluate_torch(
@@ -353,6 +382,24 @@ def train_torch(
                 f"{step}: ********* epoch {epoch} ********* "
                 f"test accuracy={test_acc:.4f} test loss={test_loss:.4f}"
             )
+
+    # Final current loss (held in the previous buffer after the last shift).
+    assert loss_previous is not None
+    assert logits_previous is not None
+    assert labels_previous is not None
+    assert prev_lr is not None
+    with torch.no_grad():
+        final_train_acc = float(
+            (logits_previous.argmax(dim=1) == labels_previous)
+            .float()
+            .mean()
+            .item()
+        )
+    print(
+        f"final: train accuracy={final_train_acc:.4f} "
+        f"loss={float(loss_previous.detach()):.4f} "
+        f"(lr={prev_lr:.6f})"
+    )
 
     print(
         f"timing torch train compute: {train_compute_s:.3f}s "
@@ -404,6 +451,11 @@ def train_nntile(
     train_compute_s = 0.0
     eval_compute_s = 0.0
     host_readout_s = 0.0
+    loss_previous: torch.Tensor | None = None
+    logits_previous: torch.Tensor | None = None
+    labels_cpu_previous: torch.Tensor | None = None
+    prev_step: int | None = None
+    prev_lr: float | None = None
     model.train()
 
     for step in range(steps + 1):
@@ -416,36 +468,54 @@ def train_nntile(
         t0 = time.perf_counter()
         optimizer.zero_grad(set_to_none=True)
         logits = model(images)
-        loss = cross_entropy(logits, labels)
-        loss.backward()
+        loss_current = cross_entropy(logits, labels)
+        loss_current.backward()
         optimizer.step()
         torch_nntile.compile_graph()
         torch_nntile.run()
-        torch_nntile.wait()
-        train_compute_s += time.perf_counter() - t0
+        # Current step is ordered; read previous while the graph can run.
+        order_s = time.perf_counter() - t0
 
-        if step % train_log_every == 0:
+        if (
+            loss_previous is not None
+            and logits_previous is not None
+            and prev_step is not None
+            and prev_lr is not None
+            and labels_cpu_previous is not None
+            and prev_step % train_log_every == 0
+        ):
             t1 = time.perf_counter()
             with torch.no_grad():
-                logits_cpu = logits.to("cpu")
-                loss_cpu = float(loss.to("cpu").item())
+                logits_cpu = logits_previous.to("cpu")
+                loss_cpu = float(loss_previous.to("cpu").item())
                 train_acc = float(
-                    (logits_cpu.argmax(dim=1) == labels_cpu)
+                    (logits_cpu.argmax(dim=1) == labels_cpu_previous)
                     .float()
                     .mean()
                     .item()
                 )
             host_readout_s += time.perf_counter() - t1
             print(
-                f"{step}: train accuracy={train_acc:.4f} "
-                f"loss={loss_cpu:.4f} (lr={lr:.6f})"
+                f"{prev_step}: train accuracy={train_acc:.4f} "
+                f"loss={loss_cpu:.4f} (lr={prev_lr:.6f})"
             )
 
-        # Drop step temporaries so mark_output(false) is visible to the
-        # pending_output_reclaim pass (end of this run / start of next compile).
-        del logits
-        del loss
-        gc.collect()
+        t_wait0 = time.perf_counter()
+        torch_nntile.wait()
+        train_compute_s += order_s + (time.perf_counter() - t_wait0)
+
+        # Drop previous-step temporaries so mark_output(false) is visible to
+        # pending_output_reclaim (end of this run / start of next compile).
+        if loss_previous is not None:
+            del loss_previous
+            del logits_previous
+            gc.collect()
+
+        loss_previous = loss_current
+        logits_previous = logits
+        labels_cpu_previous = labels_cpu
+        prev_step = step
+        prev_lr = lr
 
         if step % test_every == 0:
             test_loss, test_acc, eval_s = evaluate_nntile(
@@ -460,6 +530,30 @@ def train_nntile(
                 f"{step}: ********* epoch {epoch} ********* "
                 f"test accuracy={test_acc:.4f} test loss={test_loss:.4f}"
             )
+
+    # Final current loss (held in the previous buffer after the last shift).
+    assert loss_previous is not None
+    assert logits_previous is not None
+    assert labels_cpu_previous is not None
+    assert prev_lr is not None
+    t1 = time.perf_counter()
+    with torch.no_grad():
+        logits_cpu = logits_previous.to("cpu")
+        loss_cpu = float(loss_previous.to("cpu").item())
+        final_train_acc = float(
+            (logits_cpu.argmax(dim=1) == labels_cpu_previous)
+            .float()
+            .mean()
+            .item()
+        )
+    host_readout_s += time.perf_counter() - t1
+    print(
+        f"final: train accuracy={final_train_acc:.4f} "
+        f"loss={loss_cpu:.4f} (lr={prev_lr:.6f})"
+    )
+    del logits_previous
+    del loss_previous
+    gc.collect()
 
     print(
         f"timing nntile train compute: {train_compute_s:.3f}s "

--- a/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
+++ b/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
@@ -62,7 +62,6 @@ run is slower on CPU workers than pure torch).
 from __future__ import annotations
 
 import argparse
-import gc
 import math
 import sys
 import time
@@ -218,10 +217,6 @@ def evaluate_nntile(
             loss_cpu = float(loss.to("cpu").item())
         del logits
         del loss
-        # Full gc.collect() scans the whole heap and dominates step time as the
-        # session graph grows; generation-0 is enough to drop young cycles so
-        # ~NNTileBinding can mark_output(false) for reclaim.
-        gc.collect(0)
         total_loss += loss_cpu
         total_correct += int(
             (logits_cpu.argmax(dim=1) == labels_cpu).sum().item()
@@ -442,7 +437,6 @@ def train_nntile(
     run_s = 0.0
     wait_s = 0.0
     readout_s = 0.0
-    gc_s = 0.0
     # Host-side previous log: (step, accuracy, loss, lr). Printed only after
     # the next step has been ordered. Do not keep nntile logits/loss across
     # the next compile_graph() — that blocks pending_output_reclaim.
@@ -510,13 +504,10 @@ def train_nntile(
 
         # Drop step temporaries so mark_output(false) is visible to the
         # pending_output_reclaim pass (end of this run / start of next compile).
+        # Refcount drop via del is enough — do not gc.collect() in the step
+        # loop (full/gen0 collections scale with session size).
         del logits
         del loss_current
-        t0 = time.perf_counter()
-        # Full gc.collect() dominates step time on long sessions; gen0 is enough
-        # for young autograd cycles so bindings can mark_output(false).
-        gc.collect(0)
-        gc_s += time.perf_counter() - t0
         train_step_s += time.perf_counter() - t_step0
 
         if step % test_every == 0:
@@ -555,7 +546,7 @@ def train_nntile(
         f"timing nntile step breakdown: "
         f"record={record_s:.3f}s compile={compile_s:.3f}s "
         f"run={run_s:.3f}s wait={wait_s:.3f}s "
-        f"readout={readout_s:.3f}s gc={gc_s:.3f}s"
+        f"readout={readout_s:.3f}s"
     )
     print(f"timing nntile eval wall: {eval_wall_s:.3f}s")
     torch_nntile.print_info()

--- a/torch_nntile/torch_nntile/__init__.py
+++ b/torch_nntile/torch_nntile/__init__.py
@@ -128,7 +128,7 @@ def compile_graph() -> None:
 
 
 def run() -> None:
-    """Execute the compiled graph session (no host data transfer)."""
+    """Submit the compiled graph to StarPU (asynchronous; does not wait)."""
     _C.run()
 
 
@@ -165,10 +165,12 @@ def restore_where() -> None:
 
 
 def wait() -> None:
-    """Block until all submitted StarPU tasks finish (``starpu_task_wait_for_all``).
+    """Block until tasks submitted by :func:`run` finish.
 
-    Call before host readout (``.to("cpu")``) or :func:`shutdown_context`.
-    Required for clean CUDA teardown when ``ncuda > 0``.
+    Also runs post-run reclaim (scatter staging invalidate, pin_hold release,
+    ``pending_output_reclaim``). Call before host readout (``.to("cpu")``) or
+    :func:`shutdown_context`. Required for clean CUDA teardown when
+    ``ncuda > 0``.
     """
     _C.wait_for_all()
 

--- a/torch_nntile/torch_nntile/__init__.py
+++ b/torch_nntile/torch_nntile/__init__.py
@@ -220,6 +220,18 @@ def print_axis_groups() -> None:
     _C.print_axis_groups()
 
 
+def print_info() -> None:
+    """Print cumulative ``compile_graph`` / ``run`` / ``wait`` / host-readout timing.
+
+    Useful for comparing nntile overhead against a torch CPU baseline.
+    """
+    import sys
+
+    sys.stdout.flush()
+    _C.print_info()
+    sys.stdout.flush()
+
+
 __all__ = [
     "device",
     "_C",
@@ -241,5 +253,6 @@ __all__ = [
     "set_axis_group_tiling",
     "format_axis_groups",
     "print_axis_groups",
+    "print_info",
     "nn",
 ]

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -556,7 +556,9 @@ def train_full_batch_step(
             loss_cpu = loss.to("cpu")
         del logits
         del loss
-        gc.collect()
+        # Avoid full gc.collect() — it scales with session size and dominates
+        # step time. Generation-0 clears young cycles for mark_output(false).
+        gc.collect(0)
         return float(loss_cpu.item())
 
     loss = F.cross_entropy(logits, targets)

--- a/torch_nntile/torch_nntile/training.py
+++ b/torch_nntile/torch_nntile/training.py
@@ -21,7 +21,6 @@ kernels, mirroring ``nntile::optim::Adam`` / ``AdamW`` in libnntile.
 
 from __future__ import annotations
 
-import gc
 import math
 from typing import Callable, Iterable, Mapping
 
@@ -554,11 +553,10 @@ def train_full_batch_step(
         torch_nntile.wait()
         with torch.no_grad():
             loss_cpu = loss.to("cpu")
+        # Drop step temps so pending_output reclaim sees mark_output(false).
+        # Do not gc.collect() here — it scales with session size.
         del logits
         del loss
-        # Avoid full gc.collect() — it scales with session size and dominates
-        # step time. Generation-0 clears young cycles for mark_output(false).
-        gc.collect(0)
         return float(loss_cpu.item())
 
     loss = F.cross_entropy(logits, targets)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Speeds up incremental `torch_nntile` graph training (Google five-layer ReLU MNIST) while keeping `run()` / `execute_range` asynchronous.

### Training loop
- Double-buffer host train loss/acc logging so print overlaps StarPU compute
- Drop `gc.collect()` from nntile step loops (refcount `del` is enough)
- Honest step timing + `torch_nntile.print_info()` compile/run/wait breakdown

### Compile path
- Suffix-only DCE without rebuilding the executed `execution_order_` prefix
- Session-scoped `TensorGraphTiling` (`ensure_phase_layouts` + shared_ptr; no per-compile deep copy)
- Cached `layout_fingerprint`; O(carried) `seal_phase` via marked I/O set (sorted by node id)

### Async execution
- Defer `starpu_task_wait_for_all` in core sync wrappers during `execute_range`
- Queue last-consumer tile reclaim; flush in `Runtime::wait()`
- Empty post-DCE `run()` still requires `wait()` for pin/reclaim/scatter cleanup
- Preserve still-marked reclaim across compile; sync unmarked allocated tiles

### Misc
- Deduplicate graph pin holds by `TensorImpl` key

## Benchmark (agent VM, 300 steps, batch 100, seed 42, ncpu=1)

| | train steps | run submit | wait | notes |
|--|--|--|--|--|
| Early (pre-fix) | ~8–11s / ~27 ms/step | sync-heavy | tiny | compile dominated |
| After tiling + async | **~2.1s / ~6.9 ms/step** | **~0.06s** | **~0.65s** | compute in wait |
| torch CPU | ~0.48s / ~1.6 ms/step | — | — | |

Accuracy tracks CPU (~0.9512 vs ~0.9525).

Remaining step cost is roughly even: record / compile / wait(compute).

## Test plan

- [x] `reproduce_google_five_layer_relu_mnist.py --steps 300 --device nntile` (accuracy + timing)
- [x] Same with `--device cpu` for parity
- [ ] Re-bench on GPU/host after rebuild from this branch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8b70894-69cf-40ad-bd71-f7f20fec75cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8b70894-69cf-40ad-bd71-f7f20fec75cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

