### PR TITLE
Add TORCH_NNTILE_SKIP_STARPU dry-run for host compile profiling

### DIFF
--- a/docs/dev/graph_compile_perf_mnist.md
+++ b/docs/dev/graph_compile_perf_mnist.md
@@ -10,11 +10,42 @@ Measured on the Cloud Agent VM (CPU-only), `torch==2.9.1+cpu`,
 |------|-------|
 | StarPU workers | `--ncpu 1 --ncuda 0 --restrict-cpu` |
 | Host threads | `torch.set_num_threads(1)`, `OMP/MKL/OPENBLAS_NUM_THREADS=1` |
-| Kernels | `STARPU_DISABLE_KERNELS=1` (nntile only) |
+| Kernels | `STARPU_DISABLE_KERNELS=1` (nntile only; still submits tasks) |
+| No submit / I/O | `TORCH_NNTILE_SKIP_STARPU=1` (skip StarPU task insert + staging acquire/memcpy; still advances execute watermark + last-consumer reclaim so compile stays O(pending); accuracy meaningless) |
 | Logging | `--train-log-every 50 --test-every 50` |
 | Seed | `0` |
 
 Script: `torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py`.
+
+## `TORCH_NNTILE_SKIP_STARPU` dry-run
+
+Set `TORCH_NNTILE_SKIP_STARPU=1` to measure **record + compile** without StarPU
+compute or host↔tile copies.
+
+| Still runs | Skipped |
+|------------|---------|
+| TensorGraph capture (record) | `OpNode::execute` (StarPU task insert) |
+| Seal / lower / `Runtime::compile` (incl. allocate) | Staging `acquire` + memcpy |
+| `execute_range(..., submit_tasks=false)` — advances `executed_op_end_` and queues last-consumer reclaim | Kernel work / meaningful numerics |
+| `wait()` reclaim / `invalidate_logical_tiles` | |
+
+**Do not** skip `execute_range` entirely: leaving `Runtime::executed_op_end_`
+unchanged makes every later `compile()` treat full history as pending
+(O(session) DCE/allocate — tens of seconds on this script).
+
+`STARPU_DISABLE_KERNELS=1` is different: tasks are still submitted, so `run`
+can grow even though kernels are empty.
+
+```bash
+STARPU_WORKERS_NOBIND=1 TORCH_NNTILE_SKIP_STARPU=1 \
+  python torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py \
+    --steps 500 --batch-size 100 --seed 42 --device nntile \
+    --train-log-every 50 --test-every 50 --ncpu 1 --skip-accuracy-floor
+```
+
+`print_info()` prints
+`NOTE: TORCH_NNTILE_SKIP_STARPU=1 (no compute submit / staging acquire; reclaim on)`
+when the knob is active.
 
 ## Before vs after (real compile reductions)
 

--- a/docs/torch_nntile.md
+++ b/docs/torch_nntile.md
@@ -87,6 +87,26 @@ tensors (and their graph dependencies) stay marked. During `run()`,
 `Runtime::execute()` releases intermediate StarPU tiles after their last
 consumer when those tiles are not graph inputs/outputs.
 
