### PR TITLE
Add JSON config and checkpoint CLI to tiny train scripts

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -17,6 +17,7 @@ Start with the product docs if you are new:
 | [graph_compiler_on_design.md](graph_compiler_on_design.md) | O(N) incremental TensorGraph → TileGraph → Runtime |
 | [execution_json_schema.md](execution_json_schema.md) | Optional static `execution.json` schedule |
 | [graph_compile_perf_mnist.md](graph_compile_perf_mnist.md) | Compile-perf measurements (MNIST dry-run) |
+| [hf_tiny_cpu_vs_nntile_showcase.md](hf_tiny_cpu_vs_nntile_showcase.md) | Tiny HF smokes: CPU vs nntile loss/wall table |
 | [cuda_wheel_single_nvidia_stack_plan.md](cuda_wheel_single_nvidia_stack_plan.md) | CUDA wheel disk / single NVIDIA stack (infra) |
 
 ## Historical

--- a/docs/dev/hf_tiny_cpu_vs_nntile_showcase.md
+++ b/docs/dev/hf_tiny_cpu_vs_nntile_showcase.md
@@ -1,0 +1,153 @@
+# Tiny HF train showcase: CPU vs `device=nntile`
+
+Short smoke runs of stock HuggingFace models through `torch_nntile`
+PrivateUse1 (`device=nntile`) versus plain PyTorch CPU. Goal: show
+**numerical parity** (matching loss) and how to read the printed
+timings — not a large-scale throughput benchmark.
+
+Scripts live under [`torch_nntile/examples/`](../../torch_nntile/examples/).
+Each uses a tiny JSON config (`*_hf_tiny_config.json`) and the same
+`train` / `compare` CLI shape as [`train_gpt2_hf.py`](../../torch_nntile/examples/train_gpt2_hf.py).
+
+## How to run
+
+Environment (CPU StarPU build; no CUDA in this Cloud Agent image)::
+
+```bash
+export PKG_CONFIG_PATH=/opt/starpu/lib/pkgconfig
+export LD_LIBRARY_PATH=$PWD/build/nntile:$PWD/build/torch_nntile:/opt/starpu/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export NNTILE_BUILD_DIR=$PWD/build TORCH_NNTILE_BUILD_DIR=$PWD/build
+export NNTILE_SOURCE_DIR=$PWD
+export STARPU_SILENT=1 STARPU_FXT_TRACE=0 STARPU_WORKERS_NOBIND=1
+```
+
+Single model (example: Llama)::
+
+```bash
+# CPU reference
+python torch_nntile/examples/train_llama_hf.py train \
+  --device cpu --seed 0 --steps 1 --seq-len 16 --batch-size 1 \
+  --output-dir /tmp/llama_cpu
+
+# nntile (one StarPU CPU worker)
+python torch_nntile/examples/train_llama_hf.py train \
+  --device nntile --seed 0 --steps 1 --seq-len 16 --batch-size 1 \
+  --ncpu 1 --output-dir /tmp/llama_nntile
+
+# Optional weight compare (relative Frobenius per tensor)
+python torch_nntile/examples/train_llama_hf.py compare \
+  --checkpoint-a /tmp/llama_cpu/checkpoint.pt \
+  --checkpoint-b /tmp/llama_nntile/checkpoint.pt
+```
+
+Batch all HF smokes and print a markdown table::
+
+```bash
+python torch_nntile/examples/bench_hf_tiny_cpu_vs_nntile.py \
+  --ncpu 1 --steps 1 --seq-len 16 --batch-size 1 --seed 0 \
+  --markdown-out /tmp/hf_tiny_cpu_vs_nntile/table.md
+```
+
+Models covered by the bench: GPT-2, GPT-Neo, GPT-NeoX, Llama, BERT,
+RoBERTa, T5 (all stock HF, tiny JSON configs).
+
+## What the outputs mean
+
+### Loss
+
+Each script prints one line per train step, for example::
+
+```text
+[llama] step 1/1  loss=4.915326
+```
+
+- **Loss** is next-token (causal) or MLM / T5 CE on a **synthetic**
+  mini-batch (deterministic from `--seed`).
+- Same seed + same config ⇒ CPU and nntile should match to printing
+  precision when the aten graph is covered. In the table below, **Δ loss
+  is exactly 0** for every model (bit-identical printed values).
+
+### Wall time (train loop)
+
+Tiny HF smokes print::
+
+```text
+[llama] wall=0.024s  OK
+```
+
+That is **only the train loop** (forward → backward → optimizer step →
+host loss readout), after the model and batch are already on device.
+It does **not** include Python import, HuggingFace construction, or
+StarPU `init_context` / shutdown.
+
+For GPT-2 (`train_gpt2_hf.py`) the analogous line is::
+
+```text
+timing torch train wall (incl. per-iter sync): 0.005s (1 epochs)
+timing nntile train wall (incl. per-iter loss sync): 0.015s (1 epochs)
+```
+
+On **nntile**, each step also `compile_graph` / `run`s and syncs loss
+with `.cpu()` / `.to("cpu")` so StarPU reclaim stays in the same phase
+(see [torch_nntile_tensor_architecture.md](torch_nntile_tensor_architecture.md)).
+That sync is part of the reported wall.
+
+### Process elapsed (not in the table)
+
+Spawning a fresh Python process per run costs ~3 s here (imports +
+TF/transformers side effects). Do **not** treat process elapsed as a
+device comparison — use the printed train-loop wall.
+
+## Results (CPU vs nntile, `ncpu=1`)
+
+Measured with `bench_hf_tiny_cpu_vs_nntile.py` on the Cloud Agent VM
+(CPU-only StarPU / `USE_CUDA=OFF`, `ncpu=1`, `steps=1`, `seq-len=16`,
+`batch-size=1`, `seed=0`, date 2026-07-18). Tiny configs: ~64-wide
+hidden, 1–2 layers — **overhead-dominated**, not a speed contest.
+
+| Model | CPU loss | nntile loss | CPU wall (s) | nntile wall (s) | Δ loss | Status |
+|---|---:|---:|---:|---:|---:|---|
+| gpt2 | 5.615653 | 5.615653 | 0.005 | 0.015 | 0.000e+00 | OK |
+| gpt-neo | 4.827158 | 4.827158 | 0.004 | 0.013 | 0.000e+00 | OK |
+| gpt-neox | 4.835960 | 4.835960 | 0.004 | 0.020 | 0.000e+00 | OK |
+| llama | 4.915326 | 4.915326 | 0.004 | 0.024 | 0.000e+00 | OK |
+| bert | 4.833461 | 4.833461 | 0.004 | 0.013 | 0.000e+00 | OK |
+| roberta | 4.735972 | 4.735972 | 0.004 | 0.013 | 0.000e+00 | OK |
+| t5 | 5.692081 | 5.692081 | 0.005 | 0.033 | 0.000e+00 | OK |
+
+**Takeaways for demos**
+
+1. **Correctness:** losses match on CPU and nntile for every model above.
+2. **Timing at this scale:** nntile wall is higher (StarPU submit +
+   compile/run + host sync) while the math is tiny; expect the gap to
+   shrink (and reverse) on larger seq / batch / depth or with CUDA
+   workers (`--ncuda`).
+3. **Checkpoints:** each successful `--output-dir` run writes
+   `checkpoint.pt` (`model_state_dict` + HF `config` dict + seed /
+   step). Use `compare` for relative Frobenius norms.
+
+## Nntile-native model scripts
+
+Hand-written stacks (`train_llama.py`, `train_bert.py`, …) also take
+JSON `--config` / `--checkpoint`, but always train on `device=nntile`
+and use `torch_nntile.models.*` (plus `_C` helpers such as `gemm` /
+`rms_norm_forward`). They are **not** in the CPU column of the table.
+
+Example::
+
+```bash
+python torch_nntile/examples/train_llama.py train \
+  --seed 0 --config llama_tiny_config.json \
+  --ncpu 1 --steps 2 --output-dir /tmp/llama_native
+```
+
+On a libtorch-only / incomplete `_C` build these may fail with missing
+symbols; use a full torch_nntile extension build (CI wheel or local
+`cmake --build … --target torch_nntile` with model bindings enabled).
+
+## Related
+
+- [torch_nntile_tensor_architecture.md](torch_nntile_tensor_architecture.md)
+- [torch_nntile_aten_ops.md](torch_nntile_aten_ops.md)
+- [torch_starpu_kernels.md](torch_starpu_kernels.md)
+- Product overview: [../torch_nntile.md](../torch_nntile.md)

