### PR TITLE
Align DeepReLU MNIST example with device choice and timing reports

### DIFF
--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -59,8 +59,8 @@ collection scans the growing session heap and can dominate step time.
 
 | Direction | API | Behavior |
 |-----------|-----|----------|
-| Ingress | `.to("nntile")` / CPU→nntile `copy_` | Create `L`, attach `NodeRef`, create ephemeral single-tile `S`, write host bytes into `S`, record `scatter(S→L)`. Ingress is **once per tensor**; a second CPU copy into an already-bound tensor raises. After the scatter phase `run()`/`wait()`, ingress `S` marks are cleared and StarPU tile buffers are **removed** from the runtime map (not left live after `invalidate_submit`). |
-| Egress | `.cpu()` / `.to("cpu")` / nntile→CPU `copy_` | Create ephemeral `S`, record `clear(S)` + `gather(L→S)`, **auto-compile and run** any pending ops plus the gather phase, StarPU-read `S`, then fully release `S` the same way. |
+| Ingress | `.to("nntile")` / CPU→nntile `copy_` | Create `L`, attach `NodeRef`, create ephemeral single-tile `S` on StarPU immediately, write host bytes into `S`, record `scatter(S→L)`. Ingress is **once per tensor**. Batched prefetch keeps every `S` until the scatter phase runs; `run()` executes each scatter, waits, and destroys that `S` before the next so StarPU's allocation cache can reuse the CUDA chunk for the next `L` (submitting all scatters then unregistering all `S` left cached buffers → settled ≈2×). |
+| Egress | `.cpu()` / `.to("cpu")` / nntile→CPU `copy_` | Create ephemeral `S`, record `clear(S)` + `gather(L→S)`, **auto-compile and run** any pending ops plus the gather phase, StarPU-read `S`, fully release `S`. |
 
 ### `.cpu()` auto-flush (by design)
 
@@ -110,7 +110,7 @@ run backward (or ingress a real grad tensor via `.to("nntile")`) first.
 | # | Topic | Current behavior | Planned follow-up |
 |---|--------|------------------|-------------------|
 | D1 | TensorGraph metadata growth | Each `.cpu()` permanently appends `clear`, `gather`, and a new `io_staging_*` node (op list grows). Phase outputs cleared after `wait()` are reclaimed via `pending_output_reclaim` (O(phase outputs), not a full tile-map scan). Historical TileGraph/TensorGraph nodes still accumulate in memory. | Phase GC / compaction; reuse readout staging per session. |
-| D2 | Incremental tile-map growth | Every ingress/egress lowers a fresh ephemeral `S`. After scatter/gather `wait()`, logical marks are cleared and `Runtime::invalidate_logical_tiles` drops StarPU buffers (tile `mark_input` must be cleared too — ingress `S` was built with `mark_input(true)`, which previously skipped reclaim and left ≈2× VRAM next to untiled `L`). TensorGraph/TileGraph node metadata still accumulates. | Optional: pool single-tile `S` per `L`; compact historical tile nodes. |
+| D2 | Ingress `S` + StarPU alloc cache | Batched `.to("nntile")` keeps every ephemeral `S` until scatters run. Submitting all scatters before any `S` unregister leaves CUDA replicates of every `S` beside every `L`; unregister parks them in StarPU's allocation cache (`STARPU_USE_ALLOCATION_CACHE`) → settled ≈2×. `starpu_memchunk_tidy` only writebacks dirty chunks — it does **not** flush that cache. | During `run()`, execute each ingress scatter, `wait()`, then destroy that `S` before the next scatter so the next `L` reuses the cached chunk. |
 | D3 | Pin bookkeeping | Dedup uses `unordered_set<TensorImplKey>` while pinning; pins still clear on phase transfer. | Optional: trim earlier than phase seal if pin lists grow mid-phase. |
 | D4 | CE `ignore_index` mean | Mean CE uses `1/numel`; PyTorch uses `1/count_non_ignore`. | Graph-native valid-label count (or document as permanent limitation). |
 | D5 | `vector_norm` backward | Forward-only by design. | Add autograd when product needs it. |

--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -42,10 +42,10 @@ by marks, with an explicit pending list in torch_nntile:
    graph compaction so the **next** `compile_graph()` can reclaim them after
    Python `del`s the tensors (do not clear that list in `drop_all_ops`
    compaction — that leaked one step of activation tiles per iteration).
-4. Mid-phase, ``execute_range`` queues unmarked tiles after their last
-   consumer; ``Runtime::wait()`` invalidates them after StarPU drains.
-   Core ``*`` wrappers skip ``starpu_task_wait_for_all`` while submit is
-   deferred so ``run()`` stays asynchronous.
+4. Mid-phase, ``execute_range`` / ``run()`` issues ``invalidate_submit`` for
+   unmarked tiles as soon as their last consumer is submitted (not deferred
+   to ``wait()``). Core ``*`` wrappers skip ``starpu_task_wait_for_all``
+   while submit is deferred so ``run()`` stays asynchronous.
 
 Training loops should ``del`` step temporaries (e.g. logits) **after**
 ``wait()`` and any host readout of the loss so reclaim sees

--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -16,7 +16,8 @@ TensorImpl → NNTileBackendMeta → NodeRef → NNTileBinding { logical L }
 - **`L` (logical):** the graph/compute node. `NodeRef` ctor/dtor drive
   `mark_output(true/false)` on `L`.
 - **`S` (staging):** **ephemeral**, not stored in `NNTileBinding`. Created per
-  I/O event, invalidated after scatter/gather run.
+  I/O event; after scatter/gather `wait()`, marks are cleared and StarPU
+  tile buffers are dropped from the runtime map (not left live).
 
 There is no side map (`g_tensor_nodes`) and no eager per-op flush. All ops
 record into a shared `TensorGraph`; the caller flushes with `compile_graph()`
@@ -54,8 +55,8 @@ collection scans the growing session heap and can dominate step time.
 
 | Direction | API | Behavior |
 |-----------|-----|----------|
-| Ingress | `.to("nntile")` / CPU→nntile `copy_` | Create `L`, attach `NodeRef`, create ephemeral single-tile `S`, write host bytes into `S`, record `scatter(S→L)`. Ingress is **once per tensor**; a second CPU copy into an already-bound tensor raises. After the scatter phase runs, ingress `S` is invalidated. |
-| Egress | `.cpu()` / `.to("cpu")` / nntile→CPU `copy_` | Create ephemeral `S`, record `clear(S)` + `gather(L→S)`, **auto-compile and run** any pending ops plus the gather phase, StarPU-read `S`, invalidate `S`. |
+| Ingress | `.to("nntile")` / CPU→nntile `copy_` | Create `L`, attach `NodeRef`, create ephemeral single-tile `S`, write host bytes into `S`, record `scatter(S→L)`. Ingress is **once per tensor**; a second CPU copy into an already-bound tensor raises. After the scatter phase `run()`/`wait()`, ingress `S` marks are cleared and StarPU tile buffers are **removed** from the runtime map (not left live after `invalidate_submit`). |
+| Egress | `.cpu()` / `.to("cpu")` / nntile→CPU `copy_` | Create ephemeral `S`, record `clear(S)` + `gather(L→S)`, **auto-compile and run** any pending ops plus the gather phase, StarPU-read `S`, then fully release `S` the same way. |
 
 ### `.cpu()` auto-flush (by design)
 