+### Profiling: host path vs StarPU
+
+`torch_nntile.print_info()` prints cumulative `compile_graph` / `run` / `wait` /
+host-readout timing (and record-path sub-buckets).
+
+| Env | Purpose |
+|-----|---------|
+| `STARPU_DISABLE_KERNELS=1` | StarPU submits tasks but skips kernel bodies. Shows submit overhead; often inflates `run`. |
+| `TORCH_NNTILE_SKIP_STARPU=1` | Dry-run in torch_nntile: no StarPU task insert, no staging acquire/memcpy. Still advances the `Runtime` execute watermark and last-consumer reclaim so incremental compile stays O(pending). Isolates record + compile cost. **Results are not numerically meaningful.** |
+
+```bash
+STARPU_WORKERS_NOBIND=1 TORCH_NNTILE_SKIP_STARPU=1 \
+  python torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py \
+    --steps 500 --device nntile --ncpu 1 --skip-accuracy-floor
+```
+
+More context: [dev/graph_compile_perf_mnist.md](dev/graph_compile_perf_mnist.md)
+and the package README
+[Profiling knobs](../torch_nntile/README.md#profiling-knobs-host-vs-starpu).
+
 ## Axis-group naming and tiling
 
 Tiling in NNTile is defined on **shared axis groups** (`AxisDescriptor` in C++),

--- a/nntile/include/nntile/runtime.hh
+++ b/nntile/include/nntile/runtime.hh
@@ -16,7 +16,6 @@
 
 // Standard library headers
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -56,7 +55,14 @@ class Runtime
 
     //! Submit ops [op_begin, op_end) asynchronously (no StarPU drain).
     //! Call ``wait()`` before reading outputs or reclaiming tiles.
-    void execute_range(size_t op_begin, size_t op_end);
+    //! If ``submit_tasks`` is false, skip ``OpNode::execute`` (no StarPU
+    //! inserts) but still advance the executed watermark and queue
+    //! last-consumer tile reclaim — required so incremental ``compile()``
+    //! stays O(pending) under dry-run profiling.
+    void execute_range(
+        size_t op_begin,
+        size_t op_end,
+        bool submit_tasks = true);
 
     size_t execution_op_count() const { return execution_order_.size(); }
 
@@ -230,7 +236,9 @@ class Runtime
     void get_output_impl(const TileNode *node, std::vector<T> &result);
 
     const TileGraph &graph_;
-    std::map<const TileNode *, std::shared_ptr<void>> tile_map_;
+    //! Pointer keys: unordered_map keeps allocate/lookup O(1) as live tiles
+    //! grow; reclaim keeps size O(live), not O(session).
+    std::unordered_map<const TileNode *, std::shared_ptr<void>> tile_map_;
     std::vector<std::shared_ptr<OpNode>> execution_order_;
     ExecutionSchedule execution_schedule_;
     std::optional<ExecutionSchedule> execution_schedule_file_cache_;

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -45,9 +45,11 @@ namespace
 {
 
 template <typename T>
-void allocate_tile_and_register(const TileGraph::TileNode *node,
+void allocate_tile_and_register(
+    const TileGraph::TileNode *node,
     const std::vector<Index> &shape,
-    std::map<const TileGraph::TileNode *, std::shared_ptr<void>> &tile_map)
+    std::unordered_map<const TileGraph::TileNode *, std::shared_ptr<void>> &
+        tile_map)
 {
     auto t = std::make_shared<nntile::core::Tile<T>>(shape);
     tile_map[node] = t;
@@ -754,7 +756,10 @@ void Runtime::allocate_missing_tiles()
     compiled_tile_node_count_ = all_tiles.size();
 }
 
-void Runtime::execute_range(size_t op_begin, size_t op_end)
+void Runtime::execute_range(
+    size_t op_begin,
+    size_t op_end,
+    bool submit_tasks)
 {
     require_compiled();
     if (op_begin > op_end || op_end > execution_order_.size())
@@ -764,21 +769,29 @@ void Runtime::execute_range(size_t op_begin, size_t op_end)
     // Submit only: core sync wrappers skip wait_for_all while deferred so
     // torch_nntile run() can return before StarPU finishes the phase.
     StarpuSyncDefer defer_waits;
-    bool const use_static_schedule = has_execution_schedule();
+    bool const use_static_schedule =
+        submit_tasks && has_execution_schedule();
     for (size_t i = op_begin; i < op_end; ++i)
     {
-        if (use_static_schedule)
+        if (submit_tasks)
         {
-            starpu_worker_hint_ = sched::starpu_worker_id_for_scheduled_op(
-                execution_schedule_.worker_for_op(i),
-                execution_schedule_.use_cuda_workers,
-                execution_order_[i]->op_name());
+            if (use_static_schedule)
+            {
+                starpu_worker_hint_ =
+                    sched::starpu_worker_id_for_scheduled_op(
+                        execution_schedule_.worker_for_op(i),
+                        execution_schedule_.use_cuda_workers,
+                        execution_order_[i]->op_name());
+            }
+            else
+            {
+                starpu_worker_hint_ = -1;
+            }
+            execution_order_[i]->execute(*this);
         }
-        else
-        {
-            starpu_worker_hint_ = -1;
-        }
-        execution_order_[i]->execute(*this);
+        // Always queue last-consumer reclaim. Skipping this (and skipping
+        // the executed_op_end_ update below) makes the next compile treat
+        // the full history as pending — O(session) DCE/allocate.
         queue_dead_tiles_after_op(i);
     }
     if (op_end > executed_op_end_)

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -289,6 +289,29 @@ then set tile sizes by group name before ``compile_graph()``.
 | `print_axis_groups()` | Print summary (includes `pending_tile=` before compile) |
 | `print_info()` | Print cumulative `compile_graph` / `run` / `wait` / host-readout timing |
 
+### Profiling knobs (host vs StarPU)
+
+Use these only to attribute step time. Accuracy and loss are meaningless when
+kernels or submits are disabled.
+
+| Env | Effect |
+|-----|--------|
+| `STARPU_DISABLE_KERNELS=1` | StarPU still **submits** tasks but skips kernel bodies. Often makes `run` *slower* (queue overhead without useful work). |
+| `TORCH_NNTILE_SKIP_STARPU=1` | torch_nntile dry-run: skip StarPU **task insert** and staging **acquire/memcpy**. Still calls `Runtime::execute_range(..., submit_tasks=false)` so the executed watermark and last-consumer tile reclaim advance — incremental `compile()` stays O(pending). `print_info()` prints a NOTE when this is set. |
+
+Example (Google five-layer ReLU MNIST, host-only path):
+
+```bash
+STARPU_WORKERS_NOBIND=1 TORCH_NNTILE_SKIP_STARPU=1 \
+  python torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py \
+    --steps 500 --batch-size 100 --device nntile --ncpu 1 \
+    --train-log-every 50 --test-every 50 --skip-accuracy-floor
+```
+
+Then compare step breakdown / `print_info()` buckets (`record`, `compile_graph`
+sub-phases, `run`, `wait`) to a normal run without the env var. See
+[docs/dev/graph_compile_perf_mnist.md](../docs/dev/graph_compile_perf_mnist.md).
+
 ```python
 torch_nntile.init_context(
     ncpu=4, ncuda=0, cpu_fallback=False

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -46,6 +46,8 @@ std::vector<Index> tile_sizes_for_axis_extent(
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -59,6 +61,25 @@ namespace torch_nntile
 
 namespace
 {
+
+//! Temporary profiling knob: skip StarPU *compute* submit and host↔tile
+//! acquire/memcpy so record+compile wall time can be measured alone.
+//! ``execute_range`` still runs (watermark + last-consumer reclaim) so
+//! incremental compile stays O(pending). Set ``TORCH_NNTILE_SKIP_STARPU=1``.
+//! Results / accuracy are meaningless.
+bool skip_starpu_submit_and_acquire()
+{
+    static int const cached = []() -> int
+    {
+        char const *env = std::getenv("TORCH_NNTILE_SKIP_STARPU");
+        if (env == nullptr || env[0] == '\0' || std::strcmp(env, "0") == 0)
+        {
+            return 0;
+        }
+        return 1;
+    }();
+    return cached != 0;
+}
 
 std::recursive_mutex g_recorder_mutex;
 std::unique_ptr<nntile::TensorGraph> g_graph;
@@ -160,6 +181,8 @@ void reclaim_pending_outputs_locked()
     nntile::Runtime &runtime = *g_exec->runtime;
     // Temps are often del'd after wait(); keep still-marked entries so the
     // next compile/run can invalidate them once NodeRefs drop.
+    // Always reclaim into tile_map_ even under TORCH_NNTILE_SKIP_STARPU —
+    // otherwise registrations accumulate and runtime.compile grows O(session).
     std::vector<nntile::TensorGraph::TensorNode *> still_marked;
     still_marked.reserve(g_exec->pending_output_reclaim.size());
     for (nntile::TensorGraph::TensorNode *logical :
@@ -469,6 +492,7 @@ void write_cpu_bytes_to_staging_locked(
     nntile::Runtime &runtime = *g_exec->runtime;
     nntile::TileGraph::TileNode *tile =
         require_single_staging_tile_locked(staging);
+    bool const skip_starpu = skip_starpu_submit_and_acquire();
     switch (dtype)
     {
     case nntile::DataType::FP32:
@@ -479,13 +503,17 @@ void write_cpu_bytes_to_staging_locked(
             throw std::runtime_error(
                 "torch_nntile: staging write size mismatch");
         }
-        auto local = buf.acquire(STARPU_W);
-        const auto *src = static_cast<const float *>(host_ptr);
-        for (std::size_t i = 0; i < count; ++i)
+        if (!skip_starpu)
         {
-            local[static_cast<nntile::Index>(i)] = nntile::fp32_t(src[i]);
+            auto local = buf.acquire(STARPU_W);
+            const auto *src = static_cast<const float *>(host_ptr);
+            for (std::size_t i = 0; i < count; ++i)
+            {
+                local[static_cast<nntile::Index>(i)] =
+                    nntile::fp32_t(src[i]);
+            }
+            local.release();
         }
-        local.release();
         break;
     }
     case nntile::DataType::INT64:
@@ -496,14 +524,18 @@ void write_cpu_bytes_to_staging_locked(
             throw std::runtime_error(
                 "torch_nntile: staging write size mismatch");
         }
-        auto local = buf.acquire(STARPU_W);
-        const auto *src = static_cast<const std::int64_t *>(host_ptr);
-        for (std::size_t i = 0; i < count; ++i)
+        if (!skip_starpu)
         {
-            local[static_cast<nntile::Index>(i)] =
-                nntile::int64_t(src[i]);
+            auto local = buf.acquire(STARPU_W);
+            const auto *src =
+                static_cast<const std::int64_t *>(host_ptr);
+            for (std::size_t i = 0; i < count; ++i)
+            {
+                local[static_cast<nntile::Index>(i)] =
+                    nntile::int64_t(src[i]);
+            }
+            local.release();
         }
-        local.release();
         break;
     }
     case nntile::DataType::BOOL:
@@ -514,13 +546,17 @@ void write_cpu_bytes_to_staging_locked(
             throw std::runtime_error(
                 "torch_nntile: staging write size mismatch");
         }
-        auto local = buf.acquire(STARPU_W);
-        const auto *src = static_cast<const bool *>(host_ptr);
-        for (std::size_t i = 0; i < count; ++i)
+        if (!skip_starpu)
         {
-            local[static_cast<nntile::Index>(i)] = nntile::bool_t(src[i]);
+            auto local = buf.acquire(STARPU_W);
+            const auto *src = static_cast<const bool *>(host_ptr);
+            for (std::size_t i = 0; i < count; ++i)
+            {
+                local[static_cast<nntile::Index>(i)] =
+                    nntile::bool_t(src[i]);
+            }
+            local.release();
         }
-        local.release();
         break;
     }
     default:
@@ -538,6 +574,7 @@ void invalidate_staging_tile_submit_locked(
         return;
     }
     nntile::Runtime &runtime = *g_exec->runtime;
+    // Keep map reclaim even when SKIP_STARPU disables submit/acquire.
     runtime.wait();
     nntile::TileGraph::TileNode *tile =
         require_single_staging_tile_locked(staging);
@@ -574,6 +611,10 @@ void read_staging_to_host_locked(
         throw std::runtime_error(
             "torch_nntile: no runtime for staging readout");
     }
+    if (skip_starpu_submit_and_acquire())
+    {
+        return;
+    }
     nntile::Runtime &runtime = *g_exec->runtime;
     runtime.wait();
     nntile::TileGraph::TileNode *tile =
@@ -592,7 +633,8 @@ void read_staging_to_host_locked(
         auto *dst = static_cast<float *>(host_ptr);
         for (std::size_t i = 0; i < count; ++i)
         {
-            dst[i] = static_cast<float>(local[static_cast<nntile::Index>(i)]);
+            dst[i] = static_cast<float>(
+                local[static_cast<nntile::Index>(i)]);
         }
         local.release();
         break;
@@ -627,7 +669,8 @@ void read_staging_to_host_locked(
         auto *dst = static_cast<bool *>(host_ptr);
         for (std::size_t i = 0; i < count; ++i)
         {
-            dst[i] = static_cast<bool>(local[static_cast<nntile::Index>(i)]);
+            dst[i] = static_cast<bool>(
+                local[static_cast<nntile::Index>(i)]);
         }
         local.release();
         break;
@@ -950,9 +993,13 @@ void run_graph_locked()
         std::uint64_t const phase_ops = static_cast<std::uint64_t>(
             g_exec->pending_exec_op_end - g_exec->pending_exec_op_begin);
         SteadyClock::time_point const t0 = SteadyClock::now();
+        // Always call execute_range so Runtime::executed_op_end_ advances and
+        // last-consumer tiles are queued for wait()-time flush. SKIP_STARPU
+        // only disables OpNode::execute (StarPU task insert).
         g_exec->runtime->execute_range(
             g_exec->pending_exec_op_begin,
-            g_exec->pending_exec_op_end);
+            g_exec->pending_exec_op_end,
+            !skip_starpu_submit_and_acquire());
         g_timing.run_s += seconds_since(t0);
         ++g_timing.run_calls;
         g_timing.run_ops += phase_ops;
@@ -979,6 +1026,8 @@ void finish_run_locked()
         return;
     }
     SteadyClock::time_point const t0 = SteadyClock::now();
+    // Always join + reclaim so tile_map_ stays O(live). SKIP_STARPU only
+    // skips compute submit and host↔tile acquire/memcpy.
     g_exec->runtime->wait();
     for (nntile::TensorGraph::TensorNode *staging :
         g_exec->pending_scatter_stagings)
@@ -1780,6 +1829,11 @@ std::string format_info_locked()
 
     std::ostringstream ss;
     ss << "torch_nntile graph API timing (cumulative):\n";
+    if (skip_starpu_submit_and_acquire())
+    {
+        ss << "  NOTE: TORCH_NNTILE_SKIP_STARPU=1 "
+              "(no compute submit / staging acquire; reclaim on)\n";
+    }
     ss << "  compile_graph: " << g_timing.compile_calls << " calls, "
        << g_timing.compile_s << "s"
        << " (avg " << avg_ms(g_timing.compile_s, g_timing.compile_calls)

--- a/torch_nntile/tests/test_bmm_tiling.py
+++ b/torch_nntile/tests/test_bmm_tiling.py
@@ -26,6 +26,7 @@ def _run_subprocess(script: str) -> None:
     env = dict(**__import__("os").environ)
     # Bench scripts may leave STARPU_DISABLE_KERNELS=1 in the parent env.
     env.pop("STARPU_DISABLE_KERNELS", None)
+    env.pop("TORCH_NNTILE_SKIP_STARPU", None)
     repo = Path(__file__).resolve().parents[2]
     build_lib = repo / "build" / "nntile"
     starpu_lib = "/opt/starpu/lib"

--- a/torch_nntile/tests/test_graph_execution.py
+++ b/torch_nntile/tests/test_graph_execution.py
@@ -28,6 +28,7 @@ def _run_graph_subprocess(script: str) -> None:
     # Bench scripts may leave STARPU_DISABLE_KERNELS=1 in the parent env;
     # that skips kernels and makes host readout look like garbage.
     env.pop("STARPU_DISABLE_KERNELS", None)
+    env.pop("TORCH_NNTILE_SKIP_STARPU", None)
     repo = Path(__file__).resolve().parents[2]
     build_lib = repo / "build" / "nntile"
     starpu_lib = "/opt/starpu/lib"


### PR DESCRIPTION
## Summary
- Add `TORCH_NNTILE_SKIP_STARPU=1` to isolate TensorGraph record/compile cost: skip StarPU task insert and staging acquire/memcpy, while still calling `execute_range(..., submit_tasks=false)` so the execute watermark and last-consumer reclaim advance (avoids O(session) compile blowup).
- Add `submit_tasks` to `Runtime::execute_range` and switch `tile_map_` from `std::map` to `std::unordered_map`.
- Document the knob in `torch_nntile/README.md`, `docs/torch_nntile.md`, and `docs/dev/graph_compile_perf_mnist.md`; clear the env in graph subprocess tests.

## Test plan
- [x] Rebuild libnntile + torch_nntile
- [x] Normal MNIST run still trains (~1s steps wall without skip)
- [x] `TORCH_NNTILE_SKIP_STARPU=1` MNIST dry-run: `print_info` shows NOTE; `runtime.compile` stays ~O(0.1s) total (not tens of seconds); accuracy meaningless
- [x] Subprocess tests still pass with the env cleared (`test_graph_execution`, `test_bmm_tiling`)


Made with [Cursor](https://cursor.com)