### PR TITLE
Stop examples from shadowing installed torch_nntile via sys.path

### DIFF
--- a/torch_nntile/README.md
+++ b/torch_nntile/README.md
@@ -536,8 +536,20 @@ extension + `tools/smoke_test_wheel.py`).
 
 ## Usage
 
-Run Python from **outside** the repo root (or from inside `torch_nntile/`) so
-`import torch_nntile` resolves the installed package, not the project folder.
+Install `torch_nntile` first (wheel or editable). Examples and scripts import
+the installed package — they do **not** rewrite `sys.path`. Do not run from
+the repo root or `torch_nntile/` with an unbuilt tree on `PYTHONPATH`; that
+shadows site-packages and yields a missing `_C` (often misreported as a
+circular import).
+
+For local development, prefer:
+
+```bash
+CXX=g++ pip install -e ./torch_nntile --no-build-isolation
+```
+
+`pytest` only prefers an in-tree package when a built `_C.*` is present
+(`tests/conftest.py`); otherwise it uses the installed wheel.
 
 ```python
 import torch

--- a/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
+++ b/torch_nntile/examples/reproduce_google_five_layer_relu_mnist.py
@@ -64,9 +64,7 @@ from __future__ import annotations
 
 import argparse
 import math
-import sys
 import time
-from pathlib import Path
 from typing import Iterator
 
 import torch
@@ -74,12 +72,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
-
-_REPO = Path(__file__).resolve().parents[2]
-_TORCH_NNTILE_ROOT = _REPO / "torch_nntile"
-if str(_TORCH_NNTILE_ROOT) not in sys.path:
-    sys.path.insert(0, str(_TORCH_NNTILE_ROOT))
-
 
 HIDDEN_WIDTHS = (200, 100, 60, 30)
 

--- a/torch_nntile/examples/simple_matmul.py
+++ b/torch_nntile/examples/simple_matmul.py
@@ -29,18 +29,11 @@ CUDA example (manual, requires GPU)::
 from __future__ import annotations
 
 import argparse
-import sys
 import time
 from dataclasses import dataclass
-from pathlib import Path
 
 import torch
-
-_REPO = Path(__file__).resolve().parents[2]
-if str(_REPO / "torch_nntile") not in sys.path:
-    sys.path.insert(0, str(_REPO / "torch_nntile"))
-
-import torch_nntile  # noqa: E402
+import torch_nntile
 
 
 @dataclass(frozen=True)

--- a/torch_nntile/examples/train_bert.py
+++ b/torch_nntile/examples/train_bert.py
@@ -15,18 +15,11 @@ Example::
 from __future__ import annotations
 
 import argparse
-import sys
-from pathlib import Path
 
 import torch
-
-_REPO = Path(__file__).resolve().parents[2]
-if str(_REPO / "torch_nntile") not in sys.path:
-    sys.path.insert(0, str(_REPO / "torch_nntile"))
-
-import torch_nntile  # noqa: E402
-from torch_nntile.models.bert import BertConfig, BertMlm  # noqa: E402
-from torch_nntile.training import AdamW, cross_entropy  # noqa: E402
+import torch_nntile
+from torch_nntile.models.bert import BertConfig, BertMlm
+from torch_nntile.training import AdamW, cross_entropy
 
 IGNORE_INDEX = -100
 

--- a/torch_nntile/examples/train_deep_relu_mnist.py
+++ b/torch_nntile/examples/train_deep_relu_mnist.py
@@ -84,7 +84,6 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import sys
 import time
 from pathlib import Path
 from typing import Type
@@ -95,8 +94,6 @@ from torchvision import datasets
 
 _REPO = Path(__file__).resolve().parents[2]
 _TORCH_NNTILE_ROOT = _REPO / "torch_nntile"
-if str(_TORCH_NNTILE_ROOT) not in sys.path:
-    sys.path.insert(0, str(_TORCH_NNTILE_ROOT))
 
 _DeepReLU: Type[nn.Module] | None = None
 

--- a/torch_nntile/examples/train_gpt2.py
+++ b/torch_nntile/examples/train_gpt2.py
@@ -66,10 +66,6 @@ import torch_nntile
 from transformers import GPT2Config, GPT2LMHeadModel
 
 
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[2]
-
-
 def _default_config_path() -> Path:
     return Path(__file__).resolve().parent / "gpt2_hf_tiny_config.json"
 

--- a/torch_nntile/examples/train_gpt2_hf.py
+++ b/torch_nntile/examples/train_gpt2_hf.py
@@ -71,16 +71,11 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 import time
 from pathlib import Path
 
 import torch
 from transformers import GPT2Config, GPT2LMHeadModel
-
-
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[2]
 
 
 def _default_config_path() -> Path:
@@ -676,9 +671,6 @@ def train_torch(args: argparse.Namespace) -> int:
 
 def train_nntile(args: argparse.Namespace) -> int:
     # Import only on the nntile path so CUDA/CPU training stays unaffected.
-    root = _repo_root() / "torch_nntile"
-    if str(root) not in sys.path:
-        sys.path.insert(0, str(root))
     import torch_nntile
     from torch_nntile.training import SGD, clone_model_weights
 

--- a/torch_nntile/examples/train_gpt_neo.py
+++ b/torch_nntile/examples/train_gpt_neo.py
@@ -15,18 +15,12 @@ Example::
 from __future__ import annotations
 
 import argparse
-import sys
-from pathlib import Path
 
 import torch
 
-_REPO = Path(__file__).resolve().parents[2]
-if str(_REPO / "torch_nntile") not in sys.path:
-    sys.path.insert(0, str(_REPO / "torch_nntile"))
-
-import torch_nntile  # noqa: E402
-from torch_nntile.models.gpt_neo import GPTNeoCausal, GPTNeoConfig  # noqa: E402
-from torch_nntile.training import AdamW, cross_entropy  # noqa: E402
+import torch_nntile
+from torch_nntile.models.gpt_neo import GPTNeoCausal, GPTNeoConfig
+from torch_nntile.training import AdamW, cross_entropy
 
 
 def tiny_config() -> GPTNeoConfig:

--- a/torch_nntile/examples/train_gpt_neox.py
+++ b/torch_nntile/examples/train_gpt_neox.py
@@ -15,21 +15,15 @@ Example::
 from __future__ import annotations
 
 import argparse
-import sys
-from pathlib import Path
 
 import torch
 
-_REPO = Path(__file__).resolve().parents[2]
-if str(_REPO / "torch_nntile") not in sys.path:
-    sys.path.insert(0, str(_REPO / "torch_nntile"))
-
-import torch_nntile  # noqa: E402
-from torch_nntile.models.gpt_neox import (  # noqa: E402
+import torch_nntile
+from torch_nntile.models.gpt_neox import (
     GPTNeoXCausal,
     GPTNeoXConfig,
 )
-from torch_nntile.training import AdamW, cross_entropy  # noqa: E402
+from torch_nntile.training import AdamW, cross_entropy
 
 
 def tiny_config() -> GPTNeoXConfig:

--- a/torch_nntile/examples/train_llama.py
+++ b/torch_nntile/examples/train_llama.py
@@ -15,18 +15,12 @@ Example::
 from __future__ import annotations
 
 import argparse
-import sys
-from pathlib import Path
 
 import torch
 
-_REPO = Path(__file__).resolve().parents[2]
-if str(_REPO / "torch_nntile") not in sys.path:
-    sys.path.insert(0, str(_REPO / "torch_nntile"))
-
-import torch_nntile  # noqa: E402
-from torch_nntile.models.llama import LlamaCausal, LlamaConfig  # noqa: E402
-from torch_nntile.training import AdamW, cross_entropy  # noqa: E402
+import torch_nntile
+from torch_nntile.models.llama import LlamaCausal, LlamaConfig
+from torch_nntile.training import AdamW, cross_entropy
 
 
 def tiny_config() -> LlamaConfig:

--- a/torch_nntile/examples/train_roberta.py
+++ b/torch_nntile/examples/train_roberta.py
@@ -15,18 +15,12 @@ Example::
 from __future__ import annotations
 
 import argparse
-import sys
-from pathlib import Path
 
 import torch
 
-_REPO = Path(__file__).resolve().parents[2]
-if str(_REPO / "torch_nntile") not in sys.path:
-    sys.path.insert(0, str(_REPO / "torch_nntile"))
-
-import torch_nntile  # noqa: E402
-from torch_nntile.models.roberta import RobertaConfig, RobertaMlm  # noqa: E402
-from torch_nntile.training import AdamW, cross_entropy  # noqa: E402
+import torch_nntile
+from torch_nntile.models.roberta import RobertaConfig, RobertaMlm
+from torch_nntile.training import AdamW, cross_entropy
 
 IGNORE_INDEX = -100
 

--- a/torch_nntile/examples/train_t5.py
+++ b/torch_nntile/examples/train_t5.py
@@ -15,21 +15,15 @@ Example::
 from __future__ import annotations
 
 import argparse
-import sys
-from pathlib import Path
 
 import torch
 
-_REPO = Path(__file__).resolve().parents[2]
-if str(_REPO / "torch_nntile") not in sys.path:
-    sys.path.insert(0, str(_REPO / "torch_nntile"))
-
-import torch_nntile  # noqa: E402
-from torch_nntile.models.t5 import (  # noqa: E402
+import torch_nntile
+from torch_nntile.models.t5 import (
     T5Config,
     T5ForConditionalGeneration,
 )
-from torch_nntile.training import AdamW, cross_entropy  # noqa: E402
+from torch_nntile.training import AdamW, cross_entropy
 
 
 def tiny_config() -> T5Config:

--- a/torch_nntile/torch_nntile/__init__.py
+++ b/torch_nntile/torch_nntile/__init__.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import atexit
+from pathlib import Path
 
 import torch
 
@@ -17,7 +18,22 @@ from ._cuda_deps import ensure_linux_cuda_deps
 
 ensure_linux_cuda_deps(required=BUILT_WITH_CUDA)
 
-from . import _C  # noqa: E402, F401 - loads kernels and allocator
+try:
+    from . import _C  # noqa: F401 - loads kernels and allocator
+except ImportError as exc:
+    pkg_dir = Path(__file__).resolve().parent
+    # Missing extension (source tree / bad install). Keep linker errors for a
+    # present `_C` (e.g. libtorch_nntile not on LD_LIBRARY_PATH) unchanged.
+    if any(pkg_dir.glob("_C.*")):
+        raise
+    raise ImportError(
+        "torch_nntile extension `_C` is missing from "
+        f"{pkg_dir}. Install a built package "
+        "(wheel or `pip install -e ./torch_nntile`), and avoid "
+        "importing the unbuilt source tree via cwd/PYTHONPATH. "
+        "pytest may use an in-tree `_C` when present; see "
+        "torch_nntile/tests/conftest.py."
+    ) from exc
 from . import loss as _loss  # noqa: E402, F401
 from . import compat as _compat  # noqa: E402, F401
 from . import nn as nn  # noqa: E402, F401


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Examples were prepending the source tree onto `sys.path`, so running them (or importing from under `torch_nntile/`) loaded the unbuilt package and failed with a misleading “circular import” / missing `_C` error — even when a wheel was installed.

## Changes

- Remove all `sys.path` bootstraps from `torch_nntile/examples/`
- Keep pytest-only logic in `tests/conftest.py` (prefer in-tree package **only** when `_C.*` exists; otherwise use the installed wheel)
- Clearer `ImportError` when `_C` is missing from the loaded package dir
- Fix README usage guidance: install wheel/editable; do not rely on cwd hacks

## Standard practice

This matches the usual packaging model: `pip install` / `pip install -e`, no script-level `sys.path` mutation. Pytest may special-case an inplace extension; examples should not.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-554a5cdb-9965-44a8-8535-6d817e342613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-554a5cdb-9965-44a8-8535-6d817e342613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