@@ -105,7 +106,7 @@ run backward (or ingress a real grad tensor via `.to("nntile")`) first.
 | # | Topic | Current behavior | Planned follow-up |
 |---|--------|------------------|-------------------|
 | D1 | TensorGraph metadata growth | Each `.cpu()` permanently appends `clear`, `gather`, and a new `io_staging_*` node (op list grows). Phase outputs cleared after `wait()` are reclaimed via `pending_output_reclaim` (O(phase outputs), not a full tile-map scan). Historical TileGraph/TensorGraph nodes still accumulate in memory. | Phase GC / compaction; reuse readout staging per session. |
-| D2 | Incremental tile-map growth | Every ingress/egress lowers a fresh ephemeral `S` into `inc_state.tensor_to_tiles`; entries are never removed. | Reclaim staging descriptors after invalidate; or pool single-tile `S` per `L`. |
+| D2 | Incremental tile-map growth | Every ingress/egress lowers a fresh ephemeral `S`. After scatter/gather `wait()`, logical marks are cleared and `Runtime::invalidate_logical_tiles` drops StarPU buffers (tile `mark_input` must be cleared too — ingress `S` was built with `mark_input(true)`, which previously skipped reclaim and left ≈2× VRAM next to untiled `L`). TensorGraph/TileGraph node metadata still accumulates. | Optional: pool single-tile `S` per `L`; compact historical tile nodes. |
 | D3 | Pin bookkeeping | Dedup uses `unordered_set<TensorImplKey>` while pinning; pins still clear on phase transfer. | Optional: trim earlier than phase seal if pin lists grow mid-phase. |
 | D4 | CE `ignore_index` mean | Mean CE uses `1/numel`; PyTorch uses `1/count_non_ignore`. | Graph-native valid-label count (or document as permanent limitation). |
 | D5 | `vector_norm` backward | Forward-only by design. | Add autograd when product needs it. |

--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -38,6 +38,10 @@ by marks, with an explicit pending list in torch_nntile:
 3. After `wait()` (following `run()`), pin holds are cleared (temps drop their
    NodeRefs). Any snapshot entry that is no longer marked input/output is
    passed to `Runtime::invalidate_logical_tiles` once — no full tile-map scan.
+   Entries still marked at `wait()` stay on `pending_output_reclaim` across
+   graph compaction so the **next** `compile_graph()` can reclaim them after
+   Python `del`s the tensors (do not clear that list in `drop_all_ops`
+   compaction — that leaked one step of activation tiles per iteration).
 4. Mid-phase, ``execute_range`` queues unmarked tiles after their last
    consumer; ``Runtime::wait()`` invalidates them after StarPU drains.
    Core ``*`` wrappers skip ``starpu_task_wait_for_all`` while submit is

--- a/nntile/include/nntile/runtime.hh
+++ b/nntile/include/nntile/runtime.hh
@@ -54,11 +54,14 @@ class Runtime
     void compile();
 
     //! Submit ops [op_begin, op_end) asynchronously (no StarPU drain).
-    //! Call ``wait()`` before reading outputs or reclaiming tiles.
+    //! After each submitted op, last-consumer tiles are invalidated via
+    //! ``invalidate_submit`` and dropped from ``tile_map_`` (async w.r.t.
+    //! already-submitted consumers). Call ``wait()`` to join StarPU before
+    //! host readout.
     //! If ``submit_tasks`` is false, skip ``OpNode::execute`` (no StarPU
