### PR TITLE
DiT HF training on device=nntile (exp + AdaLN LayerNorm)

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -19,6 +19,7 @@ Start with the product docs if you are new:
 | [graph_compile_perf_mnist.md](graph_compile_perf_mnist.md) | Compile-perf measurements (MNIST dry-run) |
 | [hf_tiny_cpu_vs_nntile_showcase.md](hf_tiny_cpu_vs_nntile_showcase.md) | Tiny HF smokes: CPU vs nntile loss/wall table |
 | [cnn_tiny_cpu_vs_nntile_showcase.md](cnn_tiny_cpu_vs_nntile_showcase.md) | Tiny CNN smokes (LeNet / ResNet): CPU vs nntile |
+| [dit_tiny_cpu_vs_nntile_showcase.md](dit_tiny_cpu_vs_nntile_showcase.md) | Tiny Diffusers DiT: CPU vs nntile loss/wall |
 | [cuda_wheel_single_nvidia_stack_plan.md](cuda_wheel_single_nvidia_stack_plan.md) | CUDA wheel disk / single NVIDIA stack (infra) |
 
 ## Historical

--- a/docs/dev/cnn_tiny_cpu_vs_nntile_showcase.md
+++ b/docs/dev/cnn_tiny_cpu_vs_nntile_showcase.md
@@ -136,6 +136,8 @@ Measured with `bench_cnn_tiny_cpu_vs_nntile.py` on the Cloud Agent VM
 
 - HF language-model counterpart:
   [hf_tiny_cpu_vs_nntile_showcase.md](hf_tiny_cpu_vs_nntile_showcase.md)
+- DiT counterpart:
+  [dit_tiny_cpu_vs_nntile_showcase.md](dit_tiny_cpu_vs_nntile_showcase.md)
 - [torch_nntile_aten_ops.md](torch_nntile_aten_ops.md) (CNN PrivateUse1 list)
 - [torch_starpu_kernels.md](torch_starpu_kernels.md)
 - Product overview: [../torch_nntile.md](../torch_nntile.md)