--- a/torch_nntile/examples/bench_hf_tiny_cpu_vs_nntile.py
+++ b/torch_nntile/examples/bench_hf_tiny_cpu_vs_nntile.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# Collect cpu vs nntile timings for tiny HF train smokes (showcase).
+
+"""Run tiny HF train scripts on cpu and nntile; print a markdown table.
+
+Example::
+
+    python torch_nntile/examples/bench_hf_tiny_cpu_vs_nntile.py \\
+        --ncpu 1 --steps 1 --seq-len 16 --seed 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+SCRIPTS = (
+    ("gpt2", "train_gpt2_hf.py", True),
+    ("gpt-neo", "train_gpt_neo_hf.py", False),
+    ("gpt-neox", "train_gpt_neox_hf.py", False),
+    ("llama", "train_llama_hf.py", False),
+    ("bert", "train_bert_hf.py", False),
+    ("roberta", "train_roberta_hf.py", False),
+    ("t5", "train_t5_hf.py", False),
+)
+
+LOSS_RE = re.compile(r"loss=([0-9.]+)")
+WALL_RE = re.compile(r"wall=([0-9.]+)s")
+# gpt2_hf prints a longer wall line
+GPT2_WALL_RE = re.compile(
+    r"timing (?:nntile|torch) train wall[^:]*:\s*([0-9.]+)s"
+)
+GPT2_LOSS_RE = re.compile(r"loss=([0-9.]+)")
+
+
+@dataclass
+class RunResult:
+    name: str
+    device: str
+    ok: bool
+    loss: float | None
+    wall_s: float | None
+    elapsed_s: float
+    stderr_tail: str
+
+
+def run_one(
+    *,
+    here: Path,
+    name: str,
+    script: str,
+    is_gpt2: bool,
+    device: str,
+    ncpu: int,
+    steps: int,
+    seq_len: int,
+    batch_size: int,
+    seed: int,
+    output_root: Path,
+) -> RunResult:
+    out_dir = output_root / f"{name}_{device}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    if is_gpt2:
+        cmd = [
+            sys.executable,
+            str(here / script),
+            "train",
+            "--device",
+            device,
+            "--seed",
+            str(seed),
+            "--data-seed",
+            str(seed),
+            "--epochs",
+            "1",
+            "--seq-len",
+            str(seq_len),
+            "--batch-size",
+            str(batch_size),
+            "--max-sequences",
+            str(max(2, steps * batch_size)),
+            "--ncpu",
+            str(ncpu),
+            "--output-dir",
+            str(out_dir),
+            "--no-shuffle",
+        ]
+        if device == "nntile":
+            cmd.extend(["--ncuda", "0"])
+    else:
+        cmd = [
+            sys.executable,
+            str(here / script),
+            "train",
+            "--device",
+            device,
+            "--seed",
+            str(seed),
+            "--steps",
+            str(steps),
+            "--seq-len",
+            str(seq_len),
+            "--batch-size",
+            str(batch_size),
+            "--ncpu",
+            str(ncpu),
+            "--output-dir",
+            str(out_dir),
+        ]
+
+    t0 = time.perf_counter()
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(here.parent.parent),
+    )
+    elapsed = time.perf_counter() - t0
+    text = proc.stdout + "\n" + proc.stderr
+    loss = None
+    wall = None
+    if is_gpt2:
+        losses = GPT2_LOSS_RE.findall(text)
+        if losses:
+            loss = float(losses[-1])
+        m = GPT2_WALL_RE.search(text)
+        if m:
+            wall = float(m.group(1))
+    else:
+        losses = LOSS_RE.findall(text)
+        if losses:
+            loss = float(losses[-1])
+        m = WALL_RE.search(text)
+        if m:
+            wall = float(m.group(1))
+    ok = proc.returncode == 0 and loss is not None
+    tail = ""
+    if not ok:
+        tail = (proc.stderr or proc.stdout or "")[-500:].strip()
+    return RunResult(
+        name=name,
+        device=device,
+        ok=ok,
+        loss=loss,
+        wall_s=wall if wall is not None else elapsed,
+        elapsed_s=elapsed,
+        stderr_tail=tail,
+    )
+
+
+def format_table(results: list[RunResult]) -> str:
+    by_name: dict[str, dict[str, RunResult]] = {}
+    for r in results:
+        by_name.setdefault(r.name, {})[r.device] = r
+
+    lines = [
+        "| Model | CPU loss | nntile loss | CPU wall (s) | "
+        "nntile wall (s) | Δ loss | Status |",
+        "|---|---:|---:|---:|---:|---:|---|",
+    ]
+    for name, _, _ in SCRIPTS:
+        row = by_name.get(name, {})
+        cpu = row.get("cpu")
+        nnt = row.get("nntile")
+        if cpu is None or nnt is None:
+            lines.append(f"| {name} | — | — | — | — | — | incomplete |")
+            continue
+        if not cpu.ok or not nnt.ok:
+            status = "FAIL"
+            if not cpu.ok:
+                status += " cpu"
+            if not nnt.ok:
+                status += " nntile"
+            lines.append(
+                f"| {name} | "
+                f"{cpu.loss if cpu.loss is not None else '—'} | "
+                f"{nnt.loss if nnt.loss is not None else '—'} | "
+                f"{cpu.wall_s:.3f} | {nnt.wall_s:.3f} | — | {status} |"
+            )
+            continue
+        assert cpu.loss is not None and nnt.loss is not None
+        assert cpu.wall_s is not None and nnt.wall_s is not None
+        dloss = abs(cpu.loss - nnt.loss)
+        lines.append(
+            f"| {name} | {cpu.loss:.6f} | {nnt.loss:.6f} | "
+            f"{cpu.wall_s:.3f} | {nnt.wall_s:.3f} | {dloss:.3e} | OK |"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--ncpu", type=int, default=1)
+    p.add_argument("--steps", type=int, default=1)
+    p.add_argument("--seq-len", type=int, default=16)
+    p.add_argument("--batch-size", type=int, default=1)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument(
+        "--output-root",
+        default="/tmp/hf_tiny_cpu_vs_nntile",
+        help="Checkpoint / log root",
+    )
+    p.add_argument(
+        "--markdown-out",
+        default="",
+        help="Optional path to write the markdown table",
+    )
+    args = p.parse_args(argv)
+
+    here = Path(__file__).resolve().parent
+    output_root = Path(args.output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    results: list[RunResult] = []
+    for name, script, is_gpt2 in SCRIPTS:
+        for device in ("cpu", "nntile"):
+            print(
+                f"==> {name} device={device} ncpu={args.ncpu}",
+                flush=True,
+            )
+            r = run_one(
+                here=here,
+                name=name,
+                script=script,
+                is_gpt2=is_gpt2,
+                device=device,
+                ncpu=args.ncpu,
+                steps=args.steps,
+                seq_len=args.seq_len,
+                batch_size=args.batch_size,
+                seed=args.seed,
+                output_root=output_root,
+            )
+            status = "OK" if r.ok else "FAIL"
+            print(
+                f"    {status} loss={r.loss} wall={r.wall_s} "
+                f"elapsed={r.elapsed_s:.3f}s",
+                flush=True,
+            )
+            if not r.ok and r.stderr_tail:
+                print(f"    stderr_tail:\n{r.stderr_tail}", flush=True)
+            results.append(r)
+
+    table = format_table(results)
+    print("\n" + table)
+    if args.markdown_out:
+        Path(args.markdown_out).write_text(table + "\n", encoding="utf-8")
+        print(f"\nWrote {args.markdown_out}")
+
+    failed = sum(1 for r in results if not r.ok)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/torch_nntile/examples/bert_hf_tiny_config.json
+++ b/torch_nntile/examples/bert_hf_tiny_config.json
@@ -1,0 +1,12 @@
+{
+  "vocab_size": 128,
+  "hidden_size": 64,
+  "intermediate_size": 128,
+  "num_hidden_layers": 2,
+  "num_attention_heads": 4,
+  "max_position_embeddings": 64,
+  "type_vocab_size": 2,
+  "hidden_dropout_prob": 0.0,
+  "attention_probs_dropout_prob": 0.0,
+  "pad_token_id": 0
+}

--- a/torch_nntile/examples/bert_tiny_config.json
+++ b/torch_nntile/examples/bert_tiny_config.json
@@ -1,0 +1,9 @@
+{
+  "vocab_size": 128,
+  "hidden_size": 64,
+  "intermediate_size": 128,
+  "num_hidden_layers": 1,
+  "num_attention_heads": 4,
+  "max_position_embeddings": 32,
+  "type_vocab_size": 2
+}

--- a/torch_nntile/examples/gpt_neo_hf_tiny_config.json
+++ b/torch_nntile/examples/gpt_neo_hf_tiny_config.json
@@ -1,0 +1,16 @@
+{
+  "vocab_size": 128,
+  "hidden_size": 64,
+  "intermediate_size": 128,
+  "num_layers": 2,
+  "num_heads": 4,
+  "max_position_embeddings": 64,
+  "attention_types": [[["global"], 2]],
+  "window_size": 32,
+  "attention_dropout": 0.0,
+  "embed_dropout": 0.0,
+  "resid_dropout": 0.0,
+  "classifier_dropout": 0.0,
+  "bos_token_id": 0,
+  "eos_token_id": 0
+}

--- a/torch_nntile/examples/gpt_neo_tiny_config.json
+++ b/torch_nntile/examples/gpt_neo_tiny_config.json
@@ -1,0 +1,11 @@
+{
+  "vocab_size": 128,
+  "hidden_size": 64,
+  "intermediate_size": 128,
+  "num_hidden_layers": 1,
+  "num_attention_heads": 4,
+  "max_position_embeddings": 32,
+  "window_size": 16,
+  "tie_word_embeddings": false,
+  "attention_layers": ["global"]
+}

--- a/torch_nntile/examples/gpt_neox_hf_tiny_config.json
+++ b/torch_nntile/examples/gpt_neox_hf_tiny_config.json
@@ -1,0 +1,16 @@
+{
+  "vocab_size": 128,
+  "hidden_size": 64,
+  "intermediate_size": 128,
+  "num_hidden_layers": 2,
+  "num_attention_heads": 4,
+  "max_position_embeddings": 64,
+  "rotary_pct": 0.5,
+  "rotary_emb_base": 10000,
+  "attention_dropout": 0.0,
+  "hidden_dropout": 0.0,
+  "classifier_dropout": 0.0,
+  "bos_token_id": 0,
+  "eos_token_id": 0,
+  "tie_word_embeddings": false
+}

--- a/torch_nntile/examples/gpt_neox_tiny_config.json
+++ b/torch_nntile/examples/gpt_neox_tiny_config.json
@@ -1,0 +1,10 @@
+{
+  "vocab_size": 128,
+  "hidden_size": 64,
+  "intermediate_size": 128,
+  "num_hidden_layers": 1,
+  "num_attention_heads": 4,
+  "max_position_embeddings": 32,
+  "rotary_pct": 0.25,
+  "tie_word_embeddings": false
+}

--- a/torch_nntile/examples/hf_tiny_train_common.py
+++ b/torch_nntile/examples/hf_tiny_train_common.py
@@ -4,43 +4,212 @@
 # @file torch_nntile/examples/hf_tiny_train_common.py
 # Shared helpers for tiny HuggingFace stock-model smokes on nntile/cpu.
 
-"""Shared tiny HF train loop for discovering missing torch-native ops.
+"""Shared tiny HF train loop with JSON config / checkpoint support.
 
-Each model script builds a tiny config + model, then calls
-:func:`run_tiny_hf_train` for a short synthetic step on ``cpu`` or
-``nntile``.
+Each model script points at a default ``*_hf_tiny_config.json``, then calls
+:func:`run_tiny_hf_main` for ``train`` / ``compare`` (same checkpoint payload
+shape as ``train_gpt2_hf.py``).
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import time
 import traceback
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import torch
 
+LossFn = Callable[[torch.nn.Module, dict[str, torch.Tensor]], torch.Tensor]
+BatchBuilder = Callable[
+    [Any, argparse.Namespace],
+    dict[str, torch.Tensor],
+]
+ConfigFactory = Callable[..., Any]
+ModelFactory = Callable[[Any], torch.nn.Module]
 
-def add_common_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--device",
-        choices=("cpu", "nntile"),
-        default="nntile",
-        help="Training device (cuda not used on this smoke path)",
+
+def load_json_object(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        raw = json.load(handle)
+    if not isinstance(raw, dict):
+        raise ValueError(f"config must be a JSON object: {path}")
+    return {k: v for k, v in raw.items() if not str(k).startswith("_")}
+
+
+def load_hf_config_from_json(
+    path: Path,
+    config_cls: ConfigFactory,
+    *,
+    attn_implementation: str | None = None,
+    use_cache: bool | None = None,
+) -> Any:
+    fields = load_json_object(path)
+    config = config_cls(**fields)
+    if attn_implementation is not None and hasattr(
+        config, "_attn_implementation"
+    ):
+        config._attn_implementation = attn_implementation
+    if use_cache is not None and hasattr(config, "use_cache"):
+        config.use_cache = use_cache
+    return config
+
+
+def config_to_dict(config: Any) -> dict[str, Any]:
+    if hasattr(config, "to_dict"):
+        return dict(config.to_dict())
+    raise TypeError(f"config has no to_dict(): {type(config)!r}")
+
+
+def save_checkpoint(
+    path: Path,
+    *,
+    model: torch.nn.Module,
+    config: Any,
+    seed: int,
+    epoch: int,
+    global_step: int,
+    device_name: str,
+    optimizer_state: dict | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with torch.no_grad():
+        state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in model.state_dict().items()
+        }
+    payload = {
+        "model_state_dict": state,
+        "config": config_to_dict(config),
+        "seed": seed,
+        "epoch": epoch,
+        "global_step": global_step,
+        "device": device_name,
+        "optimizer_state_dict": optimizer_state,
+    }
+    torch.save(payload, path)
+    print(f"Saved checkpoint to {path}")
+
+
+def load_checkpoint(path: Path) -> dict[str, Any]:
+    payload = torch.load(path, map_location="cpu", weights_only=False)
+    if not isinstance(payload, dict) or "model_state_dict" not in payload:
+        raise ValueError(f"invalid checkpoint format: {path}")
+    return payload
+
+
+def relative_frobenius(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    *,
+    eps: float = 1e-12,
+) -> float:
+    with torch.no_grad():
+        diff = (a.float() - b.float()).norm().item()
+        na = a.float().norm().item()
+        nb = b.float().norm().item()
+    return diff / max(na, nb, eps)
+
+
+def compare_checkpoints(path_a: Path, path_b: Path) -> int:
+    ckpt_a = load_checkpoint(path_a)
+    ckpt_b = load_checkpoint(path_b)
+    state_a = ckpt_a["model_state_dict"]
+    state_b = ckpt_b["model_state_dict"]
+    keys_a = set(state_a)
+    keys_b = set(state_b)
+    if keys_a != keys_b:
+        only_a = sorted(keys_a - keys_b)
+        only_b = sorted(keys_b - keys_a)
+        print("WARNING: state_dict key mismatch")
+        if only_a:
+            print(f"  only in A ({len(only_a)}): {only_a[:8]}")
+        if only_b:
+            print(f"  only in B ({len(only_b)}): {only_b[:8]}")
+    shared = sorted(keys_a & keys_b)
+    print(f"Comparing {len(shared)} tensors")
+    print(f"  A: {path_a}")
+    print(f"  B: {path_b}")
+    max_rel = 0.0
+    worst = ""
+    for name in shared:
+        ta = state_a[name]
+        tb = state_b[name]
+        if ta.shape != tb.shape:
+            print(
+                f"  SKIP {name}: shape {tuple(ta.shape)} vs "
+                f"{tuple(tb.shape)}"
+            )
+            continue
+        rel = relative_frobenius(ta, tb)
+        if rel > max_rel:
+            max_rel = rel
+            worst = name
+        print(f"  {name}: relative_frobenius={rel:.6e}")
+    print(f"max relative_frobenius={max_rel:.6e}  ({worst})")
+    return 0
+
+
+def add_train_compare_subparsers(
+    parser: argparse.ArgumentParser,
+    *,
+    default_config: Path,
+    devices: tuple[str, ...] = ("cpu", "nntile"),
+) -> None:
+    """Attach ``train`` / ``compare`` like ``train_gpt2_hf.py``."""
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    train = sub.add_parser(
+        "train",
+        help="Train from JSON config or resume a checkpoint",
     )
-    parser.add_argument("--steps", type=int, default=1)
-    parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--batch-size", type=int, default=1)
-    parser.add_argument("--seq-len", type=int, default=16)
-    parser.add_argument("--lr", type=float, default=1e-3)
-    parser.add_argument("--ncpu", type=int, default=2)
-    parser.add_argument(
+    train.add_argument(
+        "--device",
+        choices=devices,
+        default="nntile",
+        help="Training device",
+    )
+    train.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="RNG seed (required when training from scratch)",
+    )
+    train.add_argument(
+        "--checkpoint",
+        default="",
+        help="Resume weights from this checkpoint",
+    )
+    train.add_argument(
+        "--config",
+        default=str(default_config),
+        help="HuggingFace JSON config path",
+    )
+    train.add_argument(
+        "--output-dir",
+        default="",
+        help="Directory for checkpoint.pt (optional; skip save if empty)",
+    )
+    train.add_argument("--steps", type=int, default=1)
+    train.add_argument("--batch-size", type=int, default=1)
+    train.add_argument("--seq-len", type=int, default=16)
+    train.add_argument("--lr", type=float, default=1e-3)
+    train.add_argument("--ncpu", type=int, default=2)
+    train.add_argument(
         "--cpu-fallback",
         action="store_true",
-        help="Allow unregistered aten ops to fall back to CPU "
-        "(hides missing PrivateUse1 coverage)",
+        help="Allow unregistered aten ops to fall back to CPU",
     )
+
+    compare = sub.add_parser(
+        "compare",
+        help="Print relative Frobenius norms between two checkpoints",
+    )
+    compare.add_argument("--checkpoint-a", required=True)
+    compare.add_argument("--checkpoint-b", required=True)
 
 
 def make_causal_batch(
@@ -116,9 +285,6 @@ def make_encoder_decoder_batch(
     return enc, dec, labels
 
 
-LossFn = Callable[[torch.nn.Module, dict[str, torch.Tensor]], torch.Tensor]
-
-
 def causal_ce_loss(
     model: torch.nn.Module,
     batch: dict[str, torch.Tensor],
@@ -159,7 +325,6 @@ def t5_ce_loss(
         decoder_input_ids=batch["decoder_input_ids"],
         labels=batch["labels"],
     )
-    # Prefer HF fused loss when present; else CE on logits.
     if out.loss is not None:
         return out.loss
     logits = out.logits
@@ -170,34 +335,89 @@ def t5_ce_loss(
     )
 
 
+def _load_train_state(
+    args: argparse.Namespace,
+    *,
+    config_cls: ConfigFactory,
+    model_cls: ModelFactory,
+    attn_implementation: str | None,
+    use_cache: bool | None,
+) -> tuple[Any, torch.nn.Module, int, int]:
+    """Return ``(config, cpu_model, seed, global_step)``."""
+    global_step = 0
+    if args.checkpoint:
+        ckpt = load_checkpoint(Path(args.checkpoint))
+        config = config_cls.from_dict(ckpt["config"])
+        if attn_implementation is not None and hasattr(
+            config, "_attn_implementation"
+        ):
+            config._attn_implementation = attn_implementation
+        if use_cache is not None and hasattr(config, "use_cache"):
+            config.use_cache = use_cache
+        model = model_cls(config).float().train()
+        model.load_state_dict(ckpt["model_state_dict"])
+        global_step = int(ckpt.get("global_step", 0))
+        seed = int(
+            args.seed if args.seed is not None else ckpt.get("seed", 0)
+        )
+        print(
+            f"Resumed from {args.checkpoint} "
+            f"(step={global_step}, seed={seed})"
+        )
+        return config, model, seed, global_step
+
+    if args.seed is None:
+        raise SystemExit("--seed is required when training from scratch")
+    config = load_hf_config_from_json(
+        Path(args.config),
+        config_cls,
+        attn_implementation=attn_implementation,
+        use_cache=use_cache,
+    )
+    torch.manual_seed(args.seed)
+    model = model_cls(config).float().train()
+    return config, model, int(args.seed), global_step
+
+
 def run_tiny_hf_train(
     *,
     name: str,
     args: argparse.Namespace,
-    build_model: Callable[[], torch.nn.Module],
-    build_batch: Callable[[], dict[str, torch.Tensor]],
+    config: Any,
+    model: torch.nn.Module,
+    seed: int,
+    global_step: int,
+    build_batch: BatchBuilder,
     loss_fn: LossFn,
 ) -> int:
-    """Run a few train steps; return 0 on success, 1 on failure."""
-    torch.manual_seed(args.seed)
-    print(f"=== {name} tiny HF smoke  device={args.device} ===")
-
-    cpu_model = build_model().float().train()
-    batch_cpu = build_batch()
+    """Run a few train steps; optionally save ``checkpoint.pt``."""
+    print(
+        f"=== {name} tiny HF smoke  device={args.device}  "
+        f"config_seed={seed} ==="
+    )
+    batch_cpu = build_batch(config, args)
 
     if args.device == "cpu":
-        model = cpu_model
-        batch = {k: v.clone() for k, v in batch_cpu.items()}
-        return _train_loop(
+        code = _train_loop(
             name=name,
             model=model,
-            batch=batch,
+            batch={k: v.clone() for k, v in batch_cpu.items()},
             loss_fn=loss_fn,
             steps=args.steps,
             lr=args.lr,
-            sync_fn=lambda: None,
-            after_step=None,
+            nntile=False,
         )
+        if code == 0 and args.output_dir:
+            save_checkpoint(
+                Path(args.output_dir) / "checkpoint.pt",
+                model=model,
+                config=config,
+                seed=seed,
+                epoch=0,
+                global_step=global_step + args.steps,
+                device_name="cpu",
+            )
+        return code
 
     import torch_nntile
 
@@ -211,29 +431,32 @@ def run_tiny_hf_train(
     try:
         with torch.no_grad():
             batch = {k: v.to("nntile") for k, v in batch_cpu.items()}
-            model = cpu_model.to("nntile")
+            model = model.to("nntile")
         torch_nntile.compile_graph()
         torch_nntile.run()
-        del cpu_model
         for p in model.parameters():
             p.requires_grad_(True)
 
-        def after_step() -> None:
-            # Host sync + reclaim: loss .cpu() already flushes; keep
-            # INVALIDATEs in the same phase as zero_grad when possible.
-            pass
-
-        return _train_loop(
+        code = _train_loop(
             name=name,
             model=model,
             batch=batch,
             loss_fn=loss_fn,
             steps=args.steps,
             lr=args.lr,
-            sync_fn=lambda: None,
-            after_step=after_step,
             nntile=True,
         )
+        if code == 0 and args.output_dir:
+            save_checkpoint(
+                Path(args.output_dir) / "checkpoint.pt",
+                model=model,
+                config=config,
+                seed=seed,
+                epoch=0,
+                global_step=global_step + args.steps,
+                device_name="nntile",
+            )
+        return code
     except Exception as exc:  # noqa: BLE001 — discovery harness
         print(f"FAIL {name}: {type(exc).__name__}: {exc}")
         traceback.print_exc()
@@ -253,8 +476,6 @@ def _train_loop(
     loss_fn: LossFn,
     steps: int,
     lr: float,
-    sync_fn: Callable[[], None],
-    after_step: Callable[[], None] | None,
     nntile: bool = False,
 ) -> int:
     torch_nntile = None
@@ -277,16 +498,62 @@ def _train_loop(
         loss.backward()
         opt.step()
         if torch_nntile is not None:
-            # Materialize loss on host (also flushes pending graph).
             loss_val = float(loss.detach().cpu())
         else:
             loss_val = float(loss.detach())
-        sync_fn()
-        if after_step is not None:
-            after_step()
         print(f"[{name}] step {step + 1}/{steps}  loss={loss_val:.6f}")
     print(f"[{name}] wall={time.perf_counter() - t0:.3f}s  OK")
     return 0
+
+
+def run_tiny_hf_main(
+    *,
+    name: str,
+    argv: list[str] | None,
+    default_config: Path,
+    config_cls: ConfigFactory,
+    model_cls: ModelFactory,
+    build_batch: BatchBuilder,
+    loss_fn: LossFn,
+    attn_implementation: str | None = None,
+    use_cache: bool | None = None,
+    description: str = "",
+) -> int:
+    """CLI entry: ``train`` / ``compare`` with JSON config or checkpoint."""
+    parser = argparse.ArgumentParser(
+        description=description or f"Tiny HF {name} smoke",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    add_train_compare_subparsers(parser, default_config=default_config)
+    args = parser.parse_args(argv)
+    if args.command == "compare":
+        return compare_checkpoints(
+            Path(args.checkpoint_a),
+            Path(args.checkpoint_b),
+        )
+    if args.command != "train":
+        raise SystemExit(f"unknown command: {args.command}")
+    if not args.checkpoint and args.seed is None:
+        raise SystemExit("--seed is required when training from scratch")
+
+    config, model, seed, global_step = _load_train_state(
+        args,
+        config_cls=config_cls,
+        model_cls=model_cls,
+        attn_implementation=attn_implementation,
+        use_cache=use_cache,
+    )
+    args.seed = seed
+    return run_tiny_hf_train(
+        name=name,
+        args=args,
+        config=config,
+        model=model,
+        seed=seed,
+        global_step=global_step,
+        build_batch=build_batch,
+        loss_fn=loss_fn,
+    )
 
 
 def extract_missing_op(exc: BaseException) -> str | None:

--- a/torch_nntile/examples/llama_hf_tiny_config.json
+++ b/torch_nntile/examples/llama_hf_tiny_config.json
@@ -1,0 +1,16 @@
+{
+  "vocab_size": 128,
+  "hidden_size": 64,
+  "intermediate_size": 128,
+  "num_hidden_layers": 2,
+  "num_attention_heads": 4,
+  "num_key_value_heads": 4,
+  "max_position_embeddings": 64,
+  "rms_norm_eps": 1e-6,
+  "rope_theta": 10000.0,
+  "attention_dropout": 0.0,
+  "hidden_act": "silu",
+  "tie_word_embeddings": false,
+  "bos_token_id": 0,
+  "eos_token_id": 0
+}

--- a/torch_nntile/examples/llama_tiny_config.json
+++ b/torch_nntile/examples/llama_tiny_config.json
@@ -1,0 +1,10 @@
+{
+  "vocab_size": 128,
+  "hidden_size": 64,
+  "intermediate_size": 128,
+  "num_hidden_layers": 1,
+  "num_attention_heads": 4,
+  "num_key_value_heads": 4,
+  "max_position_embeddings": 32,
+  "tie_word_embeddings": false
+}

--- a/torch_nntile/examples/nntile_tiny_train_common.py
+++ b/torch_nntile/examples/nntile_tiny_train_common.py
@@ -1,0 +1,300 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/examples/nntile_tiny_train_common.py
+# Shared helpers for tiny torch_nntile model smokes (JSON config / checkpoint).
+
+"""Shared nntile-native tiny train loop with JSON config / checkpoint.
+
+Mirrors the ``train`` / ``compare`` UX of ``train_gpt2_hf.py`` for the
+hand-written ``torch_nntile.models.*`` stacks (Llama, BERT, …).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch_nntile
+from torch_nntile.training import AdamW
+
+from hf_tiny_train_common import (
+    compare_checkpoints,
+    load_checkpoint,
+    load_json_object,
+)
+
+BatchBuilder = Callable[
+    [Any, argparse.Namespace],
+    dict[str, torch.Tensor],
+]
+ConfigFactory = Callable[..., Any]
+ModelFactory = Callable[[Any], torch.nn.Module]
+LossFn = Callable[
+    [torch.nn.Module, dict[str, torch.Tensor]],
+    torch.Tensor,
+]
+
+
+def load_dataclass_config(
+    path: Path,
+    config_cls: ConfigFactory,
+) -> Any:
+    fields = load_json_object(path)
+    if dataclasses.is_dataclass(config_cls):
+        allowed = {f.name for f in dataclasses.fields(config_cls)}
+        fields = {k: v for k, v in fields.items() if k in allowed}
+    return config_cls(**fields)
+
+
+def dataclass_config_to_dict(config: Any) -> dict[str, Any]:
+    if dataclasses.is_dataclass(config):
+        return dataclasses.asdict(config)
+    if hasattr(config, "to_dict"):
+        return dict(config.to_dict())
+    raise TypeError(f"unsupported config type: {type(config)!r}")
+
+
+def save_nntile_checkpoint(
+    path: Path,
+    *,
+    model: torch.nn.Module,
+    config: Any,
+    seed: int,
+    epoch: int,
+    global_step: int,
+    device_name: str = "nntile",
+    optimizer_state: dict | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with torch.no_grad():
+        state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in model.state_dict().items()
+        }
+    payload = {
+        "model_state_dict": state,
+        "config": dataclass_config_to_dict(config),
+        "seed": seed,
+        "epoch": epoch,
+        "global_step": global_step,
+        "device": device_name,
+        "optimizer_state_dict": optimizer_state,
+    }
+    torch.save(payload, path)
+    print(f"Saved checkpoint to {path}")
+
+
+def add_nntile_train_compare_subparsers(
+    parser: argparse.ArgumentParser,
+    *,
+    default_config: Path,
+) -> None:
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    train = sub.add_parser(
+        "train",
+        help="Train from JSON config or resume a checkpoint",
+    )
+    train.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="RNG seed (required when training from scratch)",
+    )
+    train.add_argument(
+        "--checkpoint",
+        default="",
+        help="Resume weights from this checkpoint",
+    )
+    train.add_argument(
+        "--config",
+        default=str(default_config),
+        help="JSON config path for the nntile model",
+    )
+    train.add_argument(
+        "--output-dir",
+        default="",
+        help="Directory for checkpoint.pt (optional; skip save if empty)",
+    )
+    train.add_argument("--steps", type=int, default=2)
+    train.add_argument("--batch-size", type=int, default=2)
+    train.add_argument("--seq-len", type=int, default=8)
+    train.add_argument(
+        "--enc-len",
+        type=int,
+        default=None,
+        help="Encoder length for T5-style models (default: --seq-len)",
+    )
+    train.add_argument(
+        "--dec-len",
+        type=int,
+        default=None,
+        help="Decoder length for T5-style models (default: --seq-len)",
+    )
+    train.add_argument("--lr", type=float, default=1e-3)
+    train.add_argument("--ncpu", type=int, default=1)
+
+    compare = sub.add_parser(
+        "compare",
+        help="Print relative Frobenius norms between two checkpoints",
+    )
+    compare.add_argument("--checkpoint-a", required=True)
+    compare.add_argument("--checkpoint-b", required=True)
+
+
+def _load_train_state(
+    args: argparse.Namespace,
+    *,
+    config_cls: ConfigFactory,
+    model_cls: ModelFactory,
+) -> tuple[Any, torch.nn.Module, int, int]:
+    global_step = 0
+    if args.checkpoint:
+        ckpt = load_checkpoint(Path(args.checkpoint))
+        fields = dict(ckpt["config"])
+        if dataclasses.is_dataclass(config_cls):
+            allowed = {f.name for f in dataclasses.fields(config_cls)}
+            fields = {k: v for k, v in fields.items() if k in allowed}
+        config = config_cls(**fields)
+        model = model_cls(config).float().train()
+        model.load_state_dict(ckpt["model_state_dict"])
+        global_step = int(ckpt.get("global_step", 0))
+        seed = int(
+            args.seed if args.seed is not None else ckpt.get("seed", 0)
+        )
+        print(
+            f"Resumed from {args.checkpoint} "
+            f"(step={global_step}, seed={seed})"
+        )
+        return config, model, seed, global_step
+
+    if args.seed is None:
+        raise SystemExit("--seed is required when training from scratch")
+    config = load_dataclass_config(Path(args.config), config_cls)
+    torch.manual_seed(args.seed)
+    model = model_cls(config).float().train()
+    return config, model, int(args.seed), global_step
+
+
+def run_tiny_nntile_train(
+    *,
+    name: str,
+    args: argparse.Namespace,
+    config: Any,
+    model_cpu: torch.nn.Module,
+    seed: int,
+    global_step: int,
+    build_batch: BatchBuilder,
+    loss_fn: LossFn,
+) -> int:
+    print(f"=== {name} tiny nntile smoke  seed={seed} ===")
+    batch_cpu = build_batch(config, args)
+
+    torch_nntile.init_context(
+        ncpu=args.ncpu, ncuda=0, cpu_fallback=False
+    )
+    try:
+        with torch.no_grad():
+            batch = {k: v.to("nntile") for k, v in batch_cpu.items()}
+            model = model_cpu.to("nntile")
+        del model_cpu, batch_cpu
+        for p in model.parameters():
+            p.requires_grad_(True)
+        opt = AdamW(
+            [p for p in model.parameters() if p.requires_grad],
+            lr=args.lr,
+        )
+        opt.zero_grad(set_to_none=True)
+        t0 = time.perf_counter()
+        for step in range(args.steps):
+            loss = loss_fn(model, batch)
+            loss.backward()
+            opt.step()
+            step_loss = loss.detach()
+            del loss
+            opt.zero_grad(set_to_none=True)
+            torch_nntile.compile_graph()
+            torch_nntile.run()
+            torch_nntile.wait()
+            value = float(step_loss.to("cpu").item())
+            del step_loss
+            print(
+                f"[{name}] step {step + 1}/{args.steps}  "
+                f"loss={value:.6f}"
+            )
+        print(f"[{name}] wall={time.perf_counter() - t0:.3f}s  OK")
+        if args.output_dir:
+            save_nntile_checkpoint(
+                Path(args.output_dir) / "checkpoint.pt",
+                model=model,
+                config=config,
+                seed=seed,
+                epoch=0,
+                global_step=global_step + args.steps,
+            )
+    finally:
+        torch_nntile.shutdown_context()
+    return 0
+
+
+def run_tiny_nntile_main(
+    *,
+    name: str,
+    argv: list[str] | None,
+    default_config: Path,
+    config_cls: ConfigFactory,
+    model_cls: ModelFactory,
+    build_batch: BatchBuilder,
+    loss_fn: LossFn,
+    description: str = "",
+) -> int:
+    parser = argparse.ArgumentParser(
+        description=description or f"Tiny nntile {name} smoke",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    add_nntile_train_compare_subparsers(
+        parser, default_config=default_config
+    )
+    args = parser.parse_args(argv)
+    if args.command == "compare":
+        return compare_checkpoints(
+            Path(args.checkpoint_a),
+            Path(args.checkpoint_b),
+        )
+    if args.command != "train":
+        raise SystemExit(f"unknown command: {args.command}")
+    if not args.checkpoint and args.seed is None:
+        raise SystemExit("--seed is required when training from scratch")
+
+    config, model, seed, global_step = _load_train_state(
+        args,
+        config_cls=config_cls,
+        model_cls=model_cls,
+    )
+    args.seed = seed
+    return run_tiny_nntile_train(
+        name=name,
+        args=args,
+        config=config,
+        model_cpu=model,
+        seed=seed,
+        global_step=global_step,
+        build_batch=build_batch,
+        loss_fn=loss_fn,
+    )
+
+
+# Re-export for callers that only import this module.
+__all__ = [
+    "compare_checkpoints",
+    "load_checkpoint",
+    "load_dataclass_config",
+    "run_tiny_nntile_main",
+    "save_nntile_checkpoint",
+]

--- a/torch_nntile/examples/roberta_hf_tiny_config.json
+++ b/torch_nntile/examples/roberta_hf_tiny_config.json
@@ -1,0 +1,14 @@
+{
+  "vocab_size": 128,
+  "hidden_size": 64,
+  "intermediate_size": 128,
+  "num_hidden_layers": 2,
+  "num_attention_heads": 4,
+  "max_position_embeddings": 66,
+  "type_vocab_size": 1,
+  "hidden_dropout_prob": 0.0,
+  "attention_probs_dropout_prob": 0.0,
+  "pad_token_id": 1,
+  "bos_token_id": 0,
+  "eos_token_id": 2
+}

--- a/torch_nntile/examples/roberta_tiny_config.json
+++ b/torch_nntile/examples/roberta_tiny_config.json
@@ -1,0 +1,10 @@
+{
+  "vocab_size": 128,
+  "hidden_size": 64,
+  "intermediate_size": 128,
+  "num_hidden_layers": 1,
+  "num_attention_heads": 4,
+  "max_position_embeddings": 34,
+  "type_vocab_size": 1,
+  "pad_token_id": -1
+}

--- a/torch_nntile/examples/run_all_hf_tiny_smokes.py
+++ b/torch_nntile/examples/run_all_hf_tiny_smokes.py
@@ -45,8 +45,11 @@ def main(argv: list[str] | None = None) -> int:
         cmd = [
             sys.executable,
             str(here / script),
+            "train",
             "--device",
             args.device,
+            "--seed",
+            str(args.seed),
             "--steps",
             str(args.steps),
             "--seq-len",
@@ -55,8 +58,6 @@ def main(argv: list[str] | None = None) -> int:
             str(args.batch_size),
             "--ncpu",
             str(args.ncpu),
-            "--seed",
-            str(args.seed),
         ]
         print("\n" + "=" * 72)
         print(" ".join(cmd))

--- a/torch_nntile/examples/run_all_model_smokes.sh
+++ b/torch_nntile/examples/run_all_model_smokes.sh
@@ -32,12 +32,12 @@ run_py() {
 
 cd "${REPO_ROOT}"
 
-run_py "${EXAMPLES}/train_llama.py" --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
-run_py "${EXAMPLES}/train_gpt_neo.py" --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
-run_py "${EXAMPLES}/train_gpt_neox.py" --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
-run_py "${EXAMPLES}/train_bert.py" --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
-run_py "${EXAMPLES}/train_roberta.py" --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
-run_py "${EXAMPLES}/train_t5.py" --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
+run_py "${EXAMPLES}/train_llama.py" train --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
+run_py "${EXAMPLES}/train_gpt_neo.py" train --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
+run_py "${EXAMPLES}/train_gpt_neox.py" train --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
+run_py "${EXAMPLES}/train_bert.py" train --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
+run_py "${EXAMPLES}/train_roberta.py" train --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
+run_py "${EXAMPLES}/train_t5.py" train --steps "${STEPS}" --seed "${SEED}" --ncpu "${NCPU}"
 
 echo "==> train_deep_relu_mnist.py --help"
 python3 "${EXAMPLES}/train_deep_relu_mnist.py" --help >/dev/null

--- a/torch_nntile/examples/t5_hf_tiny_config.json
+++ b/torch_nntile/examples/t5_hf_tiny_config.json
@@ -1,0 +1,18 @@
+{
+  "vocab_size": 128,
+  "d_model": 64,
+  "d_kv": 16,
+  "d_ff": 128,
+  "num_layers": 1,
+  "num_decoder_layers": 1,
+  "num_heads": 4,
+  "relative_attention_num_buckets": 8,
+  "relative_attention_max_distance": 32,
+  "dropout_rate": 0.0,
+  "layer_norm_epsilon": 1e-6,
+  "feed_forward_proj": "relu",
+  "is_encoder_decoder": true,
+  "pad_token_id": 0,
+  "eos_token_id": 1,
+  "decoder_start_token_id": 0
+}

--- a/torch_nntile/examples/t5_tiny_config.json
+++ b/torch_nntile/examples/t5_tiny_config.json
@@ -1,0 +1,10 @@
+{
+  "vocab_size": 128,
+  "d_model": 64,
+  "d_kv": 16,
+  "d_ff": 128,
+  "num_layers": 1,
+  "num_decoder_layers": 1,
+  "num_heads": 4,
+  "tie_word_embeddings": false
+}

--- a/torch_nntile/examples/train_bert.py
+++ b/torch_nntile/examples/train_bert.py
@@ -7,121 +7,70 @@
 
 """Short BertMlm training smoke: random MLM labels, few steps, print loss.
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_bert.py --steps 2 --seed 0 --ncpu 1
+    python torch_nntile/examples/train_bert.py train \\
+        --seed 0 --config bert_tiny_config.json \\
+        --output-dir /tmp/bert --steps 2
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 import torch
-import torch_nntile
 from torch_nntile.models.bert import BertConfig, BertMlm
-from torch_nntile.training import AdamW, cross_entropy
+from torch_nntile.training import cross_entropy
+
+from nntile_tiny_train_common import run_tiny_nntile_main
 
 IGNORE_INDEX = -100
 
 
-def tiny_config() -> BertConfig:
-    return BertConfig(
-        vocab_size=128,
-        hidden_size=64,
-        intermediate_size=128,
-        num_hidden_layers=1,
-        num_attention_heads=4,
-        max_position_embeddings=32,
-        type_vocab_size=2,
-    )
-
-
-def make_mlm_batch(
-    vocab_size: int,
-    *,
-    batch_size: int,
-    seq_len: int,
-    seed: int,
-    mask_prob: float = 0.25,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Random input ids + MLM labels (``IGNORE_INDEX`` on unmasked tokens)."""
-    g = torch.Generator().manual_seed(seed)
-    input_ids = torch.randint(
-        0, vocab_size, (batch_size, seq_len), dtype=torch.long, generator=g
-    )
-    labels = input_ids.clone()
-    mask = torch.rand(batch_size, seq_len, generator=g) < mask_prob
-    # Ensure at least one masked position so CE is well-defined.
-    if not bool(mask.any()):
-        mask[0, 0] = True
-    labels = labels.masked_fill(~mask, IGNORE_INDEX)
-    # Replace masked inputs with a sentinel id (0) for a tiny MLM-like corrupt.
-    input_ids = input_ids.clone()
-    input_ids[mask] = 0
-    return input_ids, labels
-
-
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--steps", type=int, default=2)
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--ncpu", type=int, default=1)
-    p.add_argument("--batch-size", type=int, default=2)
-    p.add_argument("--seq-len", type=int, default=8)
-    p.add_argument("--lr", type=float, default=1e-3)
-    return p.parse_args(argv)
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "bert_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
-    torch.manual_seed(args.seed)
-    cfg = tiny_config()
-    inputs_cpu, labels_cpu = make_mlm_batch(
-        cfg.vocab_size,
-        batch_size=args.batch_size,
-        seq_len=args.seq_len,
-        seed=args.seed,
-    )
-    model_cpu = BertMlm(cfg).float().train()
-
-    torch_nntile.init_context(
-        ncpu=args.ncpu, ncuda=0, cpu_fallback=False
-    )
-    try:
-        with torch.no_grad():
-            inputs = inputs_cpu.to("nntile")
-            labels = labels_cpu.to("nntile")
-            model = model_cpu.to("nntile")
-        del model_cpu, inputs_cpu, labels_cpu
-        for p in model.parameters():
-            p.requires_grad_(True)
-        opt = AdamW(
-            [p for p in model.parameters() if p.requires_grad],
-            lr=args.lr,
+    def build_batch(cfg, args):
+        g = torch.Generator().manual_seed(args.seed)
+        input_ids = torch.randint(
+            0,
+            cfg.vocab_size,
+            (args.batch_size, args.seq_len),
+            dtype=torch.long,
+            generator=g,
         )
-        opt.zero_grad(set_to_none=True)
-        for step in range(args.steps):
-            logits = model(inputs)
-            loss = cross_entropy(
-                logits,
-                labels,
-                reduction="mean",
-                ignore_index=IGNORE_INDEX,
-            )
-            loss.backward()
-            opt.step()
-            step_loss = loss.detach()
-            del loss, logits
-            opt.zero_grad(set_to_none=True)
-            torch_nntile.compile_graph()
-            torch_nntile.run()
-            torch_nntile.wait()
-            value = float(step_loss.to("cpu").item())
-            del step_loss
-            print(f"[bert] step {step + 1}/{args.steps}  loss={value:.6f}")
-    finally:
-        torch_nntile.shutdown_context()
-    return 0
+        labels = input_ids.clone()
+        mask = (
+            torch.rand(args.batch_size, args.seq_len, generator=g) < 0.25
+        )
+        if not bool(mask.any()):
+            mask[0, 0] = True
+        labels = labels.masked_fill(~mask, IGNORE_INDEX)
+        input_ids = input_ids.clone()
+        input_ids[mask] = 0
+        return {"input_ids": input_ids, "labels": labels}
+
+    def loss_fn(model, batch):
+        logits = model(batch["input_ids"])
+        return cross_entropy(
+            logits,
+            batch["labels"],
+            reduction="mean",
+            ignore_index=IGNORE_INDEX,
+        )
+
+    return run_tiny_nntile_main(
+        name="bert",
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=BertConfig,
+        model_cls=BertMlm,
+        build_batch=build_batch,
+        loss_fn=loss_fn,
+        description=__doc__,
+    )
 
 
 if __name__ == "__main__":

--- a/torch_nntile/examples/train_bert_hf.py
+++ b/torch_nntile/examples/train_bert_hf.py
@@ -7,68 +7,52 @@
 
 """Tiny HF BERT MLM smoke (synthetic tokens).
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_bert_hf.py --device nntile --steps 1
+    python torch_nntile/examples/train_bert_hf.py train \\
+        --device nntile --seed 0 --config bert_hf_tiny_config.json \\
+        --output-dir /tmp/bert_hf --steps 1
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 import torch
 from transformers import BertConfig, BertForMaskedLM
 
 from hf_tiny_train_common import (
-    add_common_args,
     make_mlm_batch,
     mlm_ce_loss,
-    run_tiny_hf_train,
+    run_tiny_hf_main,
 )
 
 
-def tiny_config() -> BertConfig:
-    cfg = BertConfig(
-        vocab_size=128,
-        hidden_size=64,
-        intermediate_size=128,
-        num_hidden_layers=2,
-        num_attention_heads=4,
-        max_position_embeddings=64,
-        type_vocab_size=2,
-        hidden_dropout_prob=0.0,
-        attention_probs_dropout_prob=0.0,
-        pad_token_id=0,
-    )
-    cfg._attn_implementation = "eager"
-    return cfg
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "bert_hf_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description=__doc__)
-    add_common_args(p)
-    args = p.parse_args(argv)
-    cfg = tiny_config()
-
-    def build_model():
-        return BertForMaskedLM(cfg)
-
-    def build_batch():
+    def build_batch(cfg, args):
         x, y = make_mlm_batch(
             cfg.vocab_size,
             batch_size=args.batch_size,
             seq_len=args.seq_len,
-            seed=args.seed,
+            seed=args.seed if args.seed is not None else 0,
         )
         attn = torch.ones_like(x)
         return {"input_ids": x, "labels": y, "attention_mask": attn}
 
-    return run_tiny_hf_train(
+    return run_tiny_hf_main(
         name="bert",
-        args=args,
-        build_model=build_model,
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=BertConfig,
+        model_cls=BertForMaskedLM,
         build_batch=build_batch,
         loss_fn=mlm_ce_loss,
+        attn_implementation="eager",
+        description=__doc__,
     )
 
 

--- a/torch_nntile/examples/train_gpt_neo.py
+++ b/torch_nntile/examples/train_gpt_neo.py
@@ -7,105 +7,59 @@
 
 """Short GPTNeoCausal training smoke: synthetic tokens, few steps, print loss.
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_gpt_neo.py --steps 2 --seed 0 --ncpu 1
+    python torch_nntile/examples/train_gpt_neo.py train \\
+        --seed 0 --config gpt_neo_tiny_config.json \\
+        --output-dir /tmp/gpt_neo --steps 2
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 import torch
-import torch_nntile
 from torch_nntile.models.gpt_neo import GPTNeoCausal, GPTNeoConfig
-from torch_nntile.training import AdamW, cross_entropy
+from torch_nntile.training import cross_entropy
+
+from nntile_tiny_train_common import run_tiny_nntile_main
 
 
-def tiny_config() -> GPTNeoConfig:
-    return GPTNeoConfig(
-        vocab_size=128,
-        hidden_size=64,
-        intermediate_size=128,
-        num_hidden_layers=1,
-        num_attention_heads=4,
-        max_position_embeddings=32,
-        window_size=16,
-        tie_word_embeddings=False,
-        attention_layers=["global"],
-    )
-
-
-def make_batch(
-    vocab_size: int,
-    *,
-    batch_size: int,
-    seq_len: int,
-    seed: int,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    g = torch.Generator().manual_seed(seed)
-    packed = torch.randint(
-        0, vocab_size, (batch_size, seq_len + 1), dtype=torch.long, generator=g
-    )
-    return packed[:, :-1].clone(), packed[:, 1:].clone()
-
-
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--steps", type=int, default=2)
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--ncpu", type=int, default=1)
-    p.add_argument("--batch-size", type=int, default=2)
-    p.add_argument("--seq-len", type=int, default=8)
-    p.add_argument("--lr", type=float, default=1e-3)
-    return p.parse_args(argv)
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "gpt_neo_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
-    torch.manual_seed(args.seed)
-    cfg = tiny_config()
-    inputs_cpu, labels_cpu = make_batch(
-        cfg.vocab_size,
-        batch_size=args.batch_size,
-        seq_len=args.seq_len,
-        seed=args.seed,
-    )
-    model_cpu = GPTNeoCausal(cfg).float().train()
-
-    torch_nntile.init_context(
-        ncpu=args.ncpu, ncuda=0, cpu_fallback=False
-    )
-    try:
-        with torch.no_grad():
-            inputs = inputs_cpu.to("nntile")
-            labels = labels_cpu.to("nntile")
-            model = model_cpu.to("nntile")
-        del model_cpu, inputs_cpu, labels_cpu
-        for p in model.parameters():
-            p.requires_grad_(True)
-        opt = AdamW(
-            [p for p in model.parameters() if p.requires_grad],
-            lr=args.lr,
+    def build_batch(cfg, args):
+        g = torch.Generator().manual_seed(args.seed)
+        packed = torch.randint(
+            0,
+            cfg.vocab_size,
+            (args.batch_size, args.seq_len + 1),
+            dtype=torch.long,
+            generator=g,
         )
-        opt.zero_grad(set_to_none=True)
-        for step in range(args.steps):
-            logits = model(inputs)
-            loss = cross_entropy(logits, labels, reduction="mean")
-            loss.backward()
-            opt.step()
-            step_loss = loss.detach()
-            del loss, logits
-            opt.zero_grad(set_to_none=True)
-            torch_nntile.compile_graph()
-            torch_nntile.run()
-            torch_nntile.wait()
-            value = float(step_loss.to("cpu").item())
-            del step_loss
-            print(f"[gpt_neo] step {step + 1}/{args.steps}  loss={value:.6f}")
-    finally:
-        torch_nntile.shutdown_context()
-    return 0
+        return {
+            "input_ids": packed[:, :-1].clone(),
+            "labels": packed[:, 1:].clone(),
+        }
+
+    def loss_fn(model, batch):
+        logits = model(batch["input_ids"])
+        return cross_entropy(
+            logits, batch["labels"], reduction="mean"
+        )
+
+    return run_tiny_nntile_main(
+        name="gpt-neo",
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=GPTNeoConfig,
+        model_cls=GPTNeoCausal,
+        build_batch=build_batch,
+        loss_fn=loss_fn,
+        description=__doc__,
+    )
 
 
 if __name__ == "__main__":

--- a/torch_nntile/examples/train_gpt_neo_hf.py
+++ b/torch_nntile/examples/train_gpt_neo_hf.py
@@ -7,73 +7,51 @@
 
 """Tiny HF GPT-Neo causal LM smoke (synthetic tokens).
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_gpt_neo_hf.py --device nntile --steps 1
+    python torch_nntile/examples/train_gpt_neo_hf.py train \\
+        --device nntile --seed 0 --config gpt_neo_hf_tiny_config.json \\
+        --output-dir /tmp/gpt_neo_hf --steps 1
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 from transformers import GPTNeoConfig, GPTNeoForCausalLM
 
 from hf_tiny_train_common import (
-    add_common_args,
     causal_ce_loss,
     make_causal_batch,
-    run_tiny_hf_train,
+    run_tiny_hf_main,
 )
 
 
-def tiny_config() -> GPTNeoConfig:
-    cfg = GPTNeoConfig(
-        vocab_size=128,
-        hidden_size=64,
-        intermediate_size=128,
-        num_layers=2,
-        num_heads=4,
-        max_position_embeddings=64,
-        attention_types=[[["global"], 2]],
-        window_size=32,
-        attention_dropout=0.0,
-        embed_dropout=0.0,
-        resid_dropout=0.0,
-        classifier_dropout=0.0,
-        bos_token_id=0,
-        eos_token_id=0,
-    )
-    # GPT-Neo has no SDPA path in this transformers version; eager uses
-    # matmul attention (still exercises nntile mm/add/softmax/etc.).
-    cfg._attn_implementation = "eager"
-    cfg.use_cache = False
-    return cfg
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "gpt_neo_hf_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description=__doc__)
-    add_common_args(p)
-    args = p.parse_args(argv)
-    cfg = tiny_config()
-
-    def build_model():
-        return GPTNeoForCausalLM(cfg)
-
-    def build_batch():
+    def build_batch(cfg, args):
         x, y = make_causal_batch(
             cfg.vocab_size,
             batch_size=args.batch_size,
             seq_len=args.seq_len,
-            seed=args.seed,
+            seed=args.seed if args.seed is not None else 0,
         )
         return {"input_ids": x, "labels": y}
 
-    return run_tiny_hf_train(
+    return run_tiny_hf_main(
         name="gpt-neo",
-        args=args,
-        build_model=build_model,
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=GPTNeoConfig,
+        model_cls=GPTNeoForCausalLM,
         build_batch=build_batch,
         loss_fn=causal_ce_loss,
+        attn_implementation="eager",
+        use_cache=False,
+        description=__doc__,
     )
 
 

--- a/torch_nntile/examples/train_gpt_neox.py
+++ b/torch_nntile/examples/train_gpt_neox.py
@@ -7,106 +7,59 @@
 
 """Short GPTNeoXCausal training smoke: synthetic tokens, few steps, print loss.
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_gpt_neox.py --steps 2 --seed 0 --ncpu 1
+    python torch_nntile/examples/train_gpt_neox.py train \\
+        --seed 0 --config gpt_neox_tiny_config.json \\
+        --output-dir /tmp/gpt_neox --steps 2
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 import torch
-import torch_nntile
 from torch_nntile.models.gpt_neox import GPTNeoXCausal, GPTNeoXConfig
-from torch_nntile.training import AdamW, cross_entropy
+from torch_nntile.training import cross_entropy
+
+from nntile_tiny_train_common import run_tiny_nntile_main
 
 
-def tiny_config() -> GPTNeoXConfig:
-    return GPTNeoXConfig(
-        vocab_size=128,
-        hidden_size=64,
-        intermediate_size=128,
-        num_hidden_layers=1,
-        num_attention_heads=4,
-        max_position_embeddings=32,
-        rotary_pct=0.25,
-        tie_word_embeddings=False,
-    )
-
-
-def make_batch(
-    vocab_size: int,
-    *,
-    batch_size: int,
-    seq_len: int,
-    seed: int,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    g = torch.Generator().manual_seed(seed)
-    packed = torch.randint(
-        0, vocab_size, (batch_size, seq_len + 1), dtype=torch.long, generator=g
-    )
-    return packed[:, :-1].clone(), packed[:, 1:].clone()
-
-
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--steps", type=int, default=2)
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--ncpu", type=int, default=1)
-    p.add_argument("--batch-size", type=int, default=2)
-    p.add_argument("--seq-len", type=int, default=8)
-    p.add_argument("--lr", type=float, default=1e-3)
-    return p.parse_args(argv)
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "gpt_neox_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
-    torch.manual_seed(args.seed)
-    cfg = tiny_config()
-    inputs_cpu, labels_cpu = make_batch(
-        cfg.vocab_size,
-        batch_size=args.batch_size,
-        seq_len=args.seq_len,
-        seed=args.seed,
-    )
-    model_cpu = GPTNeoXCausal(cfg).float().train()
-
-    torch_nntile.init_context(
-        ncpu=args.ncpu, ncuda=0, cpu_fallback=False
-    )
-    try:
-        with torch.no_grad():
-            inputs = inputs_cpu.to("nntile")
-            labels = labels_cpu.to("nntile")
-            model = model_cpu.to("nntile")
-        del model_cpu, inputs_cpu, labels_cpu
-        for p in model.parameters():
-            p.requires_grad_(True)
-        opt = AdamW(
-            [p for p in model.parameters() if p.requires_grad],
-            lr=args.lr,
+    def build_batch(cfg, args):
+        g = torch.Generator().manual_seed(args.seed)
+        packed = torch.randint(
+            0,
+            cfg.vocab_size,
+            (args.batch_size, args.seq_len + 1),
+            dtype=torch.long,
+            generator=g,
         )
-        opt.zero_grad(set_to_none=True)
-        for step in range(args.steps):
-            logits = model(inputs)
-            loss = cross_entropy(logits, labels, reduction="mean")
-            loss.backward()
-            opt.step()
-            step_loss = loss.detach()
-            del loss, logits
-            opt.zero_grad(set_to_none=True)
-            torch_nntile.compile_graph()
-            torch_nntile.run()
-            torch_nntile.wait()
-            value = float(step_loss.to("cpu").item())
-            del step_loss
-            print(
-                f"[gpt_neox] step {step + 1}/{args.steps}  loss={value:.6f}"
-            )
-    finally:
-        torch_nntile.shutdown_context()
-    return 0
+        return {
+            "input_ids": packed[:, :-1].clone(),
+            "labels": packed[:, 1:].clone(),
+        }
+
+    def loss_fn(model, batch):
+        logits = model(batch["input_ids"])
+        return cross_entropy(
+            logits, batch["labels"], reduction="mean"
+        )
+
+    return run_tiny_nntile_main(
+        name="gpt-neox",
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=GPTNeoXConfig,
+        model_cls=GPTNeoXCausal,
+        build_batch=build_batch,
+        loss_fn=loss_fn,
+        description=__doc__,
+    )
 
 
 if __name__ == "__main__":

--- a/torch_nntile/examples/train_gpt_neox_hf.py
+++ b/torch_nntile/examples/train_gpt_neox_hf.py
@@ -7,73 +7,51 @@
 
 """Tiny HF GPT-NeoX causal LM smoke (synthetic tokens).
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_gpt_neox_hf.py --device nntile --steps 1
+    python torch_nntile/examples/train_gpt_neox_hf.py train \\
+        --device nntile --seed 0 --config gpt_neox_hf_tiny_config.json \\
+        --output-dir /tmp/gpt_neox_hf --steps 1
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 from transformers import GPTNeoXConfig, GPTNeoXForCausalLM
 
 from hf_tiny_train_common import (
-    add_common_args,
     causal_ce_loss,
     make_causal_batch,
-    run_tiny_hf_train,
+    run_tiny_hf_main,
 )
 
 
-def tiny_config() -> GPTNeoXConfig:
-    cfg = GPTNeoXConfig(
-        vocab_size=128,
-        hidden_size=64,
-        intermediate_size=128,
-        num_hidden_layers=2,
-        num_attention_heads=4,
-        max_position_embeddings=64,
-        # Full rotary leaves an empty q_pass slice; TensorGraph rejects
-        # zero-sized dims on backward. Partial RoPE keeps a pass-through.
-        rotary_pct=0.5,
-        rotary_emb_base=10000,
-        attention_dropout=0.0,
-        hidden_dropout=0.0,
-        classifier_dropout=0.0,
-        bos_token_id=0,
-        eos_token_id=0,
-        tie_word_embeddings=False,
-    )
-    cfg._attn_implementation = "sdpa"
-    cfg.use_cache = False
-    return cfg
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "gpt_neox_hf_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description=__doc__)
-    add_common_args(p)
-    args = p.parse_args(argv)
-    cfg = tiny_config()
-
-    def build_model():
-        return GPTNeoXForCausalLM(cfg)
-
-    def build_batch():
+    def build_batch(cfg, args):
         x, y = make_causal_batch(
             cfg.vocab_size,
             batch_size=args.batch_size,
             seq_len=args.seq_len,
-            seed=args.seed,
+            seed=args.seed if args.seed is not None else 0,
         )
         return {"input_ids": x, "labels": y}
 
-    return run_tiny_hf_train(
+    return run_tiny_hf_main(
         name="gpt-neox",
-        args=args,
-        build_model=build_model,
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=GPTNeoXConfig,
+        model_cls=GPTNeoXForCausalLM,
         build_batch=build_batch,
         loss_fn=causal_ce_loss,
+        attn_implementation="sdpa",
+        use_cache=False,
+        description=__doc__,
     )
 
 

--- a/torch_nntile/examples/train_llama.py
+++ b/torch_nntile/examples/train_llama.py
@@ -7,104 +7,59 @@
 
 """Short LlamaCausal training smoke: synthetic tokens, few steps, print loss.
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_llama.py --steps 2 --seed 0 --ncpu 1
+    python torch_nntile/examples/train_llama.py train \\
+        --seed 0 --config llama_tiny_config.json \\
+        --output-dir /tmp/llama --steps 2
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 import torch
-import torch_nntile
 from torch_nntile.models.llama import LlamaCausal, LlamaConfig
-from torch_nntile.training import AdamW, cross_entropy
+from torch_nntile.training import cross_entropy
+
+from nntile_tiny_train_common import run_tiny_nntile_main
 
 
-def tiny_config() -> LlamaConfig:
-    return LlamaConfig(
-        vocab_size=128,
-        hidden_size=64,
-        intermediate_size=128,
-        num_hidden_layers=1,
-        num_attention_heads=4,
-        num_key_value_heads=4,
-        max_position_embeddings=32,
-        tie_word_embeddings=False,
-    )
-
-
-def make_batch(
-    vocab_size: int,
-    *,
-    batch_size: int,
-    seq_len: int,
-    seed: int,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    g = torch.Generator().manual_seed(seed)
-    packed = torch.randint(
-        0, vocab_size, (batch_size, seq_len + 1), dtype=torch.long, generator=g
-    )
-    return packed[:, :-1].clone(), packed[:, 1:].clone()
-
-
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--steps", type=int, default=2)
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--ncpu", type=int, default=1)
-    p.add_argument("--batch-size", type=int, default=2)
-    p.add_argument("--seq-len", type=int, default=8)
-    p.add_argument("--lr", type=float, default=1e-3)
-    return p.parse_args(argv)
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "llama_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
-    torch.manual_seed(args.seed)
-    cfg = tiny_config()
-    inputs_cpu, labels_cpu = make_batch(
-        cfg.vocab_size,
-        batch_size=args.batch_size,
-        seq_len=args.seq_len,
-        seed=args.seed,
-    )
-    model_cpu = LlamaCausal(cfg).float().train()
-
-    torch_nntile.init_context(
-        ncpu=args.ncpu, ncuda=0, cpu_fallback=False
-    )
-    try:
-        with torch.no_grad():
-            inputs = inputs_cpu.to("nntile")
-            labels = labels_cpu.to("nntile")
-            model = model_cpu.to("nntile")
-        del model_cpu, inputs_cpu, labels_cpu
-        for p in model.parameters():
-            p.requires_grad_(True)
-        opt = AdamW(
-            [p for p in model.parameters() if p.requires_grad],
-            lr=args.lr,
+    def build_batch(cfg, args):
+        g = torch.Generator().manual_seed(args.seed)
+        packed = torch.randint(
+            0,
+            cfg.vocab_size,
+            (args.batch_size, args.seq_len + 1),
+            dtype=torch.long,
+            generator=g,
         )
-        opt.zero_grad(set_to_none=True)
-        for step in range(args.steps):
-            logits = model(inputs)
-            loss = cross_entropy(logits, labels, reduction="mean")
-            loss.backward()
-            opt.step()
-            step_loss = loss.detach()
-            del loss, logits
-            opt.zero_grad(set_to_none=True)
-            torch_nntile.compile_graph()
-            torch_nntile.run()
-            torch_nntile.wait()
-            value = float(step_loss.to("cpu").item())
-            del step_loss
-            print(f"[llama] step {step + 1}/{args.steps}  loss={value:.6f}")
-    finally:
-        torch_nntile.shutdown_context()
-    return 0
+        return {
+            "input_ids": packed[:, :-1].clone(),
+            "labels": packed[:, 1:].clone(),
+        }
+
+    def loss_fn(model, batch):
+        logits = model(batch["input_ids"])
+        return cross_entropy(
+            logits, batch["labels"], reduction="mean"
+        )
+
+    return run_tiny_nntile_main(
+        name="llama",
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=LlamaConfig,
+        model_cls=LlamaCausal,
+        build_batch=build_batch,
+        loss_fn=loss_fn,
+        description=__doc__,
+    )
 
 
 if __name__ == "__main__":

--- a/torch_nntile/examples/train_llama_hf.py
+++ b/torch_nntile/examples/train_llama_hf.py
@@ -7,71 +7,53 @@
 
 """Tiny HF Llama causal LM smoke (synthetic tokens).
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_llama_hf.py --device nntile --steps 1
+    python torch_nntile/examples/train_llama_hf.py train \\
+        --device nntile --seed 0 --config llama_hf_tiny_config.json \\
+        --output-dir /tmp/llama_hf --steps 1
+
+    python ... compare --checkpoint-a A.pt --checkpoint-b B.pt
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 from transformers import LlamaConfig, LlamaForCausalLM
 
 from hf_tiny_train_common import (
-    add_common_args,
     causal_ce_loss,
     make_causal_batch,
-    run_tiny_hf_train,
+    run_tiny_hf_main,
 )
 
 
-def tiny_config() -> LlamaConfig:
-    cfg = LlamaConfig(
-        vocab_size=128,
-        hidden_size=64,
-        intermediate_size=128,
-        num_hidden_layers=2,
-        num_attention_heads=4,
-        num_key_value_heads=4,
-        max_position_embeddings=64,
-        rms_norm_eps=1e-6,
-        rope_theta=10000.0,
-        attention_dropout=0.0,
-        hidden_act="silu",
-        tie_word_embeddings=False,
-        bos_token_id=0,
-        eos_token_id=0,
-    )
-    cfg._attn_implementation = "sdpa"
-    cfg.use_cache = False
-    return cfg
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "llama_hf_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description=__doc__)
-    add_common_args(p)
-    args = p.parse_args(argv)
-    cfg = tiny_config()
-
-    def build_model():
-        return LlamaForCausalLM(cfg)
-
-    def build_batch():
+    def build_batch(cfg, args):
         x, y = make_causal_batch(
             cfg.vocab_size,
             batch_size=args.batch_size,
             seq_len=args.seq_len,
-            seed=args.seed,
+            seed=args.seed if args.seed is not None else 0,
         )
         return {"input_ids": x, "labels": y}
 
-    return run_tiny_hf_train(
+    return run_tiny_hf_main(
         name="llama",
-        args=args,
-        build_model=build_model,
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=LlamaConfig,
+        model_cls=LlamaForCausalLM,
         build_batch=build_batch,
         loss_fn=causal_ce_loss,
+        attn_implementation="sdpa",
+        use_cache=False,
+        description=__doc__,
     )
 
 

--- a/torch_nntile/examples/train_roberta.py
+++ b/torch_nntile/examples/train_roberta.py
@@ -7,127 +7,74 @@
 
 """Short RobertaMlm training smoke: random MLM labels, few steps, print loss.
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_roberta.py --steps 2 --seed 0 --ncpu 1
+    python torch_nntile/examples/train_roberta.py train \\
+        --seed 0 --config roberta_tiny_config.json \\
+        --output-dir /tmp/roberta --steps 2
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 import torch
-import torch_nntile
 from torch_nntile.models.roberta import RobertaConfig, RobertaMlm
-from torch_nntile.training import AdamW, cross_entropy
+from torch_nntile.training import cross_entropy
+
+from nntile_tiny_train_common import run_tiny_nntile_main
 
 IGNORE_INDEX = -100
 
 
-def tiny_config() -> RobertaConfig:
-    return RobertaConfig(
-        vocab_size=128,
-        hidden_size=64,
-        intermediate_size=128,
-        num_hidden_layers=1,
-        num_attention_heads=4,
-        max_position_embeddings=34,
-        type_vocab_size=1,
-        # nntile Embedding requires padding_idx == -1.
-        pad_token_id=-1,
-    )
-
-
-def make_mlm_batch(
-    vocab_size: int,
-    *,
-    batch_size: int,
-    seq_len: int,
-    seed: int,
-    pad_token_id: int,
-    mask_prob: float = 0.25,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Random input ids + MLM labels (``IGNORE_INDEX`` on unmasked tokens)."""
-    g = torch.Generator().manual_seed(seed)
-    # Avoid pad_token_id in content so position ids stay dense.
-    hi = max(vocab_size, 2)
-    choices = [i for i in range(hi) if i != pad_token_id]
-    idx = torch.randint(
-        0, len(choices), (batch_size, seq_len), dtype=torch.long, generator=g
-    )
-    input_ids = torch.tensor(choices, dtype=torch.long)[idx]
-    labels = input_ids.clone()
-    mask = torch.rand(batch_size, seq_len, generator=g) < mask_prob
-    if not bool(mask.any()):
-        mask[0, 0] = True
-    labels = labels.masked_fill(~mask, IGNORE_INDEX)
-    input_ids = input_ids.clone()
-    input_ids[mask] = 0
-    return input_ids, labels
-
-
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--steps", type=int, default=2)
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--ncpu", type=int, default=1)
-    p.add_argument("--batch-size", type=int, default=2)
-    p.add_argument("--seq-len", type=int, default=8)
-    p.add_argument("--lr", type=float, default=1e-3)
-    return p.parse_args(argv)
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "roberta_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
-    torch.manual_seed(args.seed)
-    cfg = tiny_config()
-    inputs_cpu, labels_cpu = make_mlm_batch(
-        cfg.vocab_size,
-        batch_size=args.batch_size,
-        seq_len=args.seq_len,
-        seed=args.seed,
-        pad_token_id=cfg.pad_token_id,
-    )
-    model_cpu = RobertaMlm(cfg).float().train()
-
-    torch_nntile.init_context(
-        ncpu=args.ncpu, ncuda=0, cpu_fallback=False
-    )
-    try:
-        with torch.no_grad():
-            inputs = inputs_cpu.to("nntile")
-            labels = labels_cpu.to("nntile")
-            model = model_cpu.to("nntile")
-        del model_cpu, inputs_cpu, labels_cpu
-        for p in model.parameters():
-            p.requires_grad_(True)
-        opt = AdamW(
-            [p for p in model.parameters() if p.requires_grad],
-            lr=args.lr,
+    def build_batch(cfg, args):
+        g = torch.Generator().manual_seed(args.seed)
+        pad_token_id = int(cfg.pad_token_id)
+        hi = max(cfg.vocab_size, 2)
+        choices = [i for i in range(hi) if i != pad_token_id]
+        idx = torch.randint(
+            0,
+            len(choices),
+            (args.batch_size, args.seq_len),
+            dtype=torch.long,
+            generator=g,
         )
-        opt.zero_grad(set_to_none=True)
-        for step in range(args.steps):
-            logits = model(inputs)
-            loss = cross_entropy(
-                logits,
-                labels,
-                reduction="mean",
-                ignore_index=IGNORE_INDEX,
-            )
-            loss.backward()
-            opt.step()
-            step_loss = loss.detach()
-            del loss, logits
-            opt.zero_grad(set_to_none=True)
-            torch_nntile.compile_graph()
-            torch_nntile.run()
-            torch_nntile.wait()
-            value = float(step_loss.to("cpu").item())
-            del step_loss
-            print(f"[roberta] step {step + 1}/{args.steps}  loss={value:.6f}")
-    finally:
-        torch_nntile.shutdown_context()
-    return 0
+        input_ids = torch.tensor(choices, dtype=torch.long)[idx]
+        labels = input_ids.clone()
+        mask = (
+            torch.rand(args.batch_size, args.seq_len, generator=g) < 0.25
+        )
+        if not bool(mask.any()):
+            mask[0, 0] = True
+        labels = labels.masked_fill(~mask, IGNORE_INDEX)
+        input_ids = input_ids.clone()
+        input_ids[mask] = 0
+        return {"input_ids": input_ids, "labels": labels}
+
+    def loss_fn(model, batch):
+        logits = model(batch["input_ids"])
+        return cross_entropy(
+            logits,
+            batch["labels"],
+            reduction="mean",
+            ignore_index=IGNORE_INDEX,
+        )
+
+    return run_tiny_nntile_main(
+        name="roberta",
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=RobertaConfig,
+        model_cls=RobertaMlm,
+        build_batch=build_batch,
+        loss_fn=loss_fn,
+        description=__doc__,
+    )
 
 
 if __name__ == "__main__":

--- a/torch_nntile/examples/train_roberta_hf.py
+++ b/torch_nntile/examples/train_roberta_hf.py
@@ -7,63 +7,40 @@
 
 """Tiny HF RoBERTa MLM smoke (synthetic tokens).
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_roberta_hf.py --device nntile --steps 1
+    python torch_nntile/examples/train_roberta_hf.py train \\
+        --device nntile --seed 0 --config roberta_hf_tiny_config.json \\
+        --output-dir /tmp/roberta_hf --steps 1
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 import torch
 from transformers import RobertaConfig, RobertaForMaskedLM
 
 from hf_tiny_train_common import (
-    add_common_args,
     make_mlm_batch,
     mlm_ce_loss,
-    run_tiny_hf_train,
+    run_tiny_hf_main,
 )
 
 
-def tiny_config() -> RobertaConfig:
-    cfg = RobertaConfig(
-        vocab_size=128,
-        hidden_size=64,
-        intermediate_size=128,
-        num_hidden_layers=2,
-        num_attention_heads=4,
-        max_position_embeddings=66,
-        type_vocab_size=1,
-        hidden_dropout_prob=0.0,
-        attention_probs_dropout_prob=0.0,
-        pad_token_id=1,
-        bos_token_id=0,
-        eos_token_id=2,
-    )
-    cfg._attn_implementation = "eager"
-    return cfg
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "roberta_hf_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description=__doc__)
-    add_common_args(p)
-    args = p.parse_args(argv)
-    cfg = tiny_config()
-
-    def build_model():
-        return RobertaForMaskedLM(cfg)
-
-    def build_batch():
+    def build_batch(cfg, args):
         x, y = make_mlm_batch(
             cfg.vocab_size,
             batch_size=args.batch_size,
             seq_len=args.seq_len,
-            seed=args.seed,
+            seed=args.seed if args.seed is not None else 0,
         )
         attn = torch.ones_like(x)
-        # Host position ids: skips RobertaEmbeddings ne(pad) path.
         pos = (
             torch.arange(args.seq_len, dtype=torch.long)
             .unsqueeze(0)
@@ -77,12 +54,16 @@ def main(argv: list[str] | None = None) -> int:
             "position_ids": pos,
         }
 
-    return run_tiny_hf_train(
+    return run_tiny_hf_main(
         name="roberta",
-        args=args,
-        build_model=build_model,
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=RobertaConfig,
+        model_cls=RobertaForMaskedLM,
         build_batch=build_batch,
         loss_fn=mlm_ce_loss,
+        attn_implementation="eager",
+        description=__doc__,
     )
 
 

--- a/torch_nntile/examples/train_t5.py
+++ b/torch_nntile/examples/train_t5.py
@@ -7,114 +7,73 @@
 
 """Short T5 training smoke: encoder/decoder ids, few steps, print loss.
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_t5.py --steps 2 --seed 0 --ncpu 1
+    python torch_nntile/examples/train_t5.py train \\
+        --seed 0 --config t5_tiny_config.json \\
+        --output-dir /tmp/t5 --steps 2
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 import torch
-import torch_nntile
 from torch_nntile.models.t5 import T5Config, T5ForConditionalGeneration
-from torch_nntile.training import AdamW, cross_entropy
+from torch_nntile.training import cross_entropy
+
+from nntile_tiny_train_common import run_tiny_nntile_main
 
 
-def tiny_config() -> T5Config:
-    return T5Config(
-        vocab_size=128,
-        d_model=64,
-        d_kv=16,
-        d_ff=128,
-        num_layers=1,
-        num_decoder_layers=1,
-        num_heads=4,
-        tie_word_embeddings=False,
-    )
-
-
-def make_batch(
-    vocab_size: int,
-    *,
-    batch_size: int,
-    enc_len: int,
-    dec_len: int,
-    seed: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Encoder ids, decoder ids, and next-token labels for the decoder."""
-    g = torch.Generator().manual_seed(seed)
-    enc = torch.randint(
-        0, vocab_size, (batch_size, enc_len), dtype=torch.long, generator=g
-    )
-    packed = torch.randint(
-        0, vocab_size, (batch_size, dec_len + 1), dtype=torch.long, generator=g
-    )
-    dec = packed[:, :-1].clone()
-    labels = packed[:, 1:].clone()
-    return enc, dec, labels
-
-
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--steps", type=int, default=2)
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--ncpu", type=int, default=1)
-    p.add_argument("--batch-size", type=int, default=2)
-    p.add_argument("--enc-len", type=int, default=8)
-    p.add_argument("--dec-len", type=int, default=8)
-    p.add_argument("--lr", type=float, default=1e-3)
-    return p.parse_args(argv)
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "t5_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv)
-    torch.manual_seed(args.seed)
-    cfg = tiny_config()
-    enc_cpu, dec_cpu, labels_cpu = make_batch(
-        cfg.vocab_size,
-        batch_size=args.batch_size,
-        enc_len=args.enc_len,
-        dec_len=args.dec_len,
-        seed=args.seed,
-    )
-    model_cpu = T5ForConditionalGeneration(cfg).float().train()
-
-    torch_nntile.init_context(
-        ncpu=args.ncpu, ncuda=0, cpu_fallback=False
-    )
-    try:
-        with torch.no_grad():
-            enc = enc_cpu.to("nntile")
-            dec = dec_cpu.to("nntile")
-            labels = labels_cpu.to("nntile")
-            model = model_cpu.to("nntile")
-        del model_cpu, enc_cpu, dec_cpu, labels_cpu
-        for p in model.parameters():
-            p.requires_grad_(True)
-        opt = AdamW(
-            [p for p in model.parameters() if p.requires_grad],
-            lr=args.lr,
+    def build_batch(cfg, args):
+        enc_len = (
+            args.enc_len if args.enc_len is not None else args.seq_len
         )
-        opt.zero_grad(set_to_none=True)
-        for step in range(args.steps):
-            logits = model(enc, dec)
-            loss = cross_entropy(logits, labels, reduction="mean")
-            loss.backward()
-            opt.step()
-            step_loss = loss.detach()
-            del loss, logits
-            opt.zero_grad(set_to_none=True)
-            torch_nntile.compile_graph()
-            torch_nntile.run()
-            torch_nntile.wait()
-            value = float(step_loss.to("cpu").item())
-            del step_loss
-            print(f"[t5] step {step + 1}/{args.steps}  loss={value:.6f}")
-    finally:
-        torch_nntile.shutdown_context()
-    return 0
+        dec_len = (
+            args.dec_len if args.dec_len is not None else args.seq_len
+        )
+        g = torch.Generator().manual_seed(args.seed)
+        enc = torch.randint(
+            0,
+            cfg.vocab_size,
+            (args.batch_size, enc_len),
+            dtype=torch.long,
+            generator=g,
+        )
+        packed = torch.randint(
+            0,
+            cfg.vocab_size,
+            (args.batch_size, dec_len + 1),
+            dtype=torch.long,
+            generator=g,
+        )
+        return {
+            "input_ids": enc,
+            "decoder_input_ids": packed[:, :-1].clone(),
+            "labels": packed[:, 1:].clone(),
+        }
+
+    def loss_fn(model, batch):
+        logits = model(batch["input_ids"], batch["decoder_input_ids"])
+        return cross_entropy(
+            logits, batch["labels"], reduction="mean"
+        )
+
+    return run_tiny_nntile_main(
+        name="t5",
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=T5Config,
+        model_cls=T5ForConditionalGeneration,
+        build_batch=build_batch,
+        loss_fn=loss_fn,
+        description=__doc__,
+    )
 
 
 if __name__ == "__main__":

--- a/torch_nntile/examples/train_t5_hf.py
+++ b/torch_nntile/examples/train_t5_hf.py
@@ -7,66 +7,37 @@
 
 """Tiny HF T5 encoder-decoder smoke (synthetic tokens).
 
-Example::
+Uses JSON config / checkpoint like ``train_gpt2_hf.py``::
 
-    python torch_nntile/examples/train_t5_hf.py --device nntile --steps 1
+    python torch_nntile/examples/train_t5_hf.py train \\
+        --device nntile --seed 0 --config t5_hf_tiny_config.json \\
+        --output-dir /tmp/t5_hf --steps 1
 """
 
 from __future__ import annotations
 
-import argparse
+from pathlib import Path
 
 from transformers import T5Config, T5ForConditionalGeneration
 
 from hf_tiny_train_common import (
-    add_common_args,
     make_encoder_decoder_batch,
-    run_tiny_hf_train,
+    run_tiny_hf_main,
     t5_ce_loss,
 )
 
 
-def tiny_config() -> T5Config:
-    cfg = T5Config(
-        vocab_size=128,
-        d_model=64,
-        d_kv=16,
-        d_ff=128,
-        num_layers=1,
-        num_decoder_layers=1,
-        num_heads=4,
-        relative_attention_num_buckets=8,
-        relative_attention_max_distance=32,
-        dropout_rate=0.0,
-        layer_norm_epsilon=1e-6,
-        feed_forward_proj="relu",
-        is_encoder_decoder=True,
-        pad_token_id=0,
-        eos_token_id=1,
-        decoder_start_token_id=0,
-    )
-    # T5 has no SDPA path here; eager relative-attention is the supported path.
-    if hasattr(cfg, "_attn_implementation"):
-        cfg._attn_implementation = "eager"
-    cfg.use_cache = False
-    return cfg
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "t5_hf_tiny_config.json"
 
 
 def main(argv: list[str] | None = None) -> int:
-    p = argparse.ArgumentParser(description=__doc__)
-    add_common_args(p)
-    args = p.parse_args(argv)
-    cfg = tiny_config()
-
-    def build_model():
-        return T5ForConditionalGeneration(cfg)
-
-    def build_batch():
+    def build_batch(cfg, args):
         enc, dec, labels = make_encoder_decoder_batch(
             cfg.vocab_size,
             batch_size=args.batch_size,
             seq_len=args.seq_len,
-            seed=args.seed,
+            seed=args.seed if args.seed is not None else 0,
         )
         return {
             "input_ids": enc,
@@ -74,12 +45,17 @@ def main(argv: list[str] | None = None) -> int:
             "labels": labels,
         }
 
-    return run_tiny_hf_train(
+    return run_tiny_hf_main(
         name="t5",
-        args=args,
-        build_model=build_model,
+        argv=argv,
+        default_config=_default_config(),
+        config_cls=T5Config,
+        model_cls=T5ForConditionalGeneration,
         build_batch=build_batch,
         loss_fn=t5_ce_loss,
+        attn_implementation="eager",
+        use_cache=False,
+        description=__doc__,
     )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Align the tiny model training smokes with `train_gpt2_hf.py`: each script now takes a JSON `--config` (or resumes from `--checkpoint`), supports `train` / `compare` subcommands, and can write `checkpoint.pt` under `--output-dir`.

Also adds a **CPU vs nntile showcase** under `docs/dev/hf_tiny_cpu_vs_nntile_showcase.md` with measured loss/wall table (`ncpu=1`) and a reusable bench script.

### HF smokes (`train_*_hf.py`)
- Shared harness in `hf_tiny_train_common.py` (config load, checkpoint save/load/compare)
- Default configs: `*_hf_tiny_config.json` (llama, bert, roberta, t5, gpt-neo, gpt-neox)

### Nntile-native smokes (`train_llama.py`, etc.)
- Shared harness in `nntile_tiny_train_common.py`
- Default configs: `*_tiny_config.json`

### Showcase
- [docs/dev/hf_tiny_cpu_vs_nntile_showcase.md](docs/dev/hf_tiny_cpu_vs_nntile_showcase.md) — how to run, what loss/wall mean, comparison table
- `torch_nntile/examples/bench_hf_tiny_cpu_vs_nntile.py` — reproduce the table

## Measured table (`ncpu=1`, `steps=1`, `seq-len=16`, `seed=0`)

| Model | CPU loss | nntile loss | CPU wall (s) | nntile wall (s) | Δ loss |
|---|---:|---:|---:|---:|---:|
| gpt2 | 5.615653 | 5.615653 | 0.005 | 0.015 | 0 |
| gpt-neo | 4.827158 | 4.827158 | 0.004 | 0.013 | 0 |
| gpt-neox | 4.835960 | 4.835960 | 0.004 | 0.020 | 0 |
| llama | 4.915326 | 4.915326 | 0.004 | 0.024 | 0 |
| bert | 4.833461 | 4.833461 | 0.004 | 0.013 | 0 |
| roberta | 4.735972 | 4.735972 | 0.004 | 0.013 | 0 |
| t5 | 5.692081 | 5.692081 | 0.005 | 0.033 | 0 |

Wall = train loop only (not process import). Losses match exactly on this run.

## Test plan
- [x] HF llama/bert/t5/… train on cpu and nntile (`ncpu=1`)
- [x] Bench script produces the table
- [x] Docs linked from `docs/dev/README.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23ac51d9-f3bf-4ab2-be61-346aa90b858d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23ac51d9-f3bf-4ab2-be61-346aa90b858d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