-    //! inserts) but still advance the executed watermark and queue
-    //! last-consumer tile reclaim — required so incremental ``compile()``
-    //! stays O(pending) under dry-run profiling.
+    //! inserts) but still advance the executed watermark and last-consumer
+    //! reclaim — required so incremental ``compile()`` stays O(pending)
+    //! under dry-run profiling.
     void execute_range(
         size_t op_begin,
         size_t op_end,
@@ -99,8 +102,9 @@ class Runtime
     void bind_data(TileNode const *tile, const std::vector<T> &data);
 
     //! Submit all compiled ops asynchronously (no StarPU drain).
-    //! Call ``wait()`` to join and flush last-consumer reclaim. Same
-    //! submit contract as ``execute_range(0, execution_op_count())``.
+    //! Last-consumer ``invalidate_submit`` runs during submit (see
+    //! ``execute_range``). Call ``wait()`` to join StarPU. Same submit
+    //! contract as ``execute_range(0, execution_op_count())``.
     void execute();
 
     //! StarPU worker for ``STARPU_EXECUTE_ON_WORKER`` during tile op execution,
@@ -110,7 +114,8 @@ class Runtime
     int starpu_worker_hint() const noexcept { return starpu_worker_hint_; }
 
     //! Block until all tasks submitted by ``execute()`` / ``execute_range()``
-    //! have finished, then flush queued last-consumer tile reclaim.
+    //! have finished. Last-consumer tile invalidation already ran during
+    //! submit; this only drains StarPU.
     void wait();
 
     //! Read a logical tensor or tile buffer marked for host I/O (input or
@@ -256,8 +261,8 @@ class Runtime
     std::unordered_map<const TileNode *, std::shared_ptr<void>> tile_adoption_;
     std::unordered_set<const TileNode *> live_tile_nodes_;
     std::unordered_map<const TileNode *, size_t> tile_last_consumer_op_;
-    //! Tiles whose last consumer ran during async execute_range; flushed in
-    //! ``wait()`` after ``starpu_task_wait_for_all``.
+    //! Scratch for last-consumer tiles; flushed via invalidate_submit during
+    //! ``execute_range`` (not deferred to ``wait()``).
     std::vector<const TileNode *> queued_dead_tiles_;
     //! Highest exclusive op index already run via execute / execute_range.
     size_t executed_op_end_ = 0;

--- a/nntile/include/nntile/runtime.hh
+++ b/nntile/include/nntile/runtime.hh
@@ -66,6 +66,13 @@ class Runtime
 
     size_t execution_op_count() const { return execution_order_.size(); }
 
+    //! Exclusive end index of the last op in ``[op_begin, op_end)`` that
+    //! lists ``tile`` as an input. Returns ``op_begin`` if none.
+    size_t last_input_consumer_end(
+        TileNode const *tile,
+        size_t op_begin,
+        size_t op_end) const;
+
     //! Bind host data to a logical tensor or scatter to its tiles.
     template <typename T>
     void bind_data(

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -761,6 +761,35 @@ void Runtime::allocate_missing_tiles()
     compiled_tile_node_count_ = all_tiles.size();
 }
 
+size_t Runtime::last_input_consumer_end(
+    TileNode const *tile,
+    size_t op_begin,
+    size_t op_end) const
+{
+    if (tile == nullptr || op_begin >= op_end)
+    {
+        return op_begin;
+    }
+    if (op_end > execution_order_.size())
+    {
+        throw std::out_of_range(
+            "Runtime::last_input_consumer_end: bad range");
+    }
+    size_t last = op_begin;
+    for (size_t i = op_begin; i < op_end; ++i)
+    {
+        for (TileNode const *in : execution_order_[i]->inputs())
+        {
+            if (in == tile)
+            {
+                last = i + 1;
+                break;
+            }
+        }
+    }
+    return last;
+}
+
 void Runtime::execute_range(
     size_t op_begin,
     size_t op_end,

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -216,12 +216,17 @@ void Runtime::invalidate_logical_tiles(
     {
         return;
     }
+    // Clear tile marks to match the unmarked logical. Ingress staging
+    // tiles are built with mark_input(true); leaving that set made
+    // reclaim a no-op and kept a full-size StarPU buffer beside L
+    // (≈2× VRAM with untiled single-tile layouts).
     for (TileGraph::TileNode *tile : desc->tiles)
     {
         if (tile == nullptr)
         {
             continue;
         }
+        tile->mark_input(false);
         tile->mark_output(false);
     }
 
@@ -229,7 +234,7 @@ void Runtime::invalidate_logical_tiles(
     to_release.reserve(desc->tiles.size());
     for (TileGraph::TileNode *tile : desc->tiles)
     {
-        if (tile == nullptr || tile->is_input())
+        if (tile == nullptr)
         {
             continue;
         }

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -823,10 +823,12 @@ void Runtime::execute_range(
             }
             execution_order_[i]->execute(*this);
         }
-        // Always queue last-consumer reclaim. Skipping this (and skipping
-        // the executed_op_end_ update below) makes the next compile treat
-        // the full history as pending — O(session) DCE/allocate.
+        // Last-consumer reclaim during run()/submit: invalidate_submit is
+        // ordered after the consumer task already inserted above. Do not
+        // defer to wait() — that kept pre-ReLU activations resident for the
+        // whole forward+backward phase (~2× activation VRAM).
         queue_dead_tiles_after_op(i);
+        flush_queued_dead_tiles();
     }
     if (op_end > executed_op_end_)
     {
@@ -844,7 +846,7 @@ void Runtime::execute()
     executed_op_end_ = 0;
     allocate_missing_tiles();
     // Submit only — same contract as execute_range. Call wait() to join
-    // StarPU and flush queued last-consumer reclaim.
+    // StarPU. Last-consumer invalidate_submit runs inside execute_range.
     execute_range(0, execution_order_.size());
 }
 
@@ -1116,6 +1118,8 @@ void Runtime::eliminate_dead_ops()
 void Runtime::wait()
 {
     starpu_task_wait_for_all();
+    // Last-consumer invalidate_submit already ran in execute_range / run().
+    // Drain any stragglers if a path queued without flushing.
     flush_queued_dead_tiles();
 }
 

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -255,7 +255,10 @@ Architecture reference:
 - Every ``device=nntile`` tensor uses **0-byte** ``Storage``. Payload lives in
   StarPU tiles behind ``NodeRef`` → ``NNTileBinding { logical L }``.
 - **Staging ``S`` is ephemeral** (not stored in the binding): created for each
-  ``.to("nntile")`` scatter or ``.cpu()`` gather, then invalidated after run.
+  ``.to("nntile")`` scatter or ``.cpu()`` gather, then **fully released** after
+  ``wait()`` (StarPU tile buffers dropped from the runtime map; not merely
+  ``invalidate_submit``). Ingress ``S`` tiles are built with ``mark_input``;
+  reclaim clears those marks so untiled ``L``+``S`` do not stay at ≈2× VRAM.
 - Ingress is **one-shot** per tensor via ``.to("nntile")``; CPU→bound-nntile
   copy raises.
 - **Views / reshape / contiguous-preserving permute** share ``NodeRef`` (no

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -266,8 +266,9 @@ Architecture reference:
   data copy). **nntile→nntile ``copy_``** with matching shape/dtype also
   **aliases** ``NodeRef`` (no tile copy).
 - ``Tensor.contiguous()`` is unsupported on non-contiguous nntile tensors.
-- During ``run()``, intermediate StarPU tile buffers may be released after
-  their last consumer when not marked as inputs/outputs.
+- During ``run()`` / ``execute_range``, intermediate StarPU tile buffers are
+  released after their last consumer is submitted (``invalidate_submit``), when
+  not marked as inputs/outputs — not deferred until ``wait()``.
 - On each ``compile_graph()``, ``Runtime`` refreshes tile marks from logical
   ``mark_output`` / ``mark_input`` for the pending slice. torch_nntile snapshots
   phase outputs and, after ``wait()`` (and again at the next compile), calls

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -254,11 +254,12 @@ Architecture reference:
 
 - Every ``device=nntile`` tensor uses **0-byte** ``Storage``. Payload lives in
   StarPU tiles behind ``NodeRef`` → ``NNTileBinding { logical L }``.
-- **Staging ``S`` is ephemeral** (not stored in the binding): created for each
-  ``.to("nntile")`` scatter or ``.cpu()`` gather, then **fully released** after
-  ``wait()`` (StarPU tile buffers dropped from the runtime map; not merely
-  ``invalidate_submit``). Ingress ``S`` tiles are built with ``mark_input``;
-  reclaim clears those marks so untiled ``L``+``S`` do not stay at ≈2× VRAM.
+- **Staging ``S`` is ephemeral** (not stored in the binding): created on StarPU
+  for each ``.to("nntile")`` scatter or ``.cpu()`` gather. During ``run()`` of
+  an ingress scatter phase, each ``S`` is destroyed right after its scatter
+  finishes so StarPU's allocation cache can reuse that CUDA chunk for the next
+  logical ``L`` (batching all scatters then unregistering all ``S`` left
+  cached buffers and settled at ≈2× VRAM).
 - Ingress is **one-shot** per tensor via ``.to("nntile")``; CPU→bound-nntile
   copy raises.
 - **Views / reshape / contiguous-preserving permute** share ``NodeRef`` (no

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -872,10 +872,10 @@ void compact_tensor_graph_session_locked()
         return;
     }
     g_graph->drop_all_ops();
-    if (g_exec != nullptr)
-    {
-        g_exec->pending_output_reclaim.clear();
-    }
+    // Keep pending_output_reclaim. Step temps are often still mark_output
+    // at wait() (Python dels them after wait); reclaim parks them as
+    // still_marked. Clearing here dropped that list and leaked their
+    // StarPU tiles every iteration (VRAM grew without CE).
 }
 
 void compile_graph_locked(

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -566,34 +566,24 @@ void write_cpu_bytes_to_staging_locked(
     runtime.mark_initialized(staging);
 }
 
-void invalidate_staging_tile_submit_locked(
-    nntile::TensorGraph::TensorNode *staging)
+void release_io_staging_locked(nntile::TensorGraph::TensorNode *staging)
 {
     if (staging == nullptr || g_exec == nullptr || g_exec->runtime == nullptr)
     {
         return;
     }
-    nntile::Runtime &runtime = *g_exec->runtime;
-    // Keep map reclaim even when SKIP_STARPU disables submit/acquire.
-    runtime.wait();
-    nntile::TileGraph::TileNode *tile =
-        require_single_staging_tile_locked(staging);
-    switch (staging->dtype())
+    // Clear logical marks, then drop StarPU tile buffers from
+    // Runtime::tile_map_ (invalidate_submit alone left handles live).
+    staging->mark_input(false);
+    staging->mark_output(false);
+    g_exec->runtime->invalidate_logical_tiles(staging);
+    g_exec->inc_state.tensor_to_tiles.erase(staging);
+    g_exec->inc_state.tensor_layout_fp.erase(staging);
+    g_exec->tile_map.erase(staging);
+    if (g_exec->session_tiling != nullptr)
     {
-    case nntile::DataType::FP32:
-        runtime.get_tile<nntile::fp32_t>(tile).invalidate_submit();
-        break;
-    case nntile::DataType::INT64:
-        runtime.get_tile<nntile::int64_t>(tile).invalidate_submit();
-        break;
-    case nntile::DataType::BOOL:
-        runtime.get_tile<nntile::bool_t>(tile).invalidate_submit();
-        break;
-    default:
-        throw std::runtime_error(
-            "torch_nntile: unsupported staging invalidate dtype");
+        g_exec->session_tiling->erase(staging);
     }
-    runtime.invalidate_initialized(staging);
 }
 
 void read_staging_to_host_locked(
@@ -1032,20 +1022,7 @@ void finish_run_locked()
     for (nntile::TensorGraph::TensorNode *staging :
         g_exec->pending_scatter_stagings)
     {
-        invalidate_staging_tile_submit_locked(staging);
-        // .to("nntile") marks ingress staging as input; clear marks after
-        // scatter completes so later seals do not keep carrying stagings.
-        // Drop incremental tile state so the next compile cannot reuse the
-        // invalidated staging tile nodes and allocate empty replacements.
-        staging->mark_input(false);
-        staging->mark_output(false);
-        g_exec->inc_state.tensor_to_tiles.erase(staging);
-        g_exec->inc_state.tensor_layout_fp.erase(staging);
-        g_exec->tile_map.erase(staging);
-        if (g_exec->session_tiling != nullptr)
-        {
-            g_exec->session_tiling->erase(staging);
-        }
+        release_io_staging_locked(staging);
     }
     g_exec->pending_scatter_stagings.clear();
     if (g_defer_pending_clear_after_run)
@@ -1307,8 +1284,7 @@ void gather_logical_to_staging_and_read_locked(
     finish_run_locked();
 
     read_staging_to_host_locked(staging, host_ptr, dtype, count);
-    invalidate_staging_tile_submit_locked(staging);
-    staging->mark_output(false);
+    release_io_staging_locked(staging);
     g_timing.host_readout_s += seconds_since(t0);
     ++g_timing.host_readout_calls;
 }

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -1058,7 +1058,7 @@ void run_graph_locked()
         SteadyClock::time_point const t0 = SteadyClock::now();
         bool const submit = !skip_starpu_submit_and_acquire();
         // Always call execute_range so Runtime::executed_op_end_ advances and
-        // last-consumer tiles are queued for wait()-time flush. SKIP_STARPU
+        // last-consumer tiles get invalidate_submit during submit. SKIP_STARPU
         // only disables OpNode::execute (StarPU task insert).
         if (!g_exec->pending_scatter_stagings.empty())
         {

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -43,6 +43,7 @@ std::vector<Index> tile_sizes_for_axis_extent(
     Index extent);
 } // namespace nntile
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
@@ -586,6 +587,78 @@ void release_io_staging_locked(nntile::TensorGraph::TensorNode *staging)
     }
 }
 
+//! Run pending tile ops, releasing each ingress ``S`` right after its
+//! scatter consumers finish.
+//!
+//! Batched ``.to("nntile")`` creates every ephemeral ``S`` first, then
+//! compile lowers every logical ``L``. Submitting all scatters before any
+//! ``S`` unregister leaves StarPU holding CUDA replicates of every ``S``
+//! beside every ``L``; unregister only parks those buffers in the
+//! allocation cache (``nvidia-smi`` stays ≈2×). Drain + destroy each
+//! ``S`` before the next scatter so the next ``L`` reuses the cached
+//! chunk instead of allocating another full working set.
+void run_pending_with_scatter_staging_release_locked(
+    std::size_t op_begin,
+    std::size_t op_end,
+    bool submit_tasks)
+{
+    struct ReleasePoint
+    {
+        std::size_t after_op_end = 0;
+        nntile::TensorGraph::TensorNode *staging = nullptr;
+    };
+    std::vector<ReleasePoint> points;
+    points.reserve(g_exec->pending_scatter_stagings.size());
+    for (nntile::TensorGraph::TensorNode *staging :
+        g_exec->pending_scatter_stagings)
+    {
+        if (staging == nullptr)
+        {
+            continue;
+        }
+        std::size_t after = op_begin;
+        auto const found = g_exec->tile_map.find(staging);
+        if (found != g_exec->tile_map.end() && found->second.size() == 1 &&
+            found->second[0] != nullptr)
+        {
+            after = g_exec->runtime->last_input_consumer_end(
+                found->second[0],
+                op_begin,
+                op_end);
+        }
+        points.push_back(ReleasePoint{after, staging});
+    }
+    std::stable_sort(
+        points.begin(),
+        points.end(),
+        [](ReleasePoint const &a, ReleasePoint const &b)
+        {
+            return a.after_op_end < b.after_op_end;
+        });
+
+    std::size_t cursor = op_begin;
+    for (ReleasePoint const &pt : points)
+    {
+        if (pt.after_op_end > cursor)
+        {
+            g_exec->runtime->execute_range(
+                cursor,
+                pt.after_op_end,
+                submit_tasks);
+            cursor = pt.after_op_end;
+        }
+        // Join before destroying S so its CUDA replicate can enter the
+        // allocation cache for the next L allocate.
+        g_exec->runtime->wait();
+        release_io_staging_locked(pt.staging);
+    }
+    if (cursor < op_end)
+    {
+        g_exec->runtime->execute_range(cursor, op_end, submit_tasks);
+    }
+    g_exec->pending_scatter_stagings.clear();
+}
+
 void read_staging_to_host_locked(
     nntile::TensorGraph::TensorNode *staging,
     void *host_ptr,
@@ -976,20 +1049,33 @@ void run_graph_locked()
     {
         return;
     }
-    // Submit only. Never wait here — callers use wait_graph_session() /
-    // torch_nntile.wait() for synchronization and post-run reclaim.
+    // Submit only (except ingress scatters — see below). Callers use
+    // wait_graph_session() / torch_nntile.wait() for post-run reclaim.
     if (g_exec->pending_exec_op_end > g_exec->pending_exec_op_begin)
     {
         std::uint64_t const phase_ops = static_cast<std::uint64_t>(
             g_exec->pending_exec_op_end - g_exec->pending_exec_op_begin);
         SteadyClock::time_point const t0 = SteadyClock::now();
+        bool const submit = !skip_starpu_submit_and_acquire();
         // Always call execute_range so Runtime::executed_op_end_ advances and
         // last-consumer tiles are queued for wait()-time flush. SKIP_STARPU
         // only disables OpNode::execute (StarPU task insert).
-        g_exec->runtime->execute_range(
-            g_exec->pending_exec_op_begin,
-            g_exec->pending_exec_op_end,
-            !skip_starpu_submit_and_acquire());
+        if (!g_exec->pending_scatter_stagings.empty())
+        {
+            // Per-S release so StarPU's allocation cache can reuse each
+            // ephemeral CUDA chunk for the next logical L (avoids ≈2×).
+            run_pending_with_scatter_staging_release_locked(
+                g_exec->pending_exec_op_begin,
+                g_exec->pending_exec_op_end,
+                submit);
+        }
+        else
+        {
+            g_exec->runtime->execute_range(
+                g_exec->pending_exec_op_begin,
+                g_exec->pending_exec_op_end,
+                submit);
+        }
         g_timing.run_s += seconds_since(t0);
         ++g_timing.run_calls;
         g_timing.run_ops += phase_ops;
@@ -997,8 +1083,7 @@ void run_graph_locked()
         g_exec->pending_exec_op_begin = g_exec->pending_exec_op_end;
     }
     // Always require wait() for compile-side cleanup (pin_hold, reclaim,
-    // scatter stagings, deferred pending clear) — including empty post-DCE
-    // phases that submit no StarPU tasks.
+    // deferred pending clear) — including empty post-DCE phases.
     g_run_cleanup_pending = true;
 }
 
@@ -1019,6 +1104,8 @@ void finish_run_locked()
     // Always join + reclaim so tile_map_ stays O(live). SKIP_STARPU only
     // skips compute submit and host↔tile acquire/memcpy.
     g_exec->runtime->wait();
+    // Ingress S is normally released during run() (per-scatter). Any
+    // leftover (e.g. empty execute range) is cleaned here.
     for (nntile::TensorGraph::TensorNode *staging :
         g_exec->pending_scatter_stagings)
     {

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -21,6 +21,9 @@ training time.
 
 Pass ``--compare-torch`` with ``--device nntile`` to also train a CPU
 PyTorch reference and print per-epoch loss / final weight parity.
+Nntile-only flags (``--ncpu``, ``--ncuda``, ``--restrict-*``,
+``--axis-tiling``, ``--print-axis-groups``, ``--compare-torch``) are
+accepted on ``--device cpu`` / ``cuda`` but ignored (reported in output).
 
 Axis-group naming and tiling (optional) are configured in this script:
 
@@ -299,20 +302,26 @@ def _build_parser() -> argparse.ArgumentParser:
         "--ncpu",
         type=int,
         default=-1,
-        help="StarPU CPU workers for nntile (-1 = env default)",
+        help=(
+            "StarPU CPU workers for nntile (-1 = env default; "
+            "ignored on --device cpu/cuda)"
+        ),
     )
     parser.add_argument(
         "--ncuda",
         type=int,
         default=-1,
-        help="StarPU CUDA workers for nntile (-1 = env default)",
+        help=(
+            "StarPU CUDA workers for nntile (-1 = env default; "
+            "ignored on --device cpu/cuda)"
+        ),
     )
     parser.add_argument(
         "--compare-torch",
         action="store_true",
         help=(
             "With --device nntile: also train a CPU PyTorch reference and "
-            "print loss/weight parity"
+            "print loss/weight parity (ignored on --device cpu/cuda)"
         ),
     )
     parser.add_argument(
@@ -322,23 +331,33 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="NAME=SIZES",
         help=(
             "Axis-group tiling for nntile, e.g. batch=15000,15000,15000,15000 "
-            "or features=392,392 or hidden=128,128. Repeat for multiple groups."
+            "or features=392,392 or hidden=128,128. Repeat for multiple "
+            "groups (ignored on --device cpu/cuda)."
         ),
     )
     parser.add_argument(
         "--print-axis-groups",
         action="store_true",
-        help="Print axis groups after the first nntile training step",
+        help=(
+            "Print axis groups after the first nntile training step "
+            "(ignored on --device cpu/cuda)"
+        ),
     )
     parser.add_argument(
         "--restrict-cuda",
         action="store_true",
-        help="Pin nntile kernels to CUDA workers (requires ncuda > 0)",
+        help=(
+            "Pin nntile kernels to CUDA workers (requires ncuda > 0; "
+            "ignored on --device cpu/cuda)"
+        ),
     )
     parser.add_argument(
         "--restrict-cpu",
         action="store_true",
-        help="Pin nntile kernels to CPU workers",
+        help=(
+            "Pin nntile kernels to CPU workers "
+            "(ignored on --device cpu/cuda)"
+        ),
     )
     parser.add_argument(
         "--verbose",
@@ -352,31 +371,55 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _nntile_only_args_set(args: argparse.Namespace) -> list[str]:
+    """Return nntile-only CLI flags that were explicitly set."""
+    ignored: list[str] = []
+    if args.ncpu != -1:
+        ignored.append(f"--ncpu={args.ncpu}")
+    if args.ncuda != -1:
+        ignored.append(f"--ncuda={args.ncuda}")
+    if args.restrict_cuda:
+        ignored.append("--restrict-cuda")
+    if args.restrict_cpu:
+        ignored.append("--restrict-cpu")
+    if args.axis_tiling:
+        ignored.append("--axis-tiling")
+    if args.print_axis_groups:
+        ignored.append("--print-axis-groups")
+    if args.compare_torch:
+        ignored.append("--compare-torch")
+    return ignored
+
+
 def main() -> None:
     args = _build_parser().parse_args()
     axis_group_tiling = build_axis_group_tiling(args.axis_tiling)
     compare_torch = bool(args.compare_torch)
     use_nntile = args.device == "nntile"
 
-    if compare_torch and not use_nntile:
-        raise SystemExit("--compare-torch requires --device nntile")
-    if args.restrict_cuda and args.restrict_cpu:
+    if use_nntile and args.restrict_cuda and args.restrict_cpu:
         raise SystemExit("Pass only one of --restrict-cuda / --restrict-cpu")
-    if (args.restrict_cuda or args.restrict_cpu) and not use_nntile:
-        raise SystemExit(
-            "--restrict-cuda / --restrict-cpu require --device nntile"
-        )
-    if axis_group_tiling and not use_nntile:
-        raise SystemExit("--axis-tiling requires --device nntile")
 
     if use_nntile and compare_torch:
         print("Mode: nntile + CPU torch parity")
     else:
         print(f"Mode: {args.device}-only")
+
     if use_nntile:
         print(f"StarPU workers: ncpu={args.ncpu} ncuda={args.ncuda}")
-    if axis_group_tiling:
-        print(f"Axis-group tiling: {axis_group_tiling}")
+        if axis_group_tiling:
+            print(f"Axis-group tiling: {axis_group_tiling}")
+    else:
+        # Accept nntile-only flags on torch paths; report and ignore them.
+        ignored = _nntile_only_args_set(args)
+        if ignored:
+            print(
+                "Ignoring nntile-only arguments on "
+                f"--device {args.device}: {', '.join(ignored)}"
+            )
+        compare_torch = False
+        axis_group_tiling = {}
+
     print(
         f"DeepReLU hidden_dim={args.hidden_dim} depth={args.depth} "
         f"epochs={args.epochs} device={args.device}"

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -3,22 +3,24 @@
 #                              (Skoltech), Russia. All rights reserved.
 #
 # @file torch_nntile/examples/train_deep_relu_mnist.py
-# Train DeepReLU on the full MNIST training set (60k batch) on nntile.
+# Train DeepReLU on the full MNIST training set (60k batch).
 
-"""Full-batch MNIST training with DeepReLU on device=\"nntile\".
+"""Full-batch MNIST training with DeepReLU (nntile parallelization demo).
 
-By default this script trains only on nntile (useful for larger tiled /
-multi-worker runs). Pass ``--compare-torch`` to also train a CPU PyTorch
-reference and print per-epoch loss / final weight parity.
+Trains ``DeepReLU.mnist()`` on the entire MNIST training set as one batch
+(60 000 images). Primary goal: show how well nntile parallelizes a large
+DeepReLU across StarPU CPU/CUDA workers.
 
-Cross-entropy is evaluated on nntile via ``torch_nntile.training.cross_entropy``
-(same tensor-op chain as ``NNCrossEntropyOp`` in libnntile). Logits are
-``[batch, classes]`` (class dim last). The scalar loss lives on
-``device="nntile"``; read it with ``loss.to("cpu")`` after ``compile_graph()`` and
-``run()`` in graph mode.
+Supports ``--device cpu`` / ``cuda`` (PyTorch SGD) and ``--device nntile``
+(``train_full_batch_step`` + StarPU). Pass ``--ncpu`` / ``--ncuda`` to set
+StarPU workers for the nntile path (``-1`` = env default).
 
-StarPU may use CUDA workers for the nntile path via ``STARPU_NCUDA`` and
-``--restrict-cuda``.
+Before training, the full MNIST batch (images + labels) and the model are
+moved onto the training device; the script prints prefetch time and wall
+training time.
+
+Pass ``--compare-torch`` with ``--device nntile`` to also train a CPU
+PyTorch reference and print per-epoch loss / final weight parity.
 
 Axis-group naming and tiling (optional) are configured in this script:
 
@@ -28,22 +30,25 @@ Axis-group naming and tiling (optional) are configured in this script:
   weight/grad/velocity matrix row or column of that size
 - ``classes`` — output logits dimension (10)
 
-Nntile-only (tiled CUDA workers)::
+Nntile (tiled CUDA workers)::
 
     export LD_LIBRARY_PATH=$PWD/build/nntile:/opt/starpu/lib
-    STARPU_NCPU=0 STARPU_NCUDA=2 \\
     python torch_nntile/examples/train_deep_relu_mnist.py \\
-        --restrict-cuda \\
+        --device nntile --ncpu 0 --ncuda 2 --restrict-cuda \\
         --epochs 5 \\
         --axis-tiling batch=15000,15000,15000,15000 \\
         --axis-tiling features=392,392 \\
         --axis-tiling hidden=128,128
 
-CPU torch parity check::
+CPU torch reference::
 
-    STARPU_NCPU=4 STARPU_NCUDA=0 \\
     python torch_nntile/examples/train_deep_relu_mnist.py \\
-        --compare-torch --epochs 5
+        --device cpu --epochs 5
+
+Nntile + CPU torch parity::
+
+    python torch_nntile/examples/train_deep_relu_mnist.py \\
+        --device nntile --ncpu 4 --ncuda 0 --compare-torch --epochs 5
 
 Run instructions and expected output:
 ``docs/torch_nntile.md`` (DeepReLU MNIST example section).
@@ -53,6 +58,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import time
 from pathlib import Path
 
 import torch
@@ -112,6 +118,11 @@ def build_axis_group_tiling(
     return tiling
 
 
+def synchronize_device(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
 def _clone_state_dict_cpu(model: torch.nn.Module) -> dict[str, torch.Tensor]:
     return {
         name: tensor.detach().cpu().clone()
@@ -155,8 +166,9 @@ def train_torch_reference(
     *,
     epochs: int,
     learning_rate: float,
+    device: torch.device | None = None,
 ) -> list[float]:
-    """Pure-PyTorch full-batch SGD on CPU."""
+    """Pure-PyTorch full-batch SGD on preloaded device tensors."""
     losses: list[float] = []
     for epoch in range(epochs):
         for param in model.parameters():
@@ -168,9 +180,11 @@ def train_torch_reference(
             for param in model.parameters():
                 if param.grad is not None:
                     param.add_(param.grad, alpha=-learning_rate)
+        if device is not None:
+            synchronize_device(device)
         value = float(loss.detach().item())
         losses.append(value)
-        print(f"[cpu] epoch {epoch + 1}/{epochs}  loss={value:.6f}")
+        print(f"[torch] epoch {epoch + 1}/{epochs}  loss={value:.6f}")
     return losses
 
 
@@ -240,12 +254,10 @@ def train_on_nntile(
     axis_group_tiling: dict[str, list[int]] | None = None,
     print_axis_groups: bool = False,
 ) -> list[float]:
+    """Train on preloaded nntile tensors (images/labels already on device)."""
     import torch_nntile
     from torch_nntile.training import train_full_batch_step
 
-    with torch.no_grad():
-        x = images.to("nntile")
-        y = labels.to("nntile")
     if axis_group_tiling is not None:
         for name, tile_sizes in axis_group_tiling.items():
             torch_nntile.set_axis_group_tiling(name, tile_sizes)
@@ -257,8 +269,8 @@ def train_on_nntile(
     for epoch in range(epochs):
         loss = train_full_batch_step(
             model,
-            x,
-            y,
+            images,
+            labels,
             learning_rate,
             name_axis_groups=name_axis_groups,
             axis_group_tiling=axis_group_tiling,
@@ -278,11 +290,29 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--hidden-dim", type=int, default=256)
     parser.add_argument("--depth", type=int, default=5)
     parser.add_argument(
+        "--device",
+        default="nntile",
+        choices=("cpu", "cuda", "nntile"),
+        help="Training device (default: nntile)",
+    )
+    parser.add_argument(
+        "--ncpu",
+        type=int,
+        default=-1,
+        help="StarPU CPU workers for nntile (-1 = env default)",
+    )
+    parser.add_argument(
+        "--ncuda",
+        type=int,
+        default=-1,
+        help="StarPU CUDA workers for nntile (-1 = env default)",
+    )
+    parser.add_argument(
         "--compare-torch",
         action="store_true",
         help=(
-            "Also train a CPU PyTorch reference and print loss/weight "
-            "parity (default: nntile-only)"
+            "With --device nntile: also train a CPU PyTorch reference and "
+            "print loss/weight parity"
         ),
     )
     parser.add_argument(
@@ -306,6 +336,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Pin nntile kernels to CUDA workers (requires ncuda > 0)",
     )
     parser.add_argument(
+        "--restrict-cpu",
+        action="store_true",
+        help="Pin nntile kernels to CPU workers",
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help=(
@@ -321,31 +356,41 @@ def main() -> None:
     args = _build_parser().parse_args()
     axis_group_tiling = build_axis_group_tiling(args.axis_tiling)
     compare_torch = bool(args.compare_torch)
+    use_nntile = args.device == "nntile"
 
-    if compare_torch:
+    if compare_torch and not use_nntile:
+        raise SystemExit("--compare-torch requires --device nntile")
+    if args.restrict_cuda and args.restrict_cpu:
+        raise SystemExit("Pass only one of --restrict-cuda / --restrict-cpu")
+    if (args.restrict_cuda or args.restrict_cpu) and not use_nntile:
+        raise SystemExit(
+            "--restrict-cuda / --restrict-cpu require --device nntile"
+        )
+    if axis_group_tiling and not use_nntile:
+        raise SystemExit("--axis-tiling requires --device nntile")
+
+    if use_nntile and compare_torch:
         print("Mode: nntile + CPU torch parity")
     else:
-        print("Mode: nntile-only (pass --compare-torch for CPU parity)")
+        print(f"Mode: {args.device}-only")
+    if use_nntile:
+        print(f"StarPU workers: ncpu={args.ncpu} ncuda={args.ncuda}")
     if axis_group_tiling:
         print(f"Axis-group tiling: {axis_group_tiling}")
-    print(f"DeepReLU hidden_dim={args.hidden_dim} depth={args.depth}")
+    print(
+        f"DeepReLU hidden_dim={args.hidden_dim} depth={args.depth} "
+        f"epochs={args.epochs} device={args.device}"
+    )
 
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     print("Loading MNIST training set (60 000 images, single batch)...")
-    images, labels = load_mnist_full_batch(args.data_dir)
-    print(f"  images {tuple(images.shape)}, labels {tuple(labels.shape)}")
-
-    import torch_nntile
-    from torch_nntile import _C
-    from torch_nntile.training import clone_model_weights, max_weight_delta
-
-    if not _C.has_libnntile():
-        raise SystemExit(
-            "torch_nntile was built without libnntile. "
-            "Set NNTILE_BUILD_DIR and reinstall."
-        )
+    images_cpu, labels_cpu = load_mnist_full_batch(args.data_dir)
+    print(
+        f"  images {tuple(images_cpu.shape)}, "
+        f"labels {tuple(labels_cpu.shape)}"
+    )
 
     model_init = build_torch_model(
         seed=args.seed,
@@ -359,86 +404,162 @@ def main() -> None:
     torch_losses: list[float] | None = None
     final_torch: dict[str, torch.Tensor] | None = None
     if compare_torch:
-        print("\nTraining on torch (cpu)...")
+        print("\nTraining CPU torch reference (parity)...")
         torch_losses = train_torch_reference(
             model_init,
-            images,
-            labels,
+            images_cpu,
+            labels_cpu,
             epochs=args.epochs,
             learning_rate=args.lr,
+            device=torch.device("cpu"),
         )
         final_torch = _clone_state_dict_cpu(model_init)
         if args.verbose:
             print_state_dict_norms("torch/final", final_torch)
     del model_init
 
-    torch_nntile.init_context(
-        ncpu=-1,
-        ncuda=-1,
-        verbose=int(args.verbose),
-        cpu_fallback=False,
-    )
-    if args.restrict_cuda:
-        torch_nntile.restrict_cuda()
-        print("Worker placement: CUDA only (restrict_cuda)")
+    if use_nntile:
+        import torch_nntile
+        from torch_nntile import _C
+        from torch_nntile.training import clone_model_weights, max_weight_delta
 
-    try:
-        model_nnt = build_nntile_model(
-            hidden_dim=args.hidden_dim,
-            depth=args.depth,
-            state_dict=init_weights,
+        if not _C.has_libnntile():
+            raise SystemExit(
+                "torch_nntile was built without libnntile. "
+                "Set NNTILE_BUILD_DIR and reinstall."
+            )
+
+        torch_nntile.init_context(
+            ncpu=args.ncpu,
+            ncuda=args.ncuda,
+            verbose=int(args.verbose),
+            cpu_fallback=False,
         )
-        # Do not .cpu() / clone_model_weights before the first tiled compile:
-        # that seals untiled layouts into the TileGraph and later
-        # --axis-tiling hits layout_fingerprint mismatch.
+        if args.restrict_cuda:
+            torch_nntile.restrict_cuda()
+            print("Worker placement: CUDA only (restrict_cuda)")
+        elif args.restrict_cpu:
+            torch_nntile.restrict_cpu()
+            print("Worker placement: CPU only (restrict_cpu)")
+
+        try:
+            print("Prefetching MNIST + model to nntile...")
+            t_pre0 = time.perf_counter()
+            with torch.no_grad():
+                images = images_cpu.to("nntile")
+                labels = labels_cpu.to("nntile")
+                model_nnt = build_nntile_model(
+                    hidden_dim=args.hidden_dim,
+                    depth=args.depth,
+                    state_dict=init_weights,
+                )
+            # Ensure transfers are complete before stopping the clock.
+            torch_nntile.wait()
+            prefetch_s = time.perf_counter() - t_pre0
+            print(
+                f"timing host→nntile prefetch: {prefetch_s:.3f}s "
+                f"(MNIST images {images_cpu.numel()}, "
+                f"labels {labels_cpu.numel()}, + model)"
+            )
+            # Do not .cpu() / clone_model_weights before the first tiled
+            # compile: that seals untiled layouts into the TileGraph and
+            # later --axis-tiling hits layout_fingerprint mismatch.
+
+            print("\nTraining on nntile...")
+            t_train0 = time.perf_counter()
+            nnt_losses = train_on_nntile(
+                model_nnt,
+                images,
+                labels,
+                epochs=args.epochs,
+                learning_rate=args.lr,
+                hidden_dim=args.hidden_dim,
+                axis_group_tiling=axis_group_tiling or None,
+                print_axis_groups=args.print_axis_groups,
+            )
+            train_wall_s = time.perf_counter() - t_train0
+            print(
+                f"timing nntile train wall: {train_wall_s:.3f}s "
+                f"({args.epochs} epochs)"
+            )
+
+            nnt_path = output_dir / "deep_relu_mnist_nntile.pt"
+            # Host gather only after training (safe with --axis-tiling).
+            final_nnt = clone_model_weights(model_nnt)
+            torch.save(final_nnt, nnt_path)
+            print(f"\nSaved nntile model (CPU tensors) to {nnt_path}")
+            if args.verbose:
+                print_state_dict_norms("nntile/final", final_nnt)
+
+            if compare_torch:
+                assert torch_losses is not None and final_torch is not None
+                torch_path = output_dir / "deep_relu_mnist_torch_cpu.pt"
+                torch.save(final_torch, torch_path)
+                weight_delta = max_weight_delta(final_torch, final_nnt)
+
+                print("\nLoss comparison (torch/cpu vs nntile):")
+                for epoch, (loss_torch, loss_nnt) in enumerate(
+                    zip(torch_losses, nnt_losses), start=1
+                ):
+                    print(
+                        f"  epoch {epoch}: torch={loss_torch:.6f}  "
+                        f"nntile={loss_nnt:.6f}  "
+                        f"diff={abs(loss_torch - loss_nnt):.3e}"
+                    )
+
+                print(
+                    f"\nFinal weight max |torch - nntile| = "
+                    f"{weight_delta:.3e}"
+                )
+                print(f"Saved torch model (CPU tensors) to {torch_path}")
+        finally:
+            torch_nntile.wait()
+            torch_nntile.shutdown_context()
+    else:
+        device = torch.device(args.device)
+        if device.type == "cuda" and not torch.cuda.is_available():
+            raise SystemExit("CUDA is not available")
+
+        from torch_nntile.models import DeepReLU
+
+        print(f"Prefetching MNIST + model to {device}...")
+        t_pre0 = time.perf_counter()
+        with torch.no_grad():
+            images = images_cpu.to(device, non_blocking=True)
+            labels = labels_cpu.to(device, non_blocking=True)
+            model = DeepReLU.mnist(
+                hidden_dim=args.hidden_dim,
+                depth=args.depth,
+            )
+            model.load_state_dict(init_weights)
+            model = model.to(device)
+            synchronize_device(device)
+        prefetch_s = time.perf_counter() - t_pre0
         print(
-            "Initial weights loaded from torch state_dict onto nntile "
-            "(host round-trip deferred until after training)"
+            f"timing host→{device} prefetch: {prefetch_s:.3f}s "
+            f"(MNIST images {images_cpu.numel()}, "
+            f"labels {labels_cpu.numel()}, + model)"
         )
 
-        print("\nTraining on nntile...")
-        nnt_losses = train_on_nntile(
-            model_nnt,
+        print(f"\nTraining on torch ({device})...")
+        t_train0 = time.perf_counter()
+        train_torch_reference(
+            model,
             images,
             labels,
             epochs=args.epochs,
             learning_rate=args.lr,
-            hidden_dim=args.hidden_dim,
-            axis_group_tiling=axis_group_tiling or None,
-            print_axis_groups=args.print_axis_groups,
+            device=device,
+        )
+        train_wall_s = time.perf_counter() - t_train0
+        print(
+            f"timing torch train wall: {train_wall_s:.3f}s "
+            f"({args.epochs} epochs)"
         )
 
-        nnt_path = output_dir / "deep_relu_mnist_nntile.pt"
-        # Host gather only after training (safe with --axis-tiling).
-        final_nnt = clone_model_weights(model_nnt)
-        torch.save(final_nnt, nnt_path)
-        print(f"\nSaved nntile model (CPU tensors) to {nnt_path}")
-        if args.verbose:
-            print_state_dict_norms("nntile/final", final_nnt)
-
-        if compare_torch:
-            assert torch_losses is not None and final_torch is not None
-            torch_path = output_dir / "deep_relu_mnist_torch_cpu.pt"
-            torch.save(final_torch, torch_path)
-            weight_delta = max_weight_delta(final_torch, final_nnt)
-
-            print("\nLoss comparison (torch/cpu vs nntile):")
-            for epoch, (loss_torch, loss_nnt) in enumerate(
-                zip(torch_losses, nnt_losses), start=1
-            ):
-                print(
-                    f"  epoch {epoch}: torch={loss_torch:.6f}  "
-                    f"nntile={loss_nnt:.6f}  "
-                    f"diff={abs(loss_torch - loss_nnt):.3e}"
-                )
-
-            print(
-                f"\nFinal weight max |torch - nntile| = {weight_delta:.3e}"
-            )
-            print(f"Saved torch model (CPU tensors) to {torch_path}")
-    finally:
-        torch_nntile.wait()
-        torch_nntile.shutdown_context()
+        torch_path = output_dir / f"deep_relu_mnist_torch_{device.type}.pt"
+        torch.save(_clone_state_dict_cpu(model), torch_path)
+        print(f"\nSaved torch model (CPU tensors) to {torch_path}")
 
 
 if __name__ == "__main__":

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -15,6 +15,11 @@ Supports ``--device cpu`` / ``cuda`` (PyTorch SGD) and ``--device nntile``
 (``train_full_batch_step`` + StarPU). Pass ``--ncpu`` / ``--ncuda`` to set
 StarPU workers for the nntile path (``-1`` = env default).
 
+Torch cannot use CUDA and the PrivateUse1 ``nntile`` device in one process
+(PyTorch >= 2.8). This script imports ``torch_nntile`` only for
+``--device nntile``; CUDA/CPU runs load ``DeepReLU`` without registering
+nntile. Use separate processes to compare cuda vs nntile.
+
 Before training, the full MNIST batch (images + labels) and the model are
 moved onto the training device; the script prints prefetch time and wall
 training time.
@@ -48,6 +53,11 @@ CPU torch reference::
     python torch_nntile/examples/train_deep_relu_mnist.py \\
         --device cpu --epochs 5
 
+CUDA torch reference (separate process from any nntile run)::
+
+    python torch_nntile/examples/train_deep_relu_mnist.py \\
+        --device cuda --epochs 5
+
 Nntile + CPU torch parity::
 
     python torch_nntile/examples/train_deep_relu_mnist.py \\
@@ -60,17 +70,40 @@ Run instructions and expected output:
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import sys
 import time
 from pathlib import Path
+from typing import Type
 
 import torch
+import torch.nn as nn
 from torchvision import datasets
 
 _REPO = Path(__file__).resolve().parents[2]
 _TORCH_NNTILE_ROOT = _REPO / "torch_nntile"
 if str(_TORCH_NNTILE_ROOT) not in sys.path:
     sys.path.insert(0, str(_TORCH_NNTILE_ROOT))
+
+_DeepReLU: Type[nn.Module] | None = None
+
+
+def _deep_relu_class() -> Type[nn.Module]:
+    """Load DeepReLU without importing ``torch_nntile`` (no PrivateUse1)."""
+    global _DeepReLU
+    if _DeepReLU is not None:
+        return _DeepReLU
+    path = _TORCH_NNTILE_ROOT / "torch_nntile" / "models" / "deep_relu.py"
+    spec = importlib.util.spec_from_file_location(
+        "torch_nntile_deep_relu_standalone",
+        path,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load DeepReLU from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    _DeepReLU = module.DeepReLU
+    return _DeepReLU
 
 
 def load_mnist_full_batch(
@@ -153,9 +186,8 @@ def build_torch_model(
     hidden_dim: int,
     depth: int,
 ) -> torch.nn.Module:
-    """Build DeepReLU on CPU with Kaiming init."""
-    from torch_nntile.models import DeepReLU
-
+    """Build DeepReLU on CPU with Kaiming init (no torch_nntile import)."""
+    DeepReLU = _deep_relu_class()
     torch.manual_seed(seed)
     model = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
     model.init_kaiming_uniform_(seed=seed)
@@ -236,9 +268,11 @@ def build_nntile_model(
     depth: int,
     state_dict: dict[str, torch.Tensor],
 ) -> torch.nn.Module:
-    """Clone CPU ``state_dict`` onto ``device='nntile'`` (requires init_context)."""
-    from torch_nntile.models import DeepReLU
+    """Clone CPU ``state_dict`` onto ``device='nntile'`` (requires init_context).
 
+    Call only after ``import torch_nntile`` has registered the device.
+    """
+    DeepReLU = _deep_relu_class()
     model = DeepReLU.mnist(hidden_dim=hidden_dim, depth=depth)
     with torch.no_grad():
         model.load_state_dict(state_dict)
@@ -559,12 +593,13 @@ def main() -> None:
             torch_nntile.wait()
             torch_nntile.shutdown_context()
     else:
+        # Do not import torch_nntile here: PrivateUse1 registration breaks
+        # CUDA autograd in the same process (PyTorch >= 2.8).
         device = torch.device(args.device)
         if device.type == "cuda" and not torch.cuda.is_available():
             raise SystemExit("CUDA is not available")
 
-        from torch_nntile.models import DeepReLU
-
+        DeepReLU = _deep_relu_class()
         print(f"Prefetching MNIST + model to {device}...")
         t_pre0 = time.perf_counter()
         with torch.no_grad():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns `train_deep_relu_mnist.py` with the reproduce-script device/timing UX, and fixes nntile activation VRAM residency from deferred StarPU tile reclaim.

## Device / timing UX

- `--device {cpu,cuda,nntile}` (default `nntile`), plus `--ncpu` / `--ncuda` / `--restrict-cpu`
- Reports prefetch time and wall train time
- Import `torch_nntile` only for `--device nntile` so CUDA and PrivateUse1 do not share one process

## Activation VRAM (last-consumer reclaim)

DeepReLU is bias-free `Linear → ReLU`. Eager PyTorch frees the GEMM dst `Y` after ReLU (autograd saves post-activation `Z`). torch_nntile also drops the Python/`NodeRef` for `Y`, but `execute_range` only **queued** dead tiles and flushed them in `wait()` — so all pre-ReLU activations stayed allocated for the whole forward+backward phase (~2× activation VRAM at `60k×4096`).

**Fix:** `Runtime::execute_range` now runs `invalidate_submit` + drops dead tiles from `tile_map_` after each submitted op (during `run()`), not at `wait()`. Probe: `Y` leaves `tile_map_` before `wait()`.

Also: ingress staging release after scatter; keep `pending_output_reclaim` across wait-time graph compact.

## Test plan

- [x] Runtime probe: pre-ReLU unmarked after ReLU → gone from `tile_map_` after `execute_range`, before `wait()`
- [x] `pytest -vv torch_nntile/tests/test_graph_execution.py` (16 passed, CPU)
- [ ] On GPU: confirm DeepReLU MNIST VRAM closer to the ~7.3GB eager baseline

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dc7c4df-9a83-4dd5-bdc4-d665a8851b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dc7c4df-9a83-4dd5-bdc4-d665a8851b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