--- a/docs/dev/dit_tiny_cpu_vs_nntile_showcase.md
+++ b/docs/dev/dit_tiny_cpu_vs_nntile_showcase.md
@@ -1,0 +1,125 @@
+# Tiny DiT HF train showcase: CPU vs `device=nntile`
+
+Short smoke runs of HuggingFace Diffusers
+[`DiTTransformer2DModel`](https://huggingface.co/docs/diffusers/api/models/dit_transformer2d)
+through `torch_nntile` PrivateUse1 (`device=nntile`) versus plain PyTorch
+CPU. Goal: show **numerical parity** (matching loss) for AdaLN-Zero DiT
+on a tiny CIFAR-10 batch — not a large-scale throughput benchmark.
+
+Scripts live under [`torch_nntile/examples/`](../../torch_nntile/examples/):
+
+| Script | Role |
+|--------|------|
+| [`train_dit_hf.py`](../../torch_nntile/examples/train_dit_hf.py) | Stock Diffusers DiT, JSON config, `train` / `compare` |
+| [`dit_hf_tiny_config.json`](../../torch_nntile/examples/dit_hf_tiny_config.json) | Tiny DiT (16×16, 2 layers, 2 heads) |
+| [`dit_hf_tiny_train_common.py`](../../torch_nntile/examples/dit_hf_tiny_train_common.py) | CIFAR-10 (`datasets`) batch + MSE noise loss |
+| [`bench_dit_hf_tiny_cpu_vs_nntile.py`](../../torch_nntile/examples/bench_dit_hf_tiny_cpu_vs_nntile.py) | CPU vs nntile table helper |
+
+Ops exercised beyond the LM/CNN smokes: StarPU `aten::exp` (sinusoidal
+timestep frequencies), contiguous densify for AdaLN `LayerNorm`
+(`elementwise_affine=False`), plus existing Conv2d patch embed, SiLU,
+GELU-tanh MLP, SDPA, Linear, and host `mean` for MSE.
+
+## How to run
+
+Environment (CPU StarPU build; no CUDA in this Cloud Agent image)::
+
+```bash
+export PKG_CONFIG_PATH=/opt/starpu/lib/pkgconfig
+export LD_LIBRARY_PATH=$PWD/build/nntile:$PWD/build/torch_nntile:/opt/starpu/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export NNTILE_BUILD_DIR=$PWD/build TORCH_NNTILE_BUILD_DIR=$PWD/build
+export NNTILE_SOURCE_DIR=$PWD
+export PYTHONPATH=$PWD/torch_nntile${PYTHONPATH:+:$PYTHONPATH}
+export STARPU_SILENT=1 STARPU_FXT_TRACE=0 STARPU_WORKERS_NOBIND=1
+```
+
+Requires `diffusers` and `datasets` (CIFAR-10)::
+
+```bash
+pip install 'diffusers==0.32.2'  # or newer; API matches DiTTransformer2DModel
+```
+
+Single run::
+
+```bash
+# CPU reference
+python torch_nntile/examples/train_dit_hf.py train \
+  --device cpu --seed 0 --steps 1 --batch-size 2 \
+  --output-dir /tmp/dit_cpu
+
+# nntile (one StarPU CPU worker)
+python torch_nntile/examples/train_dit_hf.py train \
+  --device nntile --seed 0 --steps 1 --batch-size 2 \
+  --ncpu 1 --output-dir /tmp/dit_nntile
+
+# Optional weight compare
+python torch_nntile/examples/train_dit_hf.py compare \
+  --checkpoint-a /tmp/dit_cpu/checkpoint.pt \
+  --checkpoint-b /tmp/dit_nntile/checkpoint.pt
+```
+
+Batch CPU vs nntile and print a markdown table::
+
+```bash
+python torch_nntile/examples/bench_dit_hf_tiny_cpu_vs_nntile.py \
+  --ncpu 1 --steps 1 --batch-size 2 --seed 0 \
+  --markdown-out /tmp/dit_hf_tiny_cpu_vs_nntile/table.md
+```
+
+## What the outputs mean
+
+### Loss
+
+```text
+[dit] step 1/1  loss=1.603470
+```
+
+- **Loss** is MSE between predicted noise and the synthetic noise target
+  on a **CIFAR-10** mini-batch (first `batch_size` images from
+  `train[:64]`, resized to `sample_size`, mapped to `[-1, 1]`).
+- Timesteps / noise are drawn from `--seed` (deterministic).
+- CFG label dropout is disabled for parity (`dropout_prob=0`).
+- Same seed + same JSON config ⇒ CPU and nntile match to printing
+  precision. In the table below, **Δ loss is exactly 0**.
+
+### Wall time (train loop)
+
+```text
+[dit] wall=0.042s  OK
+```
+
+That is **only the train loop** (forward → backward → optimizer step →
+host loss readout), after the model and batch are already on device.
+It does **not** include Python import, Diffusers / datasets download, or
+StarPU `init_context` / shutdown.
+
+## Results (CPU vs nntile, `ncpu=1`)
+
+Measured with `bench_dit_hf_tiny_cpu_vs_nntile.py` on the Cloud Agent VM
+(CPU-only StarPU / `USE_CUDA=OFF`, `ncpu=1`, `steps=1`, `batch-size=2`,
+`seed=0`, date 2026-07-18). Tiny config: 16×16, 2 layers, hidden 16 —
+**overhead-dominated**, not a speed contest.
+
+| Model | CPU loss | nntile loss | CPU wall (s) | nntile wall (s) | Δ loss | Status |
+|---|---:|---:|---:|---:|---:|---|
+| dit | 1.603470 | 1.603470 | 0.007 | 0.042 | 0.000e+00 | OK |
+
+**Takeaways for demos**
+
+1. **Correctness:** noise-prediction MSE matches on CPU and nntile.
+2. **Timing at this scale:** nntile wall is higher (StarPU submit +
+   compile/run + host sync) while the math is tiny; expect the gap to
+   shrink on larger resolution / depth or with CUDA workers.
+3. **Checkpoints:** each successful `--output-dir` run writes
+   `checkpoint.pt` (`model_state_dict` + Diffusers config dict + seed /
+   step). Relative Frobenius after one step stays ~1e-9.
+
+## Related
+
+- HF language-model counterpart:
+  [hf_tiny_cpu_vs_nntile_showcase.md](hf_tiny_cpu_vs_nntile_showcase.md)
+- CNN counterpart:
+  [cnn_tiny_cpu_vs_nntile_showcase.md](cnn_tiny_cpu_vs_nntile_showcase.md)
+- [torch_nntile_aten_ops.md](torch_nntile_aten_ops.md) (`exp`, LayerNorm)
+- [torch_starpu_kernels.md](torch_starpu_kernels.md)
+- Product overview: [../torch_nntile.md](../torch_nntile.md)

--- a/docs/dev/hf_tiny_cpu_vs_nntile_showcase.md
+++ b/docs/dev/hf_tiny_cpu_vs_nntile_showcase.md
@@ -148,6 +148,7 @@ symbols; use a full torch_nntile extension build (CI wheel or local
 ## Related
 
 - CNN counterpart: [cnn_tiny_cpu_vs_nntile_showcase.md](cnn_tiny_cpu_vs_nntile_showcase.md)
+- DiT counterpart: [dit_tiny_cpu_vs_nntile_showcase.md](dit_tiny_cpu_vs_nntile_showcase.md)
 - [torch_nntile_tensor_architecture.md](torch_nntile_tensor_architecture.md)
 - [torch_nntile_aten_ops.md](torch_nntile_aten_ops.md)
 - [torch_starpu_kernels.md](torch_starpu_kernels.md)

--- a/docs/dev/torch_nntile_aten_ops.md
+++ b/docs/dev/torch_nntile_aten_ops.md
@@ -162,7 +162,7 @@ register `linear` / `matmul` (CUDA CompositeImplicit → `addmm` / `mm`).
 | `nntile_batch_norm.cpp` | `native_batch_norm`, `native_batch_norm_backward` |
 | `nntile_embedding.cpp` | `embedding`, `embedding_dense_backward` |
 | `nntile_cat.cpp` | `cat`, `cat.out` |
-| `nntile_trig.cpp` | `cos`, `sin`, `neg`, `rsqrt` (+ `.out`) |
+| `nntile_trig.cpp` | `cos`, `sin`, `neg`, `rsqrt`, `exp` (+ `.out`) |
 | `nntile_repeat.cpp` | `repeat` |
 | `nntile_max_pool2d.cpp` | `max_pool2d_with_indices`, `max_pool2d_with_indices.out`, `max_pool2d_with_indices_backward`, `max_pool2d_with_indices_backward.grad_input` |
 | `nntile_upsample2d.cpp` | `upsample_nearest2d`, `upsample_nearest2d.out`, `upsample_nearest2d_backward`, `upsample_nearest2d_backward.grad_input`, `upsample_bilinear2d` (+ `.out` / `_backward` / `.grad_input`) |

--- a/docs/dev/torch_starpu_kernels.md
+++ b/docs/dev/torch_starpu_kernels.md
@@ -299,6 +299,11 @@ Family codelet `torch_unary` (one `R` input, one `W` output):
 | `Relu` | `relu.out` | in `R`, out `W` |
 | `Silu` | `silu.out` | in `R`, out `W` |
 | `Gelu` | `gelu.out` | in `R`, out `W` |
+| `Cos` | `cos.out` | in `R`, out `W` |
+| `Sin` | `sin.out` | in `R`, out `W` |
+| `Neg` | `neg.out` | in `R`, out `W` |
+| `Rsqrt` | `rsqrt.out` | in `R`, out `W` |
+| `Exp` | `exp.out` | in `R`, out `W` |
 | `Softmax` | `_softmax.out` | in `R`, out `W` |
 | `LogSoftmax` | `_log_softmax.out` | in `R`, out `W` |
 | `Sum` | `sum.IntList_out` | in `R`, out `W` |

--- a/nntile/include/nntile/starpu/torch_dispatch.hh
+++ b/nntile/include/nntile/starpu/torch_dispatch.hh
@@ -54,6 +54,7 @@ enum class TorchKind : std::int32_t
     Sin = 14,                // R → W    aten::sin.out
     Neg = 15,                // R → W    aten::neg.out
     Rsqrt = 16,              // R → W    aten::rsqrt.out
+    Exp = 17,                // R → W    aten::exp.out
     ThresholdBackward = 20,  // R,R → W  aten::threshold_backward
     SiluBackward = 21,       // R,R → W  aten::silu_backward
     GeluBackward = 22,       // R,R → W  aten::gelu_backward

--- a/nntile/src/starpu/torch_dispatch.cc
+++ b/nntile/src/starpu/torch_dispatch.cc
@@ -44,6 +44,7 @@
 #endif
 #include <ATen/ops/embedding.h>
 #include <ATen/ops/embedding_dense_backward.h>
+#include <ATen/ops/exp.h>
 #include <ATen/ops/gelu.h>
 #include <ATen/ops/gelu_backward.h>
 #include <ATen/ops/hypot.h>
@@ -245,6 +246,9 @@ void run_unary(
         break;
     case TorchKind::Rsqrt:
         at::rsqrt_out(result, self);
+        break;
+    case TorchKind::Exp:
+        at::exp_out(result, self);
         break;
     case TorchKind::AvgPool2d:
         at::avg_pool2d_out(

--- a/torch_nntile/csrc/nntile_executor.h
+++ b/torch_nntile/csrc/nntile_executor.h
@@ -92,6 +92,7 @@ void tensor_cos_fp32(const at::Tensor &input, at::Tensor &out);
 void tensor_sin_fp32(const at::Tensor &input, at::Tensor &out);
 void tensor_neg_fp32(const at::Tensor &input, at::Tensor &out);
 void tensor_rsqrt_fp32(const at::Tensor &input, at::Tensor &out);
+void tensor_exp_fp32(const at::Tensor &input, at::Tensor &out);
 
 void tensor_relu_backward_fp32(
     const at::Tensor &x,

--- a/torch_nntile/csrc/nntile_executor_torch_native.cpp
+++ b/torch_nntile/csrc/nntile_executor_torch_native.cpp
@@ -540,6 +540,11 @@ void tensor_rsqrt_fp32(const at::Tensor &input, at::Tensor &out)
     tensor_unary_fp32(nntile::starpu::TorchKind::Rsqrt, input, out);
 }
 
+void tensor_exp_fp32(const at::Tensor &input, at::Tensor &out)
+{
+    tensor_unary_fp32(nntile::starpu::TorchKind::Exp, input, out);
+}
+
 void tensor_relu_backward_fp32(
     const at::Tensor &x,
     const at::Tensor &dy,

--- a/torch_nntile/csrc/nntile_layer_norm.cpp
+++ b/torch_nntile/csrc/nntile_layer_norm.cpp
@@ -25,6 +25,32 @@ bool is_nntile_device(c10::Device device)
     return device.type() == c10::DeviceType::PrivateUse1;
 }
 
+at::Tensor as_contiguous_fp32(
+    const at::Tensor &tensor,
+    const char *name)
+{
+    TORCH_CHECK(
+        is_nntile_device(tensor.device()),
+        "nntile layer_norm: expected nntile ",
+        name);
+    TORCH_CHECK(
+        tensor.scalar_type() == at::ScalarType::Float,
+        "nntile layer_norm supports float32 only");
+    return tensor.is_contiguous() ? tensor : tensor.contiguous();
+}
+
+//! Autograd may pass an undefined Tensor inside optional instead of nullopt.
+std::optional<at::Tensor> optional_defined_contiguous(
+    const std::optional<at::Tensor> &tensor,
+    const char *name)
+{
+    if (!tensor.has_value() || !tensor->defined())
+    {
+        return std::nullopt;
+    }
+    return as_contiguous_fp32(*tensor, name);
+}
+
 void check_norm_tensor(
     const at::Tensor &tensor,
     const char *name)
@@ -36,7 +62,6 @@ void check_norm_tensor(
     TORCH_CHECK(
         tensor.scalar_type() == at::ScalarType::Float,
         "nntile layer_norm supports float32 only");
-    TORCH_CHECK(tensor.is_contiguous(), "nntile layer_norm requires contiguous");
 }
 
 int64_t resolve_norm_axis(
@@ -141,22 +166,28 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> native_layer_norm(
     const std::optional<at::Tensor> &bias,
     double eps)
 {
-    check_norm_tensor(input, "input");
-    const int64_t norm_axis = resolve_norm_axis(input.sizes(), normalized_shape);
-    check_optional_affine(input, weight, bias, norm_axis);
+    at::Tensor input_c = as_contiguous_fp32(input, "input");
+    const int64_t norm_axis = resolve_norm_axis(
+        input_c.sizes(),
+        normalized_shape);
+    std::optional<at::Tensor> weight_c =
+        optional_defined_contiguous(weight, "weight");
+    std::optional<at::Tensor> bias_c =
+        optional_defined_contiguous(bias, "bias");
+    check_optional_affine(input_c, weight_c, bias_c, norm_axis);
 
-    at::Tensor output = at::empty_like(input);
+    at::Tensor output = at::empty_like(input_c);
     // Reduced (non-keepdim) stats - matches C++ ``NNLayerNormOp`` buffers and
     // avoids ``scale_slice`` broadcast of mean/rstd.
-    const auto stats_sizes = reduced_sizes(input.sizes(), norm_axis);
+    const auto stats_sizes = reduced_sizes(input_c.sizes(), norm_axis);
     at::Tensor mean = at::empty(
         stats_sizes,
-        input.options().memory_format(at::MemoryFormat::Contiguous));
+        input_c.options().memory_format(at::MemoryFormat::Contiguous));
     at::Tensor rstd = at::empty(
         stats_sizes,
-        input.options().memory_format(at::MemoryFormat::Contiguous));
+        input_c.options().memory_format(at::MemoryFormat::Contiguous));
     run_layer_norm_forward(
-        input, weight, bias, norm_axis, eps, output, mean, rstd);
+        input_c, weight_c, bias_c, norm_axis, eps, output, mean, rstd);
     return {output, mean, rstd};
 }
 
@@ -170,62 +201,65 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> native_layer_norm_backward(
     const std::optional<at::Tensor> &bias,
     std::array<bool, 3> output_mask)
 {
-    check_norm_tensor(grad_out, "grad_out");
-    check_norm_tensor(input, "input");
-    check_norm_tensor(mean, "mean");
-    check_norm_tensor(rstd, "rstd");
-    const int64_t norm_axis = resolve_norm_axis(input.sizes(), normalized_shape);
-    check_optional_affine(input, weight, bias, norm_axis);
+    // Sum/Mean backward often expands a non-contiguous ones view into
+    // ``grad_out``; densify before the StarPU codelet.
+    at::Tensor grad_out_c = as_contiguous_fp32(grad_out, "grad_out");
+    at::Tensor input_c = as_contiguous_fp32(input, "input");
+    at::Tensor mean_c = as_contiguous_fp32(mean, "mean");
+    at::Tensor rstd_c = as_contiguous_fp32(rstd, "rstd");
+    const int64_t norm_axis = resolve_norm_axis(
+        input_c.sizes(),
+        normalized_shape);
+    std::optional<at::Tensor> weight_c =
+        optional_defined_contiguous(weight, "weight");
+    std::optional<at::Tensor> bias_c =
+        optional_defined_contiguous(bias, "bias");
+    check_optional_affine(input_c, weight_c, bias_c, norm_axis);
 
     // Forward now saves reduced stats; accept legacy keepdim tensors too.
-    at::Tensor mean_reduced = mean;
-    at::Tensor rstd_reduced = rstd;
-    if (mean.dim() == input.dim() && mean.size(norm_axis) == 1)
+    at::Tensor mean_reduced = mean_c;
+    at::Tensor rstd_reduced = rstd_c;
+    if (mean_c.dim() == input_c.dim() && mean_c.size(norm_axis) == 1)
     {
-        mean_reduced = mean.squeeze(norm_axis);
+        mean_reduced = mean_c.squeeze(norm_axis).contiguous();
     }
-    if (rstd.dim() == input.dim() && rstd.size(norm_axis) == 1)
+    if (rstd_c.dim() == input_c.dim() && rstd_c.size(norm_axis) == 1)
     {
-        rstd_reduced = rstd.squeeze(norm_axis);
+        rstd_reduced = rstd_c.squeeze(norm_axis).contiguous();
     }
 
     at::Tensor grad_input;
     at::Tensor grad_weight;
     at::Tensor grad_bias;
-    std::vector<at::Tensor> inputs = {grad_out, input, mean_reduced, rstd_reduced};
-    if (weight.has_value())
-    {
-        inputs.push_back(*weight);
-    }
 
     if (output_mask[0])
     {
-        grad_input = at::empty_like(input);
+        grad_input = at::empty_like(input_c);
     }
-    if (output_mask[1] && weight.has_value())
+    if (output_mask[1] && weight_c.has_value())
     {
-        grad_weight = at::empty_like(*weight);
+        grad_weight = at::empty_like(*weight_c);
     }
-    if (output_mask[2] && bias.has_value())
+    if (output_mask[2] && bias_c.has_value())
     {
-        grad_bias = at::empty_like(*bias);
+        grad_bias = at::empty_like(*bias_c);
     }
 
     tensor_layer_norm_backward_fp32(
-        grad_out,
-        input,
+        grad_out_c,
+        input_c,
         mean_reduced,
         rstd_reduced,
-        weight.has_value() ? &*weight : nullptr,
-        bias.has_value() ? &*bias : nullptr,
-        weight.has_value(),
-        bias.has_value(),
+        weight_c.has_value() ? &*weight_c : nullptr,
+        bias_c.has_value() ? &*bias_c : nullptr,
+        weight_c.has_value(),
+        bias_c.has_value(),
         output_mask[0] ? &grad_input : nullptr,
-        output_mask[1] && weight.has_value() ? &grad_weight : nullptr,
-        output_mask[2] && bias.has_value() ? &grad_bias : nullptr,
+        output_mask[1] && weight_c.has_value() ? &grad_weight : nullptr,
+        output_mask[2] && bias_c.has_value() ? &grad_bias : nullptr,
         output_mask[0],
-        output_mask[1] && weight.has_value(),
-        output_mask[2] && bias.has_value(),
+        output_mask[1] && weight_c.has_value(),
+        output_mask[2] && bias_c.has_value(),
         norm_axis);
 
     return {grad_input, grad_weight, grad_bias};

--- a/torch_nntile/csrc/nntile_trig.cpp
+++ b/torch_nntile/csrc/nntile_trig.cpp
@@ -2,7 +2,7 @@
  *                              (Skoltech), Russia. All rights reserved.
  *
  * @file torch_nntile/csrc/nntile_trig.cpp
- * Torch-native cos / sin / neg / rsqrt (StarPU unary family).
+ * Torch-native cos / sin / neg / rsqrt / exp (StarPU unary family).
  */
 
 #include "nntile_executor.h"
@@ -150,11 +150,29 @@ at::Tensor &rsqrt_out(const at::Tensor &self, at::Tensor &out)
     return out;
 }
 
+at::Tensor exp_tensor(const at::Tensor &self)
+{
+    at::Tensor inp = self.is_contiguous() ? self : self.contiguous();
+    check_unary_fp32(inp, "exp");
+    at::Tensor out = at::empty_like(inp);
+    tensor_exp_fp32(inp, out);
+    return out;
+}
+
+at::Tensor &exp_out(const at::Tensor &self, at::Tensor &out)
+{
+    at::Tensor inp = self.is_contiguous() ? self : self.contiguous();
+    check_unary_fp32(inp, "exp", out);
+    tensor_exp_fp32(inp, out);
+    return out;
+}
+
 } // namespace torch_nntile
 
 // Match device=cuda: PrivateUse1 (device) forward only. Autograd uses the
 // generic VariableType formula ``-0.5 * grad * result.pow(3)`` (see
 // derivatives.yaml); keep ``pow.Tensor_Scalar`` on StarPU for exp 2/3.
+// ``exp`` likewise: VariableType ``grad * result`` (no AutogradPrivateUse1).
 TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
 {
     m.impl("cos", TORCH_FN(torch_nntile::cos_tensor));
@@ -165,4 +183,6 @@ TORCH_LIBRARY_IMPL(aten, PrivateUse1, m)
     m.impl("neg.out", TORCH_FN(torch_nntile::neg_out));
     m.impl("rsqrt", TORCH_FN(torch_nntile::rsqrt_tensor));
     m.impl("rsqrt.out", TORCH_FN(torch_nntile::rsqrt_out));
+    m.impl("exp", TORCH_FN(torch_nntile::exp_tensor));
+    m.impl("exp.out", TORCH_FN(torch_nntile::exp_out));
 }

--- a/torch_nntile/examples/bench_dit_hf_tiny_cpu_vs_nntile.py
+++ b/torch_nntile/examples/bench_dit_hf_tiny_cpu_vs_nntile.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# Collect cpu vs nntile timings for tiny DiT HF train smokes (showcase).
+
+"""Run tiny DiT HF train on cpu and nntile; print a markdown table.
+
+Example::
+
+    python torch_nntile/examples/bench_dit_hf_tiny_cpu_vs_nntile.py \\
+        --ncpu 1 --steps 1 --batch-size 2 --seed 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+LOSS_RE = re.compile(r"loss=([0-9.]+)")
+WALL_RE = re.compile(r"wall=([0-9.]+)s")
+
+
+@dataclass
+class RunResult:
+    name: str
+    device: str
+    ok: bool
+    loss: float | None
+    wall_s: float | None
+    elapsed_s: float
+    stderr_tail: str
+
+
+def run_one(
+    *,
+    here: Path,
+    device: str,
+    ncpu: int,
+    steps: int,
+    batch_size: int,
+    seed: int,
+    output_root: Path,
+) -> RunResult:
+    out_dir = output_root / f"dit_{device}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        str(here / "train_dit_hf.py"),
+        "train",
+        "--device",
+        device,
+        "--seed",
+        str(seed),
+        "--steps",
+        str(steps),
+        "--batch-size",
+        str(batch_size),
+        "--ncpu",
+        str(ncpu),
+        "--output-dir",
+        str(out_dir),
+    ]
+    t0 = time.perf_counter()
+    proc = subprocess.run(
+        cmd,
+        cwd=str(here),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    elapsed = time.perf_counter() - t0
+    text = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    loss_m = LOSS_RE.findall(text)
+    wall_m = WALL_RE.findall(text)
+    ok = proc.returncode == 0 and bool(loss_m) and "OK" in text
+    return RunResult(
+        name="dit",
+        device=device,
+        ok=ok,
+        loss=float(loss_m[-1]) if loss_m else None,
+        wall_s=float(wall_m[-1]) if wall_m else None,
+        elapsed_s=elapsed,
+        stderr_tail=(proc.stderr or "")[-800:],
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ncpu", type=int, default=1)
+    parser.add_argument("--steps", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--output-root",
+        default="/tmp/dit_hf_tiny_cpu_vs_nntile",
+    )
+    parser.add_argument(
+        "--markdown-out",
+        default="",
+        help="Optional path to write the markdown table",
+    )
+    args = parser.parse_args(argv)
+
+    here = Path(__file__).resolve().parent
+    output_root = Path(args.output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    results: list[RunResult] = []
+    for device in ("cpu", "nntile"):
+        print(f"==> dit {device}")
+        r = run_one(
+            here=here,
+            device=device,
+            ncpu=args.ncpu,
+            steps=args.steps,
+            batch_size=args.batch_size,
+            seed=args.seed,
+            output_root=output_root,
+        )
+        results.append(r)
+        status = "OK" if r.ok else "FAIL"
+        print(
+            f"  {status} loss={r.loss} wall={r.wall_s} "
+            f"elapsed={r.elapsed_s:.2f}s"
+        )
+        if not r.ok:
+            print(r.stderr_tail)
+
+    by_dev = {r.device: r for r in results}
+    cpu = by_dev.get("cpu")
+    nnt = by_dev.get("nntile")
+    lines = [
+        "| Model | CPU loss | nntile loss | CPU wall (s) | "
+        "nntile wall (s) | Δ loss | Status |",
+        "|---|---:|---:|---:|---:|---:|---|",
+    ]
+    if cpu and nnt and cpu.loss is not None and nnt.loss is not None:
+        delta = abs(cpu.loss - nnt.loss)
+        status = (
+            "OK"
+            if cpu.ok and nnt.ok and delta < 1e-5
+            else "FAIL"
+        )
+        lines.append(
+            f"| dit | {cpu.loss:.6f} | {nnt.loss:.6f} | "
+            f"{cpu.wall_s if cpu.wall_s is not None else float('nan'):.3f} | "
+            f"{nnt.wall_s if nnt.wall_s is not None else float('nan'):.3f} | "
+            f"{delta:.3e} | {status} |"
+        )
+    else:
+        lines.append("| dit | — | — | — | — | — | FAIL |")
+
+    table = "\n".join(lines) + "\n"
+    print(table)
+    if args.markdown_out:
+        Path(args.markdown_out).write_text(table, encoding="utf-8")
+        print(f"Wrote {args.markdown_out}")
+
+    return 0 if all(r.ok for r in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/torch_nntile/examples/dit_hf_tiny_config.json
+++ b/torch_nntile/examples/dit_hf_tiny_config.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Tiny Diffusers DiTTransformer2DModel for cpu/nntile smoke",
+  "sample_size": 16,
+  "patch_size": 2,
+  "in_channels": 3,
+  "out_channels": 3,
+  "num_layers": 2,
+  "attention_head_dim": 8,
+  "num_attention_heads": 2,
+  "dropout": 0.0,
+  "attention_bias": true,
+  "activation_fn": "gelu-approximate",
+  "num_embeds_ada_norm": 1000,
+  "norm_type": "ada_norm_zero",
+  "norm_elementwise_affine": false,
+  "norm_eps": 1e-5,
+  "upcast_attention": false
+}

--- a/torch_nntile/examples/dit_hf_tiny_train_common.py
+++ b/torch_nntile/examples/dit_hf_tiny_train_common.py
@@ -1,0 +1,438 @@
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/examples/dit_hf_tiny_train_common.py
+# Shared helpers for tiny Diffusers DiT smokes on cpu / nntile.
+
+"""Tiny HuggingFace Diffusers DiT train loop (JSON config / checkpoint).
+
+Mirrors :mod:`hf_tiny_train_common` for
+``diffusers.DiTTransformer2DModel`` noise-prediction training on a small
+``datasets`` image split (default: CIFAR-10).
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+import traceback
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn as nn
+import torchvision.transforms.functional as TF
+from hf_tiny_train_common import (
+    compare_checkpoints, load_json_object, save_checkpoint)
+
+LossFn = Callable[[nn.Module, dict[str, torch.Tensor]], torch.Tensor]
+BatchBuilder = Callable[
+    [Any, argparse.Namespace],
+    dict[str, torch.Tensor],
+]
+ConfigFactory = Callable[..., Any]
+
+
+def disable_dit_label_dropout(model: nn.Module) -> None:
+    """Deterministic smokes: turn off CFG label dropout (``torch.rand``)."""
+    for module in model.modules():
+        if hasattr(module, "dropout_prob"):
+            module.dropout_prob = 0.0
+
+
+def load_dit_config_from_json(path: Path, config_cls: ConfigFactory) -> Any:
+    fields = load_json_object(path)
+    # Diffusers ConfigMixin: construct via model config class / kwargs.
+    if hasattr(config_cls, "from_dict"):
+        return config_cls.from_dict(fields)
+    return config_cls(**fields)
+
+
+def config_to_dict(config: Any) -> dict[str, Any]:
+    if hasattr(config, "to_dict"):
+        return dict(config.to_dict())
+    if isinstance(config, dict):
+        return {k: v for k, v in config.items() if not str(k).startswith("_")}
+    raise TypeError(f"config has no to_dict(): {type(config)!r}")
+
+
+def make_cifar_diffusion_batch(
+    *,
+    batch_size: int,
+    sample_size: int,
+    in_channels: int,
+    num_timesteps: int,
+    num_classes: int,
+    seed: int,
+    dataset_name: str = "cifar10",
+    dataset_split: str = "train[:64]",
+) -> dict[str, torch.Tensor]:
+    """Load a tiny ``datasets`` image split and build a noise-prediction batch.
+
+    Images are resized to ``sample_size``, mapped to ``[-1, 1]``, and
+    optionally expanded/truncated to ``in_channels``. Timesteps and class
+    labels are drawn deterministically from ``seed``.
+    """
+    try:
+        from datasets import load_dataset
+    except ImportError as exc:  # pragma: no cover - env guard
+        raise SystemExit(
+            "dit HF smoke requires the HuggingFace datasets package"
+        ) from exc
+
+    g = torch.Generator().manual_seed(seed)
+    ds = load_dataset(dataset_name, split=dataset_split)
+    if len(ds) < batch_size:
+        raise ValueError(
+            f"dataset split too small: need {batch_size}, got {len(ds)}"
+        )
+
+    images: list[torch.Tensor] = []
+    labels: list[int] = []
+    for i in range(batch_size):
+        row = ds[i]
+        img = row["img"] if "img" in row else row["image"]
+        label = int(row["label"])
+        t = TF.to_tensor(img)  # CHW in [0, 1]
+        t = TF.resize(
+            t,
+            [sample_size, sample_size],
+            antialias=True,
+        )
+        if t.shape[0] == 1 and in_channels == 3:
+            t = t.repeat(3, 1, 1)
+        elif t.shape[0] >= in_channels:
+            t = t[:in_channels]
+        elif t.shape[0] < in_channels:
+            pad = t.new_zeros(in_channels - t.shape[0], *t.shape[1:])
+            t = torch.cat([t, pad], dim=0)
+        t = t * 2.0 - 1.0
+        images.append(t)
+        labels.append(label % max(num_classes, 1))
+
+    clean = torch.stack(images, dim=0).to(dtype=torch.float32)
+    noise = torch.randn(
+        clean.shape,
+        dtype=torch.float32,
+        generator=g,
+    )
+    # Linear alpha schedule (tiny smoke; not a full DDPM trainer).
+    timesteps = torch.randint(
+        0,
+        num_timesteps,
+        (batch_size,),
+        dtype=torch.long,
+        generator=g,
+    )
+    t_norm = timesteps.float() / float(max(num_timesteps - 1, 1))
+    t_norm = t_norm.view(batch_size, 1, 1, 1)
+    noisy = (1.0 - t_norm) * clean + t_norm * noise
+    class_labels = torch.tensor(labels, dtype=torch.long)
+    return {
+        "noisy": noisy,
+        "noise": noise,
+        "timesteps": timesteps,
+        "class_labels": class_labels,
+    }
+
+
+def diffusion_mse_loss(
+    model: nn.Module,
+    batch: dict[str, torch.Tensor],
+) -> torch.Tensor:
+    """Predict noise; MSE vs ground-truth noise."""
+    out = model(
+        batch["noisy"],
+        timestep=batch["timesteps"],
+        class_labels=batch["class_labels"],
+        return_dict=True,
+    )
+    pred = out.sample if hasattr(out, "sample") else out[0]
+    diff = pred - batch["noise"]
+    return (diff * diff).mean()
+
+
+def add_dit_train_compare_subparsers(
+    parser: argparse.ArgumentParser,
+    *,
+    default_config: Path,
+    devices: tuple[str, ...] = ("cpu", "nntile"),
+) -> None:
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    train = sub.add_parser(
+        "train",
+        help="Train from JSON config or resume a checkpoint",
+    )
+    train.add_argument(
+        "--device",
+        choices=devices,
+        default="nntile",
+        help="Training device",
+    )
+    train.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="RNG seed (required when training from scratch)",
+    )
+    train.add_argument(
+        "--checkpoint",
+        default="",
+        help="Resume weights from this checkpoint",
+    )
+    train.add_argument(
+        "--config",
+        default=str(default_config),
+        help="Diffusers DiT JSON config path",
+    )
+    train.add_argument(
+        "--output-dir",
+        default="",
+        help="Directory for checkpoint.pt (optional)",
+    )
+    train.add_argument("--steps", type=int, default=1)
+    train.add_argument("--batch-size", type=int, default=2)
+    train.add_argument("--lr", type=float, default=1e-3)
+    train.add_argument("--ncpu", type=int, default=2)
+    train.add_argument(
+        "--dataset",
+        default="cifar10",
+        help="HuggingFace datasets name (default: cifar10)",
+    )
+    train.add_argument(
+        "--dataset-split",
+        default="train[:64]",
+        help="datasets split slice (default: train[:64])",
+    )
+    train.add_argument(
+        "--cpu-fallback",
+        action="store_true",
+        help="Allow unregistered aten ops to fall back to CPU",
+    )
+
+    compare = sub.add_parser(
+        "compare",
+        help="Print relative Frobenius norms between two checkpoints",
+    )
+    compare.add_argument("--checkpoint-a", required=True)
+    compare.add_argument("--checkpoint-b", required=True)
+
+
+def _load_train_state(
+    args: argparse.Namespace,
+    *,
+    model_cls: type,
+) -> tuple[Any, nn.Module, int, int]:
+    global_step = 0
+    if args.checkpoint:
+        ckpt = torch.load(
+            Path(args.checkpoint),
+            map_location="cpu",
+            weights_only=False,
+        )
+        if not isinstance(ckpt, dict) or "model_state_dict" not in ckpt:
+            raise ValueError(f"invalid checkpoint: {args.checkpoint}")
+        config_dict = dict(ckpt["config"])
+        model = model_cls.from_config(config_dict).float().train()
+        model.load_state_dict(ckpt["model_state_dict"])
+        disable_dit_label_dropout(model)
+        global_step = int(ckpt.get("global_step", 0))
+        seed = int(
+            args.seed if args.seed is not None else ckpt.get("seed", 0)
+        )
+        print(
+            f"Resumed from {args.checkpoint} "
+            f"(step={global_step}, seed={seed})"
+        )
+        return model.config, model, seed, global_step
+
+    if args.seed is None:
+        raise SystemExit("--seed is required when training from scratch")
+    fields = load_json_object(Path(args.config))
+    torch.manual_seed(args.seed)
+    model = model_cls(**fields).float().train()
+    disable_dit_label_dropout(model)
+    return model.config, model, int(args.seed), global_step
+
+
+def _train_loop(
+    *,
+    name: str,
+    model: nn.Module,
+    batch: dict[str, torch.Tensor],
+    loss_fn: LossFn,
+    steps: int,
+    lr: float,
+    nntile: bool = False,
+) -> int:
+    torch_nntile = None
+    if nntile:
+        import torch_nntile as _tn
+
+        torch_nntile = _tn
+
+    opt = torch.optim.SGD(
+        [p for p in model.parameters() if p.requires_grad],
+        lr=lr,
+    )
+    t0 = time.perf_counter()
+    for step in range(steps):
+        opt.zero_grad(set_to_none=True)
+        if torch_nntile is not None:
+            torch_nntile.compile_graph()
+            torch_nntile.run()
+        loss = loss_fn(model, batch)
+        loss.backward()
+        opt.step()
+        if torch_nntile is not None:
+            loss_val = float(loss.detach().cpu())
+        else:
+            loss_val = float(loss.detach())
+        print(f"[{name}] step {step + 1}/{steps}  loss={loss_val:.6f}")
+        # Reclaim StarPU temps: drop the step loss before next compile.
+        del loss
+    print(f"[{name}] wall={time.perf_counter() - t0:.3f}s  OK")
+    return 0
+
+
+class _ConfigAdapter:
+    """Wrap Diffusers config so ``save_checkpoint`` can call ``to_dict``."""
+
+    def __init__(self, config: Any) -> None:
+        self._config = config
+
+    def to_dict(self) -> dict[str, Any]:
+        return config_to_dict(self._config)
+
+
+def run_tiny_dit_train(
+    *,
+    name: str,
+    args: argparse.Namespace,
+    config: Any,
+    model: nn.Module,
+    seed: int,
+    global_step: int,
+    build_batch: BatchBuilder,
+    loss_fn: LossFn,
+) -> int:
+    print(
+        f"=== {name} tiny DiT HF smoke  device={args.device}  "
+        f"config_seed={seed} ==="
+    )
+    batch_cpu = build_batch(config, args)
+
+    if args.device == "cpu":
+        code = _train_loop(
+            name=name,
+            model=model,
+            batch={k: v.clone() for k, v in batch_cpu.items()},
+            loss_fn=loss_fn,
+            steps=args.steps,
+            lr=args.lr,
+            nntile=False,
+        )
+        if code == 0 and args.output_dir:
+            save_checkpoint(
+                Path(args.output_dir) / "checkpoint.pt",
+                model=model,
+                config=_ConfigAdapter(config),
+                seed=seed,
+                epoch=0,
+                global_step=global_step + args.steps,
+                device_name="cpu",
+            )
+        return code
+
+    import torch_nntile
+
+    torch_nntile.init_context(
+        ncpu=args.ncpu,
+        ncuda=0,
+        verbose=0,
+        cpu_fallback=bool(args.cpu_fallback),
+    )
+    torch_nntile.restrict_cpu()
+    try:
+        with torch.no_grad():
+            batch = {k: v.to("nntile") for k, v in batch_cpu.items()}
+            model = model.to("nntile")
+        torch_nntile.compile_graph()
+        torch_nntile.run()
+        for p in model.parameters():
+            p.requires_grad_(True)
+
+        code = _train_loop(
+            name=name,
+            model=model,
+            batch=batch,
+            loss_fn=loss_fn,
+            steps=args.steps,
+            lr=args.lr,
+            nntile=True,
+        )
+        if code == 0 and args.output_dir:
+            save_checkpoint(
+                Path(args.output_dir) / "checkpoint.pt",
+                model=model,
+                config=_ConfigAdapter(config),
+                seed=seed,
+                epoch=0,
+                global_step=global_step + args.steps,
+                device_name="nntile",
+            )
+        return code
+    except Exception as exc:  # noqa: BLE001 — discovery harness
+        print(f"FAIL {name}: {type(exc).__name__}: {exc}")
+        traceback.print_exc()
+        return 1
+    finally:
+        try:
+            torch_nntile.shutdown_context()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def run_tiny_dit_hf_main(
+    *,
+    name: str,
+    argv: list[str] | None,
+    default_config: Path,
+    model_cls: type,
+    build_batch: BatchBuilder,
+    loss_fn: LossFn,
+    description: str = "",
+) -> int:
+    parser = argparse.ArgumentParser(
+        description=description or f"Tiny Diffusers {name} smoke",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    add_dit_train_compare_subparsers(parser, default_config=default_config)
+    args = parser.parse_args(argv)
+    if args.command == "compare":
+        return compare_checkpoints(
+            Path(args.checkpoint_a),
+            Path(args.checkpoint_b),
+        )
+    if args.command != "train":
+        raise SystemExit(f"unknown command: {args.command}")
+    if not args.checkpoint and args.seed is None:
+        raise SystemExit("--seed is required when training from scratch")
+
+    config, model, seed, global_step = _load_train_state(
+        args,
+        model_cls=model_cls,
+    )
+    args.seed = seed
+    return run_tiny_dit_train(
+        name=name,
+        args=args,
+        config=config,
+        model=model,
+        seed=seed,
+        global_step=global_step,
+        build_batch=build_batch,
+        loss_fn=loss_fn,
+    )

--- a/torch_nntile/examples/train_dit_hf.py
+++ b/torch_nntile/examples/train_dit_hf.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# @copyright (c) 2026-present Skolkovo Institute of Science and Technology
+#                              (Skoltech), Russia. All rights reserved.
+#
+# @file torch_nntile/examples/train_dit_hf.py
+# Tiny stock Diffusers DiTTransformer2DModel smoke on cpu/nntile.
+
+"""Tiny HF Diffusers DiT smoke (CIFAR-10 via ``datasets``).
+
+Uses JSON config / checkpoint like other HF smokes::
+
+    python torch_nntile/examples/train_dit_hf.py train \\
+        --device nntile --seed 0 --config dit_hf_tiny_config.json \\
+        --output-dir /tmp/dit_hf --steps 1
+
+    python ... compare --checkpoint-a A.pt --checkpoint-b B.pt
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from diffusers import DiTTransformer2DModel
+from dit_hf_tiny_train_common import (
+    diffusion_mse_loss, make_cifar_diffusion_batch, run_tiny_dit_hf_main)
+
+
+def _default_config() -> Path:
+    return Path(__file__).resolve().parent / "dit_hf_tiny_config.json"
+
+
+def main(argv: list[str] | None = None) -> int:
+    def build_batch(cfg, args):
+        sample_size = int(getattr(cfg, "sample_size", 16))
+        in_channels = int(getattr(cfg, "in_channels", 3))
+        num_timesteps = int(getattr(cfg, "num_embeds_ada_norm", 1000))
+        # LabelEmbedding table is sized to num_embeds_ada_norm (+ CFG).
+        num_classes = max(num_timesteps, 10)
+        return make_cifar_diffusion_batch(
+            batch_size=args.batch_size,
+            sample_size=sample_size,
+            in_channels=in_channels,
+            num_timesteps=num_timesteps,
+            num_classes=num_classes,
+            seed=args.seed if args.seed is not None else 0,
+            dataset_name=args.dataset,
+            dataset_split=args.dataset_split,
+        )
+
+    return run_tiny_dit_hf_main(
+        name="dit",
+        argv=argv,
+        default_config=_default_config(),
+        model_cls=DiTTransformer2DModel,
+        build_batch=build_batch,
+        loss_fn=diffusion_mse_loss,
+        description=__doc__,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/torch_nntile/tests/test_aten_ops_parity.py
+++ b/torch_nntile/tests/test_aten_ops_parity.py
@@ -129,6 +129,21 @@ _FWD_BWD_CASES = [
         lambda: _seeded((2, 3, 4)),
         lambda x: x.reshape(6, 4),
     ),
+    (
+        "exp",
+        lambda: _seeded((4, 8)),
+        torch.exp,
+    ),
+    (
+        "cos",
+        lambda: _seeded((4, 8)),
+        torch.cos,
+    ),
+    (
+        "sin",
+        lambda: _seeded((4, 8)),
+        torch.sin,
+    ),
 ]
 
 
@@ -179,6 +194,24 @@ def test_layer_norm_matches_cpu_forward_backward():
     assert_aten_op_forward_backward(
         op,
         inputs_cpu=[x, weight, bias],
+        rtol=_RTOL,
+        atol=_ATOL,
+        bwd_rtol=_BWD_RTOL,
+        bwd_atol=_BWD_ATOL,
+    )
+
+
+def test_layer_norm_no_affine_matches_cpu_forward_backward():
+    """DiT AdaLN uses LayerNorm(elementwise_affine=False)."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 4, 8, dtype=torch.float32, requires_grad=True)
+
+    def op(inp):
+        return F.layer_norm(inp, (8,), weight=None, bias=None, eps=1e-6)
+
+    assert_aten_op_forward_backward(
+        op,
+        inputs_cpu=[x],
         rtol=_RTOL,
         atol=_ATOL,
         bwd_rtol=_BWD_RTOL,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables stock HuggingFace Diffusers `DiTTransformer2DModel` training on `device=nntile`, with a tiny CIFAR-10 smoke and docs/dev loss/wall table.

### Ops / runtime

- **`aten::exp` (+ `.out`)** — StarPU unary `TorchKind::Exp` for sinusoidal timestep frequency embeddings
- **`native_layer_norm` / backward** — densify non-contiguous `grad_out` (sum/mean expand); treat autograd’s undefined weight/bias optionals as absent (fixes AdaLN-Zero `elementwise_affine=False`)

### Training pipeline

- `train_dit_hf.py` + `dit_hf_tiny_config.json` + shared helpers
- JSON Diffusers config, `train` / `compare` CLI (same shape as other HF smokes)
- Mini-batch from HuggingFace `datasets` CIFAR-10; MSE noise-prediction loss
- CFG label dropout disabled for deterministic CPU↔nntile parity

### Docs / tests

- New showcase: `docs/dev/dit_tiny_cpu_vs_nntile_showcase.md` (indexed from `docs/dev/README.md`)
- Aten ops / StarPU kernel docs updated for `exp`
- Parity coverage: `exp`, LayerNorm without affine

### Measured (CPU-only StarPU, `ncpu=1`, `steps=1`, `batch-size=2`, `seed=0`)

| Model | CPU loss | nntile loss | CPU wall (s) | nntile wall (s) | Δ loss | Status |
|---|---:|---:|---:|---:|---:|---|
| dit | 1.603470 | 1.603470 | 0.007 | 0.042 | 0.000e+00 | OK |

### How to run

```bash
export PYTHONPATH=$PWD/torch_nntile
export LD_LIBRARY_PATH=$PWD/build/nntile:$PWD/build/torch_nntile:/opt/starpu/lib
# needs: pip install diffusers datasets
python torch_nntile/examples/train_dit_hf.py train --device nntile --seed 0 --steps 1 --batch-size 2 --ncpu 1
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f759a-c4ab-7d9f-b412-389342e6f807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f759a-c4ab-7d9f-b412-389342e6f807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

