### PR TITLE
Fix ≈2× VRAM from unreclaimed ingress staging tiles

### DIFF
--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -16,7 +16,8 @@ TensorImpl → NNTileBackendMeta → NodeRef → NNTileBinding { logical L }
 - **`L` (logical):** the graph/compute node. `NodeRef` ctor/dtor drive
   `mark_output(true/false)` on `L`.
 - **`S` (staging):** **ephemeral**, not stored in `NNTileBinding`. Created per
-  I/O event, invalidated after scatter/gather run.
+  I/O event; after scatter/gather `wait()`, marks are cleared and StarPU
+  tile buffers are dropped from the runtime map (not left live).
 
 There is no side map (`g_tensor_nodes`) and no eager per-op flush. All ops
 record into a shared `TensorGraph`; the caller flushes with `compile_graph()`
@@ -54,8 +55,8 @@ collection scans the growing session heap and can dominate step time.
 
 | Direction | API | Behavior |
 |-----------|-----|----------|
-| Ingress | `.to("nntile")` / CPU→nntile `copy_` | Create `L`, attach `NodeRef`, create ephemeral single-tile `S`, write host bytes into `S`, record `scatter(S→L)`. Ingress is **once per tensor**; a second CPU copy into an already-bound tensor raises. After the scatter phase runs, ingress `S` is invalidated. |
-| Egress | `.cpu()` / `.to("cpu")` / nntile→CPU `copy_` | Create ephemeral `S`, record `clear(S)` + `gather(L→S)`, **auto-compile and run** any pending ops plus the gather phase, StarPU-read `S`, invalidate `S`. |
+| Ingress | `.to("nntile")` / CPU→nntile `copy_` | Create `L`, attach `NodeRef`, create ephemeral single-tile `S`, write host bytes into `S`, record `scatter(S→L)`. Ingress is **once per tensor**; a second CPU copy into an already-bound tensor raises. After the scatter phase `run()`/`wait()`, ingress `S` marks are cleared and StarPU tile buffers are **removed** from the runtime map (not left live after `invalidate_submit`). |
+| Egress | `.cpu()` / `.to("cpu")` / nntile→CPU `copy_` | Create ephemeral `S`, record `clear(S)` + `gather(L→S)`, **auto-compile and run** any pending ops plus the gather phase, StarPU-read `S`, then fully release `S` the same way. |
 
 ### `.cpu()` auto-flush (by design)
 
@@ -105,7 +106,7 @@ run backward (or ingress a real grad tensor via `.to("nntile")`) first.
 | # | Topic | Current behavior | Planned follow-up |
 |---|--------|------------------|-------------------|
 | D1 | TensorGraph metadata growth | Each `.cpu()` permanently appends `clear`, `gather`, and a new `io_staging_*` node (op list grows). Phase outputs cleared after `wait()` are reclaimed via `pending_output_reclaim` (O(phase outputs), not a full tile-map scan). Historical TileGraph/TensorGraph nodes still accumulate in memory. | Phase GC / compaction; reuse readout staging per session. |
-| D2 | Incremental tile-map growth | Every ingress/egress lowers a fresh ephemeral `S` into `inc_state.tensor_to_tiles`; entries are never removed. | Reclaim staging descriptors after invalidate; or pool single-tile `S` per `L`. |
+| D2 | Incremental tile-map growth | Every ingress/egress lowers a fresh ephemeral `S`. After scatter/gather `wait()`, logical marks are cleared and `Runtime::invalidate_logical_tiles` drops StarPU buffers (tile `mark_input` must be cleared too — ingress `S` was built with `mark_input(true)`, which previously skipped reclaim and left ≈2× VRAM next to untiled `L`). TensorGraph/TileGraph node metadata still accumulates. | Optional: pool single-tile `S` per `L`; compact historical tile nodes. |
 | D3 | Pin bookkeeping | Dedup uses `unordered_set<TensorImplKey>` while pinning; pins still clear on phase transfer. | Optional: trim earlier than phase seal if pin lists grow mid-phase. |
 | D4 | CE `ignore_index` mean | Mean CE uses `1/numel`; PyTorch uses `1/count_non_ignore`. | Graph-native valid-label count (or document as permanent limitation). |
 | D5 | `vector_norm` backward | Forward-only by design. | Add autograd when product needs it. |

