### PR TITLE
Fix CPU→nntile copy for tensors with nonzero storage_offset.

### DIFF
--- a/torch_nntile/csrc/nntile_graph_recorder.cpp
+++ b/torch_nntile/csrc/nntile_graph_recorder.cpp
@@ -1406,7 +1406,8 @@ void copy_nntile_tensor_to_cpu(const at::Tensor &src, at::Tensor &dst)
     const nntile::DataType dtype = logical->dtype();
     const std::size_t count =
         static_cast<std::size_t>(logical->nelems());
-    void *host_ptr = dst.storage().data_ptr().get();
+    // Respect dst storage_offset (matches CPU→nntile ingress via data_ptr()).
+    void *host_ptr = dst.data_ptr();
 
     // Sync a prior async execute()/run() even when no ops are pending so
     // subsequent gather recording is not wiped by wait-side drop_all_ops().
@@ -1491,9 +1492,11 @@ void init_nntile_input_from_cpu(
     }
     staging->mark_input(true);
     lower_io_staging_locked(staging);
+    // Use data_ptr() (not storage().data_ptr()): size-1 dims can be
+    // is_contiguous() with storage_offset != 0 (e.g. batch[:, 1:] at B=1).
     write_cpu_bytes_to_staging_locked(
         staging,
-        cpu_src.storage().data_ptr().get(),
+        cpu_src.data_ptr(),
         dtype,
         static_cast<std::size_t>(cpu_src.numel()));
 

--- a/torch_nntile/csrc/nntile_kernels.cpp
+++ b/torch_nntile/csrc/nntile_kernels.cpp
@@ -69,10 +69,8 @@ void memcpy_tensors(const at::Tensor &src, at::Tensor &dst)
     {
         return;
     }
-    std::memcpy(
-        dst.storage().data_ptr().get(),
-        src.storage().data_ptr().get(),
-        nbytes);
+    // data_ptr() includes storage_offset; storage().data_ptr() does not.
+    std::memcpy(dst.data_ptr(), src.data_ptr(), nbytes);
 }
 
 at::Scalar tensor_to_scalar(const at::Tensor &self)

--- a/torch_nntile/examples/train_gpt2_hf.py
+++ b/torch_nntile/examples/train_gpt2_hf.py
@@ -130,6 +130,18 @@ def build_sequences(
     return token_ids[:usable].view(n_seq, seq_len)
 
 
+def ensure_seq_len_fits_positions(config: GPT2Config, seq_len: int) -> None:
+    """Causal LM uses positions ``0 .. seq_len-2`` after the next-token split."""
+    n_positions = int(config.n_positions)
+    # After split_causal_batch, input length is seq_len - 1.
+    if seq_len - 1 > n_positions:
+        raise SystemExit(
+            f"--seq-len={seq_len} needs positions up to {seq_len - 2}, but "
+            f"config n_positions={n_positions}. Use --seq-len <= "
+            f"{n_positions + 1}."
+        )
+
+
 def make_batches(
     sequences: torch.Tensor,
     *,
@@ -261,10 +273,15 @@ def compare_checkpoints(path_a: Path, path_b: Path) -> int:
 def split_causal_batch(
     batch: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Split ``[B, T]`` into inputs ``[:, :-1]`` and labels ``[:, 1:]`` on CPU."""
+    """Split ``[B, T]`` into inputs ``[:, :-1]`` and labels ``[:, 1:]`` on CPU.
+
+    Uses ``clone()`` (not only ``contiguous()``): with ``B=1``,
+    ``batch[:, 1:]`` can report ``is_contiguous()`` while keeping
+    ``storage_offset != 0``, so ``contiguous()`` is a no-op.
+    """
     if batch.ndim != 2 or batch.shape[1] < 2:
         raise ValueError("batch must be [B, T] with T >= 2")
-    return batch[:, :-1].contiguous(), batch[:, 1:].contiguous()
+    return batch[:, :-1].clone(), batch[:, 1:].clone()
 
 
 def causal_lm_loss_torch(
@@ -329,6 +346,7 @@ def train_cuda(args: argparse.Namespace) -> int:
         else (ckpt.get("seed", 0) if ckpt else 0)
     )
     # Pack sequences after config is final (checkpoint vocab_size on resume).
+    ensure_seq_len_fits_positions(config, args.seq_len)
     data_seed = int(
         args.data_seed if args.data_seed is not None else seed
     )
@@ -446,6 +464,7 @@ def train_nntile(args: argparse.Namespace) -> int:
         else (ckpt.get("seed", 0) if ckpt else 0)
     )
     # Pack sequences after config is final (checkpoint vocab_size on resume).
+    ensure_seq_len_fits_positions(config, args.seq_len)
     data_seed = int(
         args.data_seed if args.data_seed is not None else seed
     )

--- a/torch_nntile/tests/test_storage_offset_copy.py
+++ b/torch_nntile/tests/test_storage_offset_copy.py
@@ -1,0 +1,51 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/tests/test_storage_offset_copy.py
+# CPU→nntile copy must honor storage_offset (B=1 causal label views).
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+import pytest
+
+import torch_nntile
+from torch_nntile import _C
+from torch_nntile.training import cross_entropy
+from conftest import nntile_cpu
+
+
+pytestmark = pytest.mark.skipif(
+    not _C.has_libnntile(),
+    reason="torch_nntile built without libnntile (set NNTILE_BUILD_DIR)",
+)
+
+
+def test_to_nntile_preserves_storage_offset_view():
+    """batch[:, 1:] at B=1 is is_contiguous() with storage_offset != 0."""
+    batch = torch.arange(32, dtype=torch.long).view(1, 32)
+    labels_view = batch[:, 1:]
+    assert labels_view.shape == (1, 31)
+    assert labels_view.is_contiguous()
+    assert labels_view.storage_offset() == 1
+
+    roundtrip = nntile_cpu(labels_view.to("nntile"))
+    assert torch.equal(roundtrip, labels_view)
+    assert not torch.equal(roundtrip, batch[:, :31])
+
+
+def test_cross_entropy_batch1_causal_label_view_matches_cpu():
+    torch.manual_seed(0)
+    batch = torch.randint(0, 256, (1, 32), dtype=torch.long)
+    labels_view = batch[:, 1:]
+    assert labels_view.storage_offset() == 1
+    logits = torch.randn(1, 31, 256)
+
+    ref = F.cross_entropy(logits.reshape(-1, 256), labels_view.reshape(-1))
+    loss = cross_entropy(
+        logits.to("nntile"),
+        labels_view.to("nntile"),
+        reduction="mean",
+    )
+    assert torch.allclose(nntile_cpu(loss), ref, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
Batch-size-1 causal label views are is_contiguous() but offset≠0, so memcpy from storage().data_ptr() dropped the offset and poisoned CE.