--- a/docs/dev/torch_nntile_tensor_architecture.md
+++ b/docs/dev/torch_nntile_tensor_architecture.md
@@ -38,6 +38,10 @@ by marks, with an explicit pending list in torch_nntile:
 3. After `wait()` (following `run()`), pin holds are cleared (temps drop their
    NodeRefs). Any snapshot entry that is no longer marked input/output is
    passed to `Runtime::invalidate_logical_tiles` once — no full tile-map scan.
+   Entries still marked at `wait()` stay on `pending_output_reclaim` across
+   graph compaction so the **next** `compile_graph()` can reclaim them after
+   Python `del`s the tensors (do not clear that list in `drop_all_ops`
+   compaction — that leaked one step of activation tiles per iteration).
 4. Mid-phase, ``execute_range`` queues unmarked tiles after their last
    consumer; ``Runtime::wait()`` invalidates them after StarPU drains.
    Core ``*`` wrappers skip ``starpu_task_wait_for_all`` while submit is

--- a/nntile/src/runtime.cc
+++ b/nntile/src/runtime.cc
@@ -216,12 +216,17 @@ void Runtime::invalidate_logical_tiles(
     {
         return;
     }
+    // Clear tile marks to match the unmarked logical. Ingress staging
+    // tiles are built with mark_input(true); leaving that set made
+    // reclaim a no-op and kept a full-size StarPU buffer beside L
+    // (≈2× VRAM with untiled single-tile layouts).
     for (TileGraph::TileNode *tile : desc->tiles)
     {
         if (tile == nullptr)
         {
             continue;
         }
+        tile->mark_input(false);
         tile->mark_output(false);
     }
 
@@ -229,7 +234,7 @@ void Runtime::invalidate_logical_tiles(
     to_release.reserve(desc->tiles.size());
     for (TileGraph::TileNode *tile : desc->tiles)
     {
-        if (tile == nullptr || tile->is_input())
+        if (tile == nullptr)
         {
             continue;
         }

--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -255,7 +255,10 @@ Architecture reference:
 - Every ``device=nntile`` tensor uses **0-byte** ``Storage``. Payload lives in
   StarPU tiles behind ``NodeRef`` → ``NNTileBinding { logical L }``.
 - **Staging ``S`` is ephemeral** (not stored in the binding): created for each
-  ``.to("nntile")`` scatter or ``.cpu()`` gather, then invalidated after run.
+  ``.to("nntile")`` scatter or ``.cpu()`` gather, then **fully released** after
+  ``wait()`` (StarPU tile buffers dropped from the runtime map; not merely
+  ``invalidate_submit``). Ingress ``S`` tiles are built with ``mark_input``;
+  reclaim clears those marks so untiled ``L``+``S`` do not stay at ≈2× VRAM.
 - Ingress is **one-shot** per tensor via ``.to("nntile")``; CPU→bound-nntile
   copy raises.
 - **Views / reshape / contiguous-preserving permute** share ``NodeRef`` (no

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -872,10 +872,10 @@ void compact_tensor_graph_session_locked()
         return;
     }
     g_graph->drop_all_ops();
-    if (g_exec != nullptr)
-    {
-        g_exec->pending_output_reclaim.clear();
-    }
+    // Keep pending_output_reclaim. Step temps are often still mark_output
+    // at wait() (Python dels them after wait); reclaim parks them as
+    // still_marked. Clearing here dropped that list and leaked their
+    // StarPU tiles every iteration (VRAM grew without CE).
 }
 
 void compile_graph_locked(

--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -566,34 +566,24 @@ void write_cpu_bytes_to_staging_locked(
     runtime.mark_initialized(staging);
 }
 
-void invalidate_staging_tile_submit_locked(
-    nntile::TensorGraph::TensorNode *staging)
+void release_io_staging_locked(nntile::TensorGraph::TensorNode *staging)
 {
     if (staging == nullptr || g_exec == nullptr || g_exec->runtime == nullptr)
     {
         return;
     }
-    nntile::Runtime &runtime = *g_exec->runtime;
-    // Keep map reclaim even when SKIP_STARPU disables submit/acquire.
-    runtime.wait();
-    nntile::TileGraph::TileNode *tile =
-        require_single_staging_tile_locked(staging);
-    switch (staging->dtype())
+    // Clear logical marks, then drop StarPU tile buffers from
+    // Runtime::tile_map_ (invalidate_submit alone left handles live).
+    staging->mark_input(false);
+    staging->mark_output(false);
+    g_exec->runtime->invalidate_logical_tiles(staging);
+    g_exec->inc_state.tensor_to_tiles.erase(staging);
+    g_exec->inc_state.tensor_layout_fp.erase(staging);
+    g_exec->tile_map.erase(staging);
+    if (g_exec->session_tiling != nullptr)
     {
-    case nntile::DataType::FP32:
-        runtime.get_tile<nntile::fp32_t>(tile).invalidate_submit();
-        break;
-    case nntile::DataType::INT64:
-        runtime.get_tile<nntile::int64_t>(tile).invalidate_submit();
-        break;
-    case nntile::DataType::BOOL:
-        runtime.get_tile<nntile::bool_t>(tile).invalidate_submit();
-        break;
-    default:
-        throw std::runtime_error(
-            "torch_nntile: unsupported staging invalidate dtype");
+        g_exec->session_tiling->erase(staging);
     }
-    runtime.invalidate_initialized(staging);
 }
 
 void read_staging_to_host_locked(
@@ -1032,20 +1022,7 @@ void finish_run_locked()
     for (nntile::TensorGraph::TensorNode *staging :
         g_exec->pending_scatter_stagings)
     {
-        invalidate_staging_tile_submit_locked(staging);
-        // .to("nntile") marks ingress staging as input; clear marks after
-        // scatter completes so later seals do not keep carrying stagings.
-        // Drop incremental tile state so the next compile cannot reuse the
-        // invalidated staging tile nodes and allocate empty replacements.
-        staging->mark_input(false);
-        staging->mark_output(false);
-        g_exec->inc_state.tensor_to_tiles.erase(staging);
-        g_exec->inc_state.tensor_layout_fp.erase(staging);
-        g_exec->tile_map.erase(staging);
-        if (g_exec->session_tiling != nullptr)
-        {
-            g_exec->session_tiling->erase(staging);
-        }
+        release_io_staging_locked(staging);
     }
     g_exec->pending_scatter_stagings.clear();
     if (g_defer_pending_clear_after_run)
@@ -1307,8 +1284,7 @@ void gather_logical_to_staging_and_read_locked(
     finish_run_locked();
 
     read_staging_to_host_locked(staging, host_ptr, dtype, count);
-    invalidate_staging_tile_submit_locked(staging);
-    staging->mark_output(false);
+    release_io_staging_locked(staging);
     g_timing.host_readout_s += seconds_since(t0);
     ++g_timing.host_readout_calls;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes device-memory growth that shows up as ~2× at ingress and as **per-iteration VRAM growth** even without cross-entropy.

## Causes

### 1. Ingress staging `S` not fully released (≈2× baseline)

`.to("nntile")` builds single-tile staging with `mark_input(true)`. After scatter `wait()`, cleanup only `invalidate_submit`’d and cleared logical marks. `invalidate_logical_tiles` skipped `is_input` tiles, so StarPU handles stayed in `Runtime::tile_map_`. Untiled `L` is the same size → permanent ≈2×.

### 2. `pending_output_reclaim` cleared on compact (per-step leak)

Training typically does `compile` → `run` → `wait` → then `del` step temps. At `wait()`, activations/grads are still `mark_output`, so reclaim parks them as `still_marked`. Graph compaction then **cleared** `pending_output_reclaim`, forgetting those nodes. After Python `del`s them, nothing invalidates their tiles → **one step of activation VRAM leaked every iteration** (CE unrelated).

## Fix

- Clear tile `mark_input`/`mark_output` in `invalidate_logical_tiles` and drop buffers from the runtime map; use that for ingress/egress staging release.
- **Do not** clear `pending_output_reclaim` during wait-time graph compaction so the next `compile_graph()` can reclaim temps deleted after `wait()`.

## Expected behavior

- Brief ~2× peak during the first `run` that executes scatter is still possible; after `wait()`, staging should not keep a second copy.
- Steady training VRAM should stop climbing each step once temps are deleted (next compile reclaims the previous step’s still-marked list).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dc7c4df-9a83-4dd5-bdc4-d665a8851b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dc7c4df-9a83-4dd5-bdc4-d665a8851b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